### PR TITLE
Provision Wireless devices, add examples in documentation

### DIFF
--- a/plugins/modules/inventory_intent.py
+++ b/plugins/modules/inventory_intent.py
@@ -1161,7 +1161,7 @@ class DnacDevice(DnacBase):
 
         self.status = "failed"
         failure_reason = execution_details.get("failureReason", "Unknown failure reason")
-        self.msg = f"{0} Device Provisioning failed for {1} because of {2}".format(device_type, device_ip, failure_reason)
+        self.msg = "{0} Device Provisioning failed for {1} because of {2}".format(device_type, device_ip, failure_reason)
         self.log(self.msg)
 
     def handle_provisioning_exception(self, device_ip, exception, device_type):


### PR DESCRIPTION
In this commit - 

-- Added the code for Assigning Wireless Devices to Site and then do Provisioning.

-- Add examples and parameters in the Documentation.

-- Write doctstring for each API.

Limitation:

-- Testing pending as Provision API for Wireless giving issue in DNAC GUI as well.