### PR TITLE
Supported both the camel and snake case.

### DIFF
--- a/playbooks/network_settings_intent.yml
+++ b/playbooks/network_settings_intent.yml
@@ -1,6 +1,6 @@
 - hosts: dnac_servers
   vars_files:
-    - credentials_245.yml
+    - credentials.yml
   gather_facts: no
   connection: local
   tasks:
@@ -79,7 +79,7 @@
                 configure_dnac_ip: false
                 # ip_addresses:
                 # - 10.0.0.6
-              syslogServer:
+              syslog_server:
                 configure_dnac_ip: false
                 # ip_addresses:
                 # - 10.0.0.7

--- a/plugins/module_utils/dnac.py
+++ b/plugins/module_utils/dnac.py
@@ -361,6 +361,29 @@ class DnacBase():
             pass
         return None
 
+    def camel_to_snake_case(self, config):
+        """
+        Convert camel case keys to snake case keys in the config.
+
+        Parameters:
+            config (list) - Playbook details provided by the user.
+
+        Returns:
+            new_config (list) - Updated config after eliminating the camel cases.
+        """
+
+        if isinstance(config, dict):
+            new_config = {}
+            for key, value in config.items():
+                new_key = re.sub(r'([a-z0-9])([A-Z])', r'\1_\2', key).lower()
+                new_value = self.camel_to_snake_case(value)
+                new_config[new_key] = new_value
+        elif isinstance(config, list):
+            return [self.camel_to_snake_case(item) for item in config]
+        else:
+            return config
+        return new_config
+
 
 def log(msg, frameIncrement=0):
     with open('dnac.log', 'a') as of:

--- a/plugins/module_utils/dnac.py
+++ b/plugins/module_utils/dnac.py
@@ -376,6 +376,8 @@ class DnacBase():
             new_config = {}
             for key, value in config.items():
                 new_key = re.sub(r'([a-z0-9])([A-Z])', r'\1_\2', key).lower()
+                if new_key != key:
+                    self.log("{0} will be deprecated soon. Please use {1}.".format(key, new_key))
                 new_value = self.camel_to_snake_case(value)
                 new_config[new_key] = new_value
         elif isinstance(config, list):

--- a/plugins/modules/device_credential_intent.py
+++ b/plugins/modules/device_credential_intent.py
@@ -840,10 +840,7 @@ class DnacCredential(DnacBase):
         }
 
         # Validate playbook params against the specification (temp_spec)
-        self.log("Playbook details with both cases " + str(self.config))
-        self.log("Validation structure " + str(temp_spec))
         self.config = self.camel_to_snake_case(self.config)
-        self.log("Playbook details without camel case" + str(self.config))
         valid_temp, invalid_params = validate_list_of_dicts(self.config, temp_spec)
         if invalid_params:
             self.msg = "Invalid parameters in playbook: {0}".format("\n".join(invalid_params))

--- a/plugins/modules/device_credential_intent.py
+++ b/plugins/modules/device_credential_intent.py
@@ -840,6 +840,10 @@ class DnacCredential(DnacBase):
         }
 
         # Validate playbook params against the specification (temp_spec)
+        self.log("Playbook details with both cases " + str(self.config))
+        self.log("Validation structure " + str(temp_spec))
+        self.config = self.camel_to_snake_case(self.config)
+        self.log("Playbook details without camel case" + str(self.config))
         valid_temp, invalid_params = validate_list_of_dicts(self.config, temp_spec)
         if invalid_params:
             self.msg = "Invalid parameters in playbook: {0}".format("\n".join(invalid_params))

--- a/plugins/modules/network_settings_intent.py
+++ b/plugins/modules/network_settings_intent.py
@@ -256,7 +256,7 @@ options:
                     elements: str
                     type: list
                 type: dict
-              syslogServer:
+              syslog_server:
                 description: Network V2's syslogServer.
                 suboptions:
                   configure_dnac_ip:
@@ -359,7 +359,7 @@ EXAMPLES = r"""
           snmp_server:
             configure_dnac_ip: True
             ip_addresses: list
-          syslogServer:
+          syslog_server:
             configure_dnac_ip: True
             ip_addresses: list
         site_name: string
@@ -499,7 +499,7 @@ class DnacNetwork(DnacBase):
                         "primary_ip_address": {"type": 'string'},
                         "secondary_ip_address": {"type": 'string'}
                     },
-                    "syslogServer": {
+                    "syslog_server": {
                         "type": 'dict',
                         "ip_addresses": {"type": 'list'},
                         "configure_dnac_ip": {"type": 'bool'}
@@ -544,10 +544,7 @@ class DnacNetwork(DnacBase):
         }
 
         # Validate playbook params against the specification (temp_spec)
-        self.log("Playbook details with both cases " + str(self.config))
-        self.log("Validation structure " + str(temp_spec))
         self.config = self.camel_to_snake_case(self.config)
-        self.log("Playbook details without camel case" + str(self.config))
         valid_temp, invalid_params = validate_list_of_dicts(self.config, temp_spec)
         if invalid_params:
             self.msg = "Invalid parameters in playbook: {0}".format("\n".join(invalid_params))
@@ -1478,7 +1475,7 @@ class DnacNetwork(DnacBase):
         else:
             del want_network_settings["snmpServer"]
 
-        syslogServer = network_management_details.get("syslogServer")
+        syslogServer = network_management_details.get("syslog_server")
         if syslogServer is not None:
             if syslogServer.get("configure_dnac_ip") is not None:
                 want_network_settings.get("syslogServer").update({

--- a/plugins/modules/network_settings_intent.py
+++ b/plugins/modules/network_settings_intent.py
@@ -544,6 +544,10 @@ class DnacNetwork(DnacBase):
         }
 
         # Validate playbook params against the specification (temp_spec)
+        self.log("Playbook details with both cases " + str(self.config))
+        self.log("Validation structure " + str(temp_spec))
+        self.config = self.camel_to_snake_case(self.config)
+        self.log("Playbook details without camel case" + str(self.config))
         valid_temp, invalid_params = validate_list_of_dicts(self.config, temp_spec)
         if invalid_params:
             self.msg = "Invalid parameters in playbook: {0}".format("\n".join(invalid_params))

--- a/plugins/modules/template_intent.py
+++ b/plugins/modules/template_intent.py
@@ -1436,8 +1436,10 @@ class DnacTemplate(DnacBase):
             }
         }
         # Validate template params
-        self.log(str(self.config))
-        self.log(str(temp_spec))
+        self.log("Playbook details with both cases " + str(self.config))
+        self.log("Validation structure " + str(temp_spec))
+        self.config = self.camel_to_snake_case(self.config)
+        self.log("Playbook details without camel case" + str(self.config))
         valid_temp, invalid_params = validate_list_of_dicts(
             self.config, temp_spec
         )

--- a/plugins/modules/template_intent.py
+++ b/plugins/modules/template_intent.py
@@ -1436,10 +1436,7 @@ class DnacTemplate(DnacBase):
             }
         }
         # Validate template params
-        self.log("Playbook details with both cases " + str(self.config))
-        self.log("Validation structure " + str(temp_spec))
         self.config = self.camel_to_snake_case(self.config)
-        self.log("Playbook details without camel case" + str(self.config))
         valid_temp, invalid_params = validate_list_of_dicts(
             self.config, temp_spec
         )


### PR DESCRIPTION
Supported both the camel and snake case for device_credentials_intent.py, template_intent.py, and network_settings_intent.py and added a new function in the dnac.py.
Added a log in the camel_to_snake_case function.

As we have used camel for the Release v6.8.1 (https://github.com/cisco-en-programmability/dnacenter-ansible/releases/tag/v6.8.1) and changed those camel case to snake case in the Release v6.10.0 (https://github.com/cisco-en-programmability/dnacenter-ansible/releases/tag/v6.10.0). So we are supporting both the camel case and snake case now.