### PR TITLE
Supported both the camel and snake cases

### DIFF
--- a/plugins/module_utils/dnac.py
+++ b/plugins/module_utils/dnac.py
@@ -361,6 +361,29 @@ class DnacBase():
             pass
         return None
 
+    def camel_to_snake_case(self, config):
+        """
+        Convert camel case keys to snake case keys in the config.
+
+        Parameters:
+            config (list) - Playbook details provided by the user.
+
+        Returns:
+            new_config (list) - Updated config after eliminating the camel cases.
+        """
+
+        if isinstance(config, dict):
+            new_config = {}
+            for key, value in config.items():
+                new_key = re.sub(r'([a-z0-9])([A-Z])', r'\1_\2', key).lower()
+                new_value = self.camel_to_snake_case(value)
+                new_config[new_key] = new_value
+        elif isinstance(config, list):
+            return [self.camel_to_snake_case(item) for item in config]
+        else:
+            return config
+        return new_config
+
 
 def log(msg, frameIncrement=0):
     with open('dnac.log', 'a') as of:

--- a/plugins/modules/device_credential_intent.py
+++ b/plugins/modules/device_credential_intent.py
@@ -840,6 +840,10 @@ class DnacCredential(DnacBase):
         }
 
         # Validate playbook params against the specification (temp_spec)
+        self.log("Playbook details with both cases " + str(self.config))
+        self.log("Validation structure " + str(temp_spec))
+        self.config = self.camel_to_snake_case(self.config)
+        self.log("Playbook details without camel case" + str(self.config))
         valid_temp, invalid_params = validate_list_of_dicts(self.config, temp_spec)
         if invalid_params:
             self.msg = "Invalid parameters in playbook: {0}".format("\n".join(invalid_params))

--- a/plugins/modules/network_settings_intent.py
+++ b/plugins/modules/network_settings_intent.py
@@ -544,6 +544,10 @@ class DnacNetwork(DnacBase):
         }
 
         # Validate playbook params against the specification (temp_spec)
+        self.log("Playbook details with both cases " + str(self.config))
+        self.log("Validation structure " + str(temp_spec))
+        self.config = self.camel_to_snake_case(self.config)
+        self.log("Playbook details without camel case" + str(self.config))
         valid_temp, invalid_params = validate_list_of_dicts(self.config, temp_spec)
         if invalid_params:
             self.msg = "Invalid parameters in playbook: {0}".format("\n".join(invalid_params))

--- a/plugins/modules/template_intent.py
+++ b/plugins/modules/template_intent.py
@@ -1436,8 +1436,10 @@ class DnacTemplate(DnacBase):
             }
         }
         # Validate template params
-        self.log(str(self.config))
-        self.log(str(temp_spec))
+        self.log("Playbook details with both cases " + str(self.config))
+        self.log("Validation structure " + str(temp_spec))
+        self.config = self.camel_to_snake_case(self.config)
+        self.log("Playbook details without camel case" + str(self.config))
         valid_temp, invalid_params = validate_list_of_dicts(
             self.config, temp_spec
         )


### PR DESCRIPTION
Supported both the camel and snake case for device_credentials_intent.py, template_intent.py, and network_settings_intent.py and added a new function in the dnac.py.