### PR TITLE
PnP Reset and hostname added along with unprovision in provision inte…

### DIFF
--- a/playbooks/PnP.yml
+++ b/playbooks/PnP.yml
@@ -25,20 +25,18 @@
         dnac_log: True
         state: merged
         config:
-          - device_info:
-              - serial_number: FKC2310E0HB
-                hostname: 1-5
+          - site_name: Global/USA/San Francisco/BGL_18
+            device_info:
+              - serial_number: CD2425L8M7
                 state: Unclaimed
                 pid: c9300-24P
                 is_sudi_required: False
 
-              - serial_number: FTC2320E0HB
-                hostname: 1-6
+              - serial_number: FTC2320E0H9
                 state: Unclaimed
                 pid: c9300-24P
 
               - serial_number: ETC2320E0HB
-                hostname: 1-7
                 state: Unclaimed
                 pid: c9300-24P
 
@@ -89,7 +87,7 @@
               hostname: IAC-EWLC-Claimed
             device_info:
               - serial_number: FOX2639PAY7
-                hostname: WLC
+                hostname: New_WLC
                 state: Unclaimed
                 pid: C9800-CL-K9
             gateway: 204.192.101.1
@@ -105,6 +103,6 @@
         state: deleted
         config:
           - device_info:
-              - serial_number: FKC2310E0HK
-              - serial_number: FTC2320E0HA
-              - serial_number: FKC2310E0HB
+              - serial_number: FTC2320E0HB  #Will get deleted
+              - serial_number: FTC2320E0HA  #Doesn't exist in the iobentory
+              - serial_number: FKC2310E0HB  #Doesn't exist in the inventory

--- a/playbooks/PnP.yml
+++ b/playbooks/PnP.yml
@@ -104,5 +104,5 @@
         config:
           - device_info:
               - serial_number: FTC2320E0HB  #Will get deleted
-              - serial_number: FTC2320E0HA  #Doesn't exist in the iobentory
+              - serial_number: FTC2320E0HA  #Doesn't exist in the inventory
               - serial_number: FKC2310E0HB  #Doesn't exist in the inventory

--- a/playbooks/device_provision.yml
+++ b/playbooks/device_provision.yml
@@ -27,4 +27,11 @@
           - site_name: Global/USA/San Francisco/BGL_18
             management_ip_address: 204.1.2.2
 
-    
+
+    - name: Unprovision a wired device to a site
+      cisco.dnac.provision_intent:
+        <<: *dnac_login
+        dnac_log: True
+        state: deleted
+        config:
+          - management_ip_address: 204.1.2.2

--- a/plugins/modules/discovery_intent.py
+++ b/plugins/modules/discovery_intent.py
@@ -119,16 +119,16 @@ options:
       snmp_priv_protocol:
         description: SNMP privacy protocol (DES/AES128)
         type: str
-      snmp_r_o_community:
+      snmp_ro_community:
         description: Snmp RO community of the devices to be discovered
         type: str
-      snmp_r_o_community_desc:
+      snmp_ro_community_desc:
         description: Description for Snmp RO community
         type: str
-      snmp_r_w_community:
+      snmp_rw_community:
         description: Snmp RW community of the devices to be discovered
         type: str
-      snmp_r_w_community_desc:
+      snmp_rw_community_desc:
         description: Description for Snmp RW community
         type: str
       snmp_username:
@@ -198,10 +198,10 @@ EXAMPLES = r"""
           snmp_mode: string
           snmp_priv_passphrse: string
           snmp_priv_protocol: string
-          snmp_r_o_community: string
-          snmp_r_o_community_desc: string
-          snmp_r_w_community: string
-          snmp_r_w_community_desc: string
+          snmp_ro_community: string
+          snmp_ro_community_desc: string
+          snmp_rw_community: string
+          snmp_rw_community_desc: string
           snmp_username: string
           snmp_version: string
           timeout: integer
@@ -331,10 +331,10 @@ class DnacDiscovery(DnacBase):
             'snmp_mode': {'type': 'str', 'required': False},
             'snmp_priv_passphrase': {'type': 'str', 'required': False},
             'snmp_priv_protocol': {'type': 'str', 'required': False},
-            'snmp_r_o_community': {'type': 'str', 'required': False},
-            'snmp_r_o_community_desc': {'type': 'str', 'required': False},
-            'snmp_r_w_community': {'type': 'str', 'required': False},
-            'snmp_r_w_community_desc': {'type': 'str', 'required': False},
+            'snmp_ro_community': {'type': 'str', 'required': False},
+            'snmp_ro_community_desc': {'type': 'str', 'required': False},
+            'snmp_rw_community': {'type': 'str', 'required': False},
+            'snmp_rw_community_desc': {'type': 'str', 'required': False},
             'snmp_username': {'type': 'str', 'required': False},
             'snmp_version': {'type': 'str', 'required': True},
             'timeout': {'type': 'str', 'required': False},
@@ -498,13 +498,13 @@ class DnacDiscovery(DnacBase):
         new_object_params['snmpPrivProtocol'] = self.validated_config[0].get(
             'snmp_priv_protocol')
         new_object_params['snmpROCommunity'] = self.validated_config[0].get(
-            'snmp_r_o_community')
+            'snmp_ro_community')
         new_object_params['snmpROCommunityDesc'] = self.validated_config[0].get(
-            'snmp_r_o_community_desc')
+            'snmp_ro_community_desc')
         new_object_params['snmpRWCommunity'] = self.validated_config[0].get(
-            'snmp_r_w_community')
+            'snmp_rw_community')
         new_object_params['snmpRWCommunityDesc'] = self.validated_config[0].get(
-            'snmp_r_w_community_desc')
+            'snmp_rw_community_desc')
         new_object_params['snmpUserName'] = self.validated_config[0].get(
             'snmp_username')
         new_object_params['snmpVersion'] = self.validated_config[0].get('snmp_version')

--- a/plugins/modules/discovery_intent.py
+++ b/plugins/modules/discovery_intent.py
@@ -119,16 +119,16 @@ options:
       snmp_priv_protocol:
         description: SNMP privacy protocol (DES/AES128)
         type: str
-      snmp_ro_community:
+      snmp_r_o_community:
         description: Snmp RO community of the devices to be discovered
         type: str
-      snmp_ro_community_desc:
+      snmp_r_o_community_desc:
         description: Description for Snmp RO community
         type: str
-      snmp_rw_community:
+      snmp_r_w_community:
         description: Snmp RW community of the devices to be discovered
         type: str
-      snmp_rw_community_desc:
+      snmp_r_w_community_desc:
         description: Description for Snmp RW community
         type: str
       snmp_username:
@@ -198,10 +198,10 @@ EXAMPLES = r"""
           snmp_mode: string
           snmp_priv_passphrse: string
           snmp_priv_protocol: string
-          snmp_ro_community: string
-          snmp_ro_community_desc: string
-          snmp_rw_community: string
-          snmp_rw_community_desc: string
+          snmp_r_o_community: string
+          snmp_r_o_community_desc: string
+          snmp_r_w_community: string
+          snmp_r_w_community_desc: string
           snmp_username: string
           snmp_version: string
           timeout: integer
@@ -331,10 +331,10 @@ class DnacDiscovery(DnacBase):
             'snmp_mode': {'type': 'str', 'required': False},
             'snmp_priv_passphrase': {'type': 'str', 'required': False},
             'snmp_priv_protocol': {'type': 'str', 'required': False},
-            'snmp_ro_community': {'type': 'str', 'required': False},
-            'snmp_ro_community_desc': {'type': 'str', 'required': False},
-            'snmp_rw_community': {'type': 'str', 'required': False},
-            'snmp_rw_community_desc': {'type': 'str', 'required': False},
+            'snmp_r_o_community': {'type': 'str', 'required': False},
+            'snmp_r_o_community_desc': {'type': 'str', 'required': False},
+            'snmp_r_w_community': {'type': 'str', 'required': False},
+            'snmp_r_w_community_desc': {'type': 'str', 'required': False},
             'snmp_username': {'type': 'str', 'required': False},
             'snmp_version': {'type': 'str', 'required': True},
             'timeout': {'type': 'str', 'required': False},
@@ -498,13 +498,13 @@ class DnacDiscovery(DnacBase):
         new_object_params['snmpPrivProtocol'] = self.validated_config[0].get(
             'snmp_priv_protocol')
         new_object_params['snmpROCommunity'] = self.validated_config[0].get(
-            'snmp_ro_community')
+            'snmp_r_o_community')
         new_object_params['snmpROCommunityDesc'] = self.validated_config[0].get(
-            'snmp_ro_community_desc')
+            'snmp_r_o_community_desc')
         new_object_params['snmpRWCommunity'] = self.validated_config[0].get(
-            'snmp_rw_community')
+            'snmp_r_w_community')
         new_object_params['snmpRWCommunityDesc'] = self.validated_config[0].get(
-            'snmp_rw_community_desc')
+            'snmp_r_w_community_desc')
         new_object_params['snmpUserName'] = self.validated_config[0].get(
             'snmp_username')
         new_object_params['snmpVersion'] = self.validated_config[0].get('snmp_version')

--- a/plugins/modules/pnp_intent.py
+++ b/plugins/modules/pnp_intent.py
@@ -91,7 +91,7 @@ options:
         suboptions:
           hostname:
             description: Pnp Device's hostname that we want to keep post claiming. Hostname can only
-            be changed during claiming not bulk adding/ single adding
+                be changed during claiming not bulk adding/ single adding
             type: str
           state:
             description: Pnp Device's onbording state (Unclaimed/Claimed/Provisioned).

--- a/plugins/modules/pnp_intent.py
+++ b/plugins/modules/pnp_intent.py
@@ -16,6 +16,7 @@ description:
 - Manage operations add device, claim device and unclaim device of Onboarding Configuration(PnP) resource
 - API to add device to pnp inventory and claim it to a site.
 - API to delete device from the pnp inventory.
+- API to reset the device from errored state.
 version_added: '6.6.0'
 extends_documentation_fragment:
   - cisco.dnac.intent_params
@@ -89,7 +90,8 @@ options:
         elements: dict
         suboptions:
           hostname:
-            description: Pnp Device's hostname.
+            description: Pnp Device's hostname that we want to keep post claiming. Hostname can only
+            be changed during claiming not bulk adding/ single adding
             type: str
           state:
             description: Pnp Device's onbording state (Unclaimed/Claimed/Provisioned).
@@ -115,6 +117,7 @@ notes:
     device_onboarding_pnp.DeviceOnboardingPnp.delete_device_by_id_from_pnp,
     device_onboarding_pnp.DeviceOnboardingPnp.get_device_count,
     device_onboarding_pnp.DeviceOnboardingPnp.get_device_by_id,
+    device_onboarding_pnp.DeviceOnboardingPnp.update_device,
     sites.Sites.get_site,
     software_image_management_swim.SoftwareImageManagementSwim.get_software_image_details,
     configuration_templates.ConfigurationTemplates.gets_the_templates_available
@@ -125,6 +128,7 @@ notes:
     post /dna/intent/api/v1/onboarding/pnp-device/{id}
     get /dna/intent/api/v1/onboarding/pnp-device/count
     get /dna/intent/api/v1/onboarding/pnp-device
+    put /onboarding/pnp-device/${id}
     get /dna/intent/api/v1/site
     get /dna/intent/api/v1/image/importation
     get /dna/intent/api/v1/template-programmer/template
@@ -372,6 +376,7 @@ class DnacPnp(DnacBase):
           and stores it for further processing and calling the parameters in
           other APIs.
         """
+
         params_list = params["device_info"]
         device_info_list = []
         for param in params_list:
@@ -471,6 +476,32 @@ class DnacPnp(DnacBase):
 
         return claim_params
 
+    def get_reset_params(self):
+
+        reset_params = {
+            "deviceResetList": [
+                {
+                    "configList": [
+                        {
+                            "configId": self.have.get('template_id'),
+                            "configParameters": [
+                                {
+                                    "key": "",
+                                    "value": ""
+                                }
+                            ]
+                        }
+                    ],
+                    "deviceId": self.have.get('device_id'),
+                    "licenseLevel": "",
+                    "licenseType": "",
+                    "topOfStackSerialNumber": ""
+                }
+            ]
+        }
+
+        return reset_params
+
     def get_have(self):
         """
         Get the current image, template and site details from the DNAC.
@@ -539,7 +570,7 @@ class DnacPnp(DnacBase):
                 # check if given site exits, if exists store current site info
                 site_exists = False
                 if not isinstance(self.want.get("site_name"), str) and \
-                        not self.want.get('pnp_params').get('deviceInfo'):
+                        not self.want.get('pnp_params')[0].get('deviceInfo'):
                     self.msg = "Name of the site must be a string"
                     self.status = "failed"
                     return self
@@ -586,7 +617,7 @@ class DnacPnp(DnacBase):
                             return self
 
                 else:
-                    if not self.want.get('pnp_params').get('deviceInfo'):
+                    if not self.want.get('pnp_params')[0].get('deviceInfo'):
                         self.msg = "Either Site Name or Device details must be added"
                         self.status = "failed"
                         return self
@@ -595,7 +626,6 @@ class DnacPnp(DnacBase):
                     parameters from dnac for comparison"
         self.status = "success"
         self.have = have
-
         return self
 
     def get_want(self, config):
@@ -648,6 +678,7 @@ class DnacPnp(DnacBase):
         self.msg = "Successfully collected all parameters from playbook " + \
             "for comparison"
         self.status = "success"
+        #
         return self
 
     def get_diff_merged(self):
@@ -672,7 +703,7 @@ class DnacPnp(DnacBase):
             self.status = "failed"
             return self
 
-        if len(self.want.get("pnp_params")) >= 2:
+        if len(self.want.get("pnp_params")) > 1:
             devices_added = []
             for device in self.want.get("pnp_params"):
                 multi_device_response = self.dnac_apply['exec'](
@@ -683,6 +714,7 @@ class DnacPnp(DnacBase):
 
                 if (multi_device_response and (len(multi_device_response) == 1)):
                     devices_added.append(device)
+
             if (len(self.want.get("pnp_params")) - len(devices_added)) == 0:
                 self.result['response'] = []
                 self.result['msg'] = "Devices are already added"
@@ -793,16 +825,50 @@ class DnacPnp(DnacBase):
                 params=planned_count_params,
             )
 
+            dev_details_response = self.dnac_apply['exec'](
+                family="device_onboarding_pnp",
+                function="get_device_by_id",
+                params={"id": self.have["device_id"]}
+            )
+
+            pnp_state = dev_details_response.get("deviceInfo").get("state")
+
             if not self.want["site_name"]:
                 self.result['response'] = self.have.get("device_found")
                 self.result['msg'] = "Device is already added"
             else:
+                update_payload = {"deviceInfo": self.want.get('pnp_params')[0].get("deviceInfo")}
+                update_response = self.dnac_apply['exec'](
+                    family="device_onboarding_pnp",
+                    function="update_device",
+                    params={"id": self.have["device_id"],
+                            "payload": update_payload},
+                    op_modifies=True,
+                )
+                self.log(str(update_response))
+
+                if pnp_state == "Error":
+                    reset_paramters = self.get_reset_params()
+                    reset_response = self.dnac_apply['exec'](
+                        family="device_onboarding_pnp",
+                        function="update_device",
+                        params={"payload": reset_paramters},
+                        op_modifies=True,
+                    )
+                    self.log(str(reset_response))
+                    self.result['msg'] = "Device reset done Successfully"
+                    self.result['response'] = reset_response
+                    self.result['diff'] = self.validated_config
+                    self.result['changed'] = True
+
                 if (
                     prov_dev_response.get("response") == 0 and
-                    plan_dev_response.get("response") == 0
+                    plan_dev_response.get("response") == 0 and
+                    pnp_state == "Unclaimed"
                 ):
                     claim_params = self.get_claim_params()
                     self.log(str(claim_params))
+
                     claim_response = self.dnac_apply['exec'](
                         family="device_onboarding_pnp",
                         function='claim_a_device_to_a_site',
@@ -818,6 +884,8 @@ class DnacPnp(DnacBase):
                 else:
                     self.result['response'] = self.have.get("device_found")
                     self.result['msg'] = "Device is already claimed"
+                    if update_response.get("deviceInfo"):
+                        self.result['changed'] = True
 
             return self
 

--- a/plugins/modules/provision_intent.py
+++ b/plugins/modules/provision_intent.py
@@ -542,22 +542,21 @@ class Dnacprovision(DnacBase):
 
         status = status_response.get("status")
 
-        if status == "success":
-            response = self.dnac_apply['exec'](
-                family="sda",
-                function="delete_provisioned_wired_device",
-                op_modifies=True,
-                params={
-                    "device_management_\
-                    ip_address":
-                    self.validated_config[0]["management_ip_address"]
-                },
-            )
-
-        else:
+        if status != "success":
             self.result['msg'] = "Passed IP address is not provisioned"
             self.result['response'] = self.want["prov_params"]
             return self
+
+        response = self.dnac_apply['exec'](
+            family="sda",
+            function="delete_provisioned_wired_device",
+            op_modifies=True,
+            params={
+                "device_management_\
+                ip_address":
+                self.validated_config[0]["management_ip_address"]
+            },
+        )
 
         task_id = response.get("taskId")
         deletion_info = self.get_task_status(task_id=task_id)

--- a/plugins/modules/provision_intent.py
+++ b/plugins/modules/provision_intent.py
@@ -547,7 +547,8 @@ class Dnacprovision(DnacBase):
                 family="sda",
                 function="delete_provisioned_wired_device",
                 op_modifies=True,
-                params={"device_management_\
+                params={
+                    "device_management_\
                     ip_address":
                     self.validated_config[0]["management_ip_address"]
                 },


### PR DESCRIPTION
Problem description:  PnP's reset feature in errored state, hostname change while claiming and Unprovision of devices
Fix:  Reset Feature is added (will be done in merged state), hostname can be changed while claiming the device, unprovision for wired device is added.
Limitations: Wireless is missing unprovision APIs
Other info: Have added latest playbooks for the reference