### PR TITLE
Adding DNAC log levels for Discovery and PnP

### DIFF
--- a/plugins/modules/discovery_intent.py
+++ b/plugins/modules/discovery_intent.py
@@ -1,4 +1,4 @@
-\#!/usr/bin/python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2022, Cisco Systems

--- a/plugins/modules/discovery_intent.py
+++ b/plugins/modules/discovery_intent.py
@@ -736,7 +736,7 @@ class DnacDiscovery(DnacBase):
             )
             devices = response.response
 
-            self.log("Devices Information retrieved from the get discovered network devices by discovery id API is {0}".format(str(devices)), "DEBUG")
+            self.log("Retrieved device details using the API 'get_discovered_network_devices_by_discovery_id': {0}".format(str(devices)), "DEBUG")
             if all(res.get('reachabilityStatus') == 'Success' for res in devices):
                 result = True
                 break
@@ -752,7 +752,7 @@ class DnacDiscovery(DnacBase):
             self.log(msg, "CRITICAL")
             self.module.fail_json(msg=msg)
 
-        self.log('Discovery network device with id {0} has not completed'.format(discovery_id), "INFO")
+        self.log('Discovery network device with id {0} got completed'.format(discovery_id), "INFO")
         self.result.update(dict(discovery_device_info=devices))
         return result
 
@@ -794,9 +794,9 @@ class DnacDiscovery(DnacBase):
             params=params,
         )
 
-        self.log("Response collected from delete discovery by id API is {0}".format(str(response)), "DEBUG")
+        self.log("Response collected from API 'delete_discovery_by_id': {0}".format(str(response)), "DEBUG")
         self.result.update(dict(delete_discovery=response))
-        self.log("Task Id of the delteion task is {0}".format(response.response.get('taskId')), "INFO")
+        self.log("Task Id of the deletion task is {0}".format(response.response.get('taskId')), "INFO")
         return response.response.get('taskId')
 
     def get_diff_merged(self):

--- a/plugins/modules/discovery_intent.py
+++ b/plugins/modules/discovery_intent.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+\#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2022, Cisco Systems
@@ -26,6 +26,11 @@ options:
     description: Set to True to verify the Cisco DNA Center config after applying the playbook config.
     type: bool
     default: False
+  dnac_log_level:
+    description: Specifies the log level for Cisco Catalyst Center logging, categorizing logs by severity.
+        Options- [CRITICAL, ERROR, WARNING, INFO, DEBUG]
+    type: str
+    default: WARNING
   state:
     description: The state of DNAC after module completion.
     type: str
@@ -179,6 +184,7 @@ EXAMPLES = r"""
     dnac_version: "{{dnac_version}}"
     dnac_debug: "{{dnac_debug}}"
     dnac_log: True
+    dnac_log_level: "{{dnac_log_level}}"
     state: merged
     config:
         - devices_list:
@@ -190,8 +196,8 @@ EXAMPLES = r"""
           start_index: integer
           enable_password_list: list
           records_to_return: integer
-          http_read_credential: string
-          http_write_credential: string
+          http_read_credential: dict
+          http_write_credential: dict
           ip_filter_list: list
           discovery_name: string
           password_list: list
@@ -373,13 +379,13 @@ class DnacDiscovery(DnacBase):
         if invalid_params:
             self.msg = "Invalid parameters in playbook: {0}".format(
                 "\n".join(invalid_params))
+            self.log(str(self.msg), "ERROR")
             self.status = "failed"
             return self
 
         self.validated_config = valid_discovery
-        self.log(str(valid_discovery))
-
-        self.msg = "Successfully validated input"
+        self.msg = "Successfully validated playbook configuration parameters using 'validate_input': {0}".format(str(valid_discovery))
+        self.log(str(self.msg), "INFO")
         self.status = "success"
         return self
 
@@ -393,6 +399,7 @@ class DnacDiscovery(DnacBase):
                                  the class instance.
         """
 
+        self.log("Credential IDs list is {0}".format(str(self.creds_ids_list)), "INFO")
         return self.creds_ids_list
 
     def get_dnac_global_credentials_v2_info(self):
@@ -415,14 +422,15 @@ class DnacDiscovery(DnacBase):
             params=self.validated_config[0].get('headers'),
         )
         response = response.get('response')
-        self.log(response)
+        self.log("The Global credentials response from 'get all global credentials v2' API is {0}".format(str(response)), "DEBUG")
         for value in response.values():
             if not value:
                 continue
             self.creds_ids_list.extend(element.get('id') for element in value)
 
         if not self.creds_ids_list:
-            msg = 'Not found any credentials to discover'
+            msg = 'Not found any credentials to perform discovery'
+            self.log(msg, "CRITICAL")
             self.module.fail_json(msg=msg)
 
         self.result.update(dict(credential_ids=self.creds_ids_list))
@@ -438,6 +446,7 @@ class DnacDiscovery(DnacBase):
         """
         devices_list = self.validated_config[0].get('devices_list')
         self.result.update(dict(devices_info=devices_list))
+        self.log("Devices list info passed is {0}".format(str(devices_list)), "INFO")
         return devices_list
 
     def preprocessing_devices_info(self, devices_list=None):
@@ -461,16 +470,19 @@ class DnacDiscovery(DnacBase):
 
         ip_address_list = [device['ip'] for device in devices_list]
 
+        self.log("Discovery type passed for the discovery is {0}".format(self.validated_config[0].get('discovery_type')), "INFO")
         if self.validated_config[0].get('discovery_type') in ["SINGLE", "CDP", "LLDP"]:
             if len(ip_address_list) == 1:
                 ip_address_list = ip_address_list[0]
             else:
+                self.log("Device list's length is longer than 1", "ERROR")
                 self.module.fail_json(msg="Device list's length is longer than 1", response=[])
         elif self.validated_config[0].get('discovery_type') == "CIDR":
             if len(ip_address_list) == 1 and self.validated_config[0].get('prefix_length'):
                 ip_address_list = ip_address_list[0]
                 ip_address_list = str(ip_address_list) + "/" + str(self.validated_config[0].get('prefix_length'))
             else:
+                self.log("Device list's length is longer than 1", "ERROR")
                 self.module.fail_json(msg="Device list's length is longer than 1", response=[])
         else:
             ip_address_list = list(
@@ -481,7 +493,7 @@ class DnacDiscovery(DnacBase):
             )
             ip_address_list = ','.join(ip_address_list)
 
-        self.log("Collected IP address/addresses are {0}".format(ip_address_list))
+        self.log("Collected IP address/addresses are {0}".format(str(ip_address_list)), "INFO")
         return ip_address_list
 
     def create_params(self, credential_ids=None, ip_address_list=None):
@@ -545,7 +557,7 @@ class DnacDiscovery(DnacBase):
         new_object_params['snmpVersion'] = self.validated_config[0].get('snmp_version')
         new_object_params['timeout'] = self.validated_config[0].get('timeout')
         new_object_params['userNameList'] = self.validated_config[0].get('user_name_list')
-        self.log(new_object_params)
+        self.log("The payload/object created for calling the start discovery API is {0}".format(str(new_object_params)), "INFO")
 
         return new_object_params
 
@@ -577,9 +589,10 @@ class DnacDiscovery(DnacBase):
             op_modifies=True,
         )
 
-        self.log(result)
+        self.log("The response received post discovery creation API called is {0}".format(str(result)), "DEBUG")
 
         self.result.update(dict(discovery_result=result))
+        self.log("Task Id of the API task created is {0}".format(result.response.get('taskId')), "INFO")
         return result.response.get('taskId')
 
     def get_task_status(self, task_id=None):
@@ -605,17 +618,19 @@ class DnacDiscovery(DnacBase):
                 params=params,
             )
             response = response.response
-            self.log(response)
+            self.log("Task status for the task id {0} is {1}".format(str(task_id), str(response)), "INFO")
             if response.get('isError') or re.search(
                 'failed', response.get('progress'), flags=re.IGNORECASE
             ):
                 msg = 'Discovery task with id {0} has not completed - Reason: {1}'.format(
                     task_id, response.get("failureReason"))
+                self.log(msg, "CRITICAL")
                 self.module.fail_json(msg=msg)
                 return False
 
             if response.get('progress') != 'In Progress':
                 result = True
+                self.log("The Process is completed", "INFO")
                 break
             time.sleep(3)
 
@@ -644,7 +659,7 @@ class DnacDiscovery(DnacBase):
             params=params
         )
 
-        self.log(response)
+        self.log("Response of the get discoveries via range API is {0}".format(str(response)), "DEBUG")
 
         return next(
             filter(
@@ -670,8 +685,8 @@ class DnacDiscovery(DnacBase):
 
         if not discovery:
             msg = 'Cannot find any discovery task with name {0} -- Discovery result: {1}'.format(
-                self.validated_config[0].get("discovery_name"), discovery)
-            self.log(msg)
+                str(self.validated_config[0].get("discovery_name")), str(discovery))
+            self.log(msg, "INFO")
             self.module.fail_json(msg=msg)
 
         while True:
@@ -684,8 +699,8 @@ class DnacDiscovery(DnacBase):
 
         if not result:
             msg = 'Cannot find any discovery task with name {0} -- Discovery result: {1}'.format(
-                self.validated_config[0].get("discovery_name"), discovery)
-            self.log(msg)
+                str(self.validated_config[0].get("discovery_name")), str(discovery))
+            self.log(msg, "CRITICAL")
             self.module.fail_json(msg=msg)
 
         self.result.update(dict(discovery_range=discovery))
@@ -721,7 +736,7 @@ class DnacDiscovery(DnacBase):
             )
             devices = response.response
 
-            self.log(devices)
+            self.log("Devices Information retrieved from the get discovered network devices by discovery id API is {0}".format(str(devices)), "DEBUG")
             if all(res.get('reachabilityStatus') == 'Success' for res in devices):
                 result = True
                 break
@@ -734,8 +749,10 @@ class DnacDiscovery(DnacBase):
 
         if not result:
             msg = 'Discovery network device with id {0} has not completed'.format(discovery_id)
+            self.log(msg, "CRITICAL")
             self.module.fail_json(msg=msg)
 
+        self.log('Discovery network device with id {0} has not completed'.format(discovery_id), "INFO")
         self.result.update(dict(discovery_device_info=devices))
         return result
 
@@ -777,8 +794,9 @@ class DnacDiscovery(DnacBase):
             params=params,
         )
 
-        self.log(response)
+        self.log("Response collected from delete discovery by id API is {0}".format(str(response)), "DEBUG")
         self.result.update(dict(delete_discovery=response))
+        self.log("Task Id of the delteion task is {0}".format(response.response.get('taskId')), "INFO")
         return response.response.get('taskId')
 
     def get_diff_merged(self):
@@ -812,6 +830,7 @@ class DnacDiscovery(DnacBase):
         self.result['diff'] = self.validated_config
         self.result['response'] = discovery_task_id
         self.result.update(dict(msg='Discovery Created Successfully'))
+        self.log(self.result['msg'], "INFO")
         return self
 
     def get_diff_deleted(self):
@@ -829,6 +848,7 @@ class DnacDiscovery(DnacBase):
         if not exist_discovery:
             self.result['msg'] = "Discovery {0} Not Found".format(
                 self.validated_config[0].get("discovery_name"))
+            self.log(self.result['msg'], "ERROR")
             return self
 
         params = dict(id=exist_discovery.get('id'))
@@ -838,7 +858,7 @@ class DnacDiscovery(DnacBase):
         self.result['msg'] = "Discovery Deleted Successfully"
         self.result['diff'] = self.validated_config
         self.result['response'] = discovery_task_id
-
+        self.log(self.result['msg'], "INFO")
         return self
 
     def verify_diff_merged(self, config):
@@ -856,7 +876,8 @@ class DnacDiscovery(DnacBase):
             Center configuration's Discovery Database.
         """
 
-        self.log(str(self.have))
+        self.log("Current State (have): {0}".format(str(self.have)), "INFO")
+        self.log("Desired State (want): {0}".format(str(config)), "INFO")
         # Code to validate dnac config for merged state
         discovery_task_info = self.get_discoveries_by_range_until_success()
         discovery_id = discovery_task_info.get('id')
@@ -871,10 +892,10 @@ class DnacDiscovery(DnacBase):
 
         if response:
             discovery_name = response.get('response').get('name')
-            self.log("Requested Discovery with name {0} is completed".format(discovery_name))
+            self.log("Requested Discovery with name {0} is completed".format(discovery_name), "INFO")
 
         else:
-            self.log("Requested Discovery with name {0} is not completed".format(discovery_name))
+            self.log("Requested Discovery with name {0} is not completed".format(discovery_name), "WARNING")
         self.status = "success"
 
         return self
@@ -893,7 +914,8 @@ class DnacDiscovery(DnacBase):
             Discovery Database.
         """
 
-        self.log(str(self.have))
+        self.log("Current State (have): {0}".format(str(self.have)), "INFO")
+        self.log("Desired State (want): {0}".format(str(config)), "INFO")
         # Code to validate dnac config for deleted state
         discovery_task_info = self.get_discoveries_by_range_until_success()
         discovery_id = discovery_task_info.get('id')
@@ -908,10 +930,10 @@ class DnacDiscovery(DnacBase):
 
         if response:
             discovery_name = response.get('response').get('name')
-            self.log("Requested Discovery with name {0} is present".format(discovery_name))
+            self.log("Requested Discovery with name {0} is present".format(discovery_name), "WARNING")
 
         else:
-            self.log("Requested Discovery with name {0} is not present and deleted".format(discovery_name))
+            self.log("Requested Discovery with name {0} is not present and deleted".format(discovery_name), "INFO")
         self.status = "success"
 
         return self
@@ -929,6 +951,7 @@ def main():
                     'dnac_version': {'type': 'str', 'default': '2.2.3.3'},
                     'dnac_debug': {'type': 'bool', 'default': False},
                     'dnac_log': {'type': 'bool', 'default': False},
+                    'dnac_log_level': {'type': 'str', 'default': 'WARNING'},
                     'validate_response_schema': {'type': 'bool', 'default': True},
                     'config_verify': {"type": 'bool', "default": False},
                     'config': {'required': True, 'type': 'list', 'elements': 'dict'},
@@ -949,7 +972,10 @@ def main():
 
     dnac_discovery.validate_input().check_return_status()
     for config in dnac_discovery.validated_config:
+        dnac_discovery.reset_values()
         dnac_discovery.get_diff_state_apply[state]().check_return_status()
+        if config_verify:
+            dnac_discovery.verify_diff_state_apply[state](config).check_return_status()
 
     module.exit_json(**dnac_discovery.result)
 

--- a/plugins/modules/pnp_intent.py
+++ b/plugins/modules/pnp_intent.py
@@ -1,4 +1,4 @@
-\#!/usr/bin/python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2022, Cisco Systems

--- a/plugins/modules/pnp_intent.py
+++ b/plugins/modules/pnp_intent.py
@@ -323,16 +323,18 @@ class DnacPnp(DnacBase):
                 params={"name": self.want.get("site_name")},
             )
         except Exception:
-            self.log("Site {0} not found".format(self.want.get("site_name")), "CRITICAL")
+            self.log("Exception occurred as site \
+                '{0}' was not found".format(self.want.get("site_name")), "CRITICAL")
             self.module.fail_json(msg="Site not found", response=[])
 
         if response:
-            self.log("Site details of {0} received are {1}".format(self.want.get("site_name"), str(response)), "DEBUG")
+            self.log("Received site details \
+                for '{0}': {1}".format(self.want.get("site_name"), str(response)), "DEBUG")
             site = response.get("response")
             if len(site) == 1:
                 site_id = site[0].get("id")
                 site_exists = True
-                self.log("Site Id is {0} and site name is {1}".format(site_id, self.want.get("site_name")), "INFO")
+                self.log("Site Name: {1}, Site ID: {0}".format(site_id, self.want.get("site_name")), "INFO")
 
         return (site_exists, site_id)
 
@@ -359,17 +361,19 @@ class DnacPnp(DnacBase):
                 params={"name": self.want.get("site_name")},
             )
         except Exception:
-            self.log("Site {0} not found".format(self.want.get("site_name")), "CRITICAL")
+            self.log("Exception occurred as \
+                site '{0}' was not found".format(self.want.get("site_name")), "CRITICAL")
             self.module.fail_json(msg="Site not found", response=[])
 
         if response:
-            self.log("Site details of {0} received are {1}".format(self.want.get("site_name"), str(response)), "DEBUG")
+            self.log("Received site details\
+                for '{0}': {1}".format(self.want.get("site_name"), str(response)), "DEBUG")
             site = response.get("response")
             site_additional_info = site[0].get("additionalInfo")
             for item in site_additional_info:
                 if item["nameSpace"] == "Location":
                     site_type = item.get("attributes").get("type")
-                    self.log("Site Type is {0}".format(site_type), "INFO")
+                    self.log("Site type for site name '{1}' : {0}".format(site_type, self.want.get("site_name")), "INFO")
 
         return site_type
 
@@ -530,7 +534,7 @@ class DnacPnp(DnacBase):
             ]
         }
 
-        self.log("Paramters used for resetting from deleted state are {0}".format(str(reset_params)), "INFO")
+        self.log("Paramters used for resetting from errored state:{0}".format(str(reset_params)), "INFO")
         return reset_params
 
     def get_have(self):
@@ -559,7 +563,8 @@ class DnacPnp(DnacBase):
                 function='get_device_list',
                 params={"serial_number": self.want.get("serial_number")}
             )
-            self.log("Device details of the device with serial number {0} are {1}".format(self.want.get("serial_number"), str(device_response)), "DEBUG")
+            self.log("Device details for the device with serial \
+                number '{0}': {1}".format(self.want.get("serial_number"), str(device_response)), "DEBUG")
 
             if not (device_response and (len(device_response) == 1)):
                 self.log("Device with with serial number {0} is not found in the inventory".format(self.want.get("serial_number")), "WARNING")
@@ -581,7 +586,7 @@ class DnacPnp(DnacBase):
                     params=self.want.get("image_params"),
                 )
                 image_list = image_response.get("response")
-                self.log("Image details obtained from the API 'get software image details' are {0}".format(str(image_response)), "DEBUG")
+                self.log("Image details obtained from the API 'get_software_image_details': {0}".format(str(image_response)), "DEBUG")
 
                 # check if project has templates or not
                 template_list = self.dnac_apply['exec'](
@@ -589,22 +594,22 @@ class DnacPnp(DnacBase):
                     function='gets_the_templates_available',
                     params={"project_names": self.want.get("project_name")},
                 )
-                self.log("Templates list under the project {0} is {1}".format(self.want.get("project_name"), str(template_list)), "DEBUG")
+                self.log("List of templates under the project '{0}': {1}".format(self.want.get("project_name"), str(template_list)), "DEBUG")
 
                 dev_details_response = self.dnac_apply['exec'](
                     family="device_onboarding_pnp",
                     function="get_device_by_id",
                     params={"id": device_response[0].get("id")}
                 )
-                self.log("Device details of the existing device after calling the API 'get device by id' are {0}".format(str(dev_details_response)), "DEBUG")
+                self.log("Device details retrieved after calling the 'get_device_by_id' API: {0}".format(str(dev_details_response)), "DEBUG")
                 install_mode = dev_details_response.get("deviceInfo").get("mode")
-                self.log("Installation mode of the device with the serial no. {0} is {1}".format(self.want.get("serial_number"), install_mode), "INFO")
+                self.log("Installation mode of the device with the serial no. '{0}':{1}".format(self.want.get("serial_number"), install_mode), "INFO")
 
                 # check if given site exits, if exists store current site info
                 site_exists = False
                 if not isinstance(self.want.get("site_name"), str) and \
                         not self.want.get('pnp_params')[0].get('deviceInfo'):
-                    self.msg = "Name of the site must be a string"
+                    self.msg = "The site name must be a string"
                     self.log(str(self.msg), "ERROR")
                     self.status = "failed"
                     return self
@@ -614,12 +619,11 @@ class DnacPnp(DnacBase):
 
                 if site_exists:
                     have["site_id"] = site_id
-                    self.log("Site Exists: " + str(site_exists) + "\n Site_id:" + str(site_id), "INFO")
-                    self.log("Site Name:" + str(site_name), "INFO")
+                    self.log("Site Exists: {0}\nSite Name: {1}\nSite ID: {2}".format(site_exists, site_name, site_id), "INFO")
                     if self.want.get("pnp_type") == "access_point":
                         if self.get_site_type() != "floor":
-                            self.msg = "Type of the site must \
-                                be a floor for claiming an AP"
+                            self.msg = "The site type must be specified as 'floor'\
+                                for claiming an AP"
                             self.log(str(self.msg), "ERROR")
                             self.status = "failed"
                             return self
@@ -634,13 +638,13 @@ class DnacPnp(DnacBase):
                             return self
 
                         have["image_id"] = image_list[0].get("imageUuid")
-                        self.log("Image Id is {0}".format(str(have["image_id"])), "INFO")
+                        self.log("Image ID for the image '{0}': {1}".format(self.want.get('image_params').get('image_name'), str(have["image_id"])), "INFO")
 
                     template_name = self.want.get("template_name")
                     if template_name:
                         if not (template_list and isinstance(template_list, list)):
-                            self.msg = "Project Not Found \
-                                or Project is Empty"
+                            self.msg = "Either project not found \
+                                or it is Empty"
                             self.log(self.msg, "CRITICAL")
                             self.status = "failed"
                             return self
@@ -649,7 +653,7 @@ class DnacPnp(DnacBase):
                         if template_details:
                             have["template_id"] = template_details.get("templateId")
                         else:
-                            self.msg = "Template {0} Not found".format(template_name)
+                            self.msg = "Template '{0}' is not found.".format(template_name)
                             self.log(self.msg, "CRITICAL")
                             self.status = "failed"
                             return self
@@ -753,12 +757,11 @@ class DnacPnp(DnacBase):
                     function='get_device_list',
                     params={"serial_number": device["deviceInfo"]["serialNumber"]}
                 )
-                self.log("Device details for the serial number {0}\
-                    obtained from the API 'get device list'\
-                        are {1}".format(device["deviceInfo"]["serialNumber"], str(multi_device_response)), "DEBUG")
+                self.log("Device details for serial number {0} \
+                        obtained from the API 'get_device_list': {1}".format(device["deviceInfo"]["serialNumber"], str(multi_device_response)), "DEBUG")
                 if (multi_device_response and (len(multi_device_response) == 1)):
                     devices_added.append(device)
-                    self.log("Details of the added device is {0}".format(str(device)), "INFO")
+                    self.log("Details of the added device:{0}".format(str(device)), "INFO")
             if (len(self.want.get("pnp_params")) - len(devices_added)) == 0:
                 self.result['response'] = []
                 self.result['msg'] = "Devices are already added"
@@ -776,7 +779,7 @@ class DnacPnp(DnacBase):
                 params={"payload": bulk_list},
                 op_modifies=True,
             )
-            self.log("Devices imported response from the API 'import_devices_in_bulk' is {0}".format(bulk_params), "DEBUG")
+            self.log("Response from API 'import_devices_in_bulk' for imported devices: {0}".format(bulk_params), "DEBUG")
             if len(bulk_params.get("successList")) > 0:
                 self.result['msg'] = "{0} device(s) imported successfully".format(
                     len(bulk_params.get("successList")))
@@ -818,7 +821,7 @@ class DnacPnp(DnacBase):
                 )
 
                 self.have["deviceInfo"] = dev_add_response.get("deviceInfo")
-                self.log("Single device addition response from the API 'add device' is {0}".format(str(dev_add_response)), "DEBUG")
+                self.log("Response from API 'add device' for a single device addition: {0}".format(str(dev_add_response)), "DEBUG")
                 if self.have["deviceInfo"]:
                     self.result['msg'] = "Only Device Added Successfully"
                     self.log(self.result['msg'], "INFO")
@@ -842,7 +845,7 @@ class DnacPnp(DnacBase):
                     op_modifies=True,
                 )
                 self.have["deviceInfo"] = dev_add_response.get("deviceInfo")
-                self.log("Single device addition response from the API 'add device'is {0}".format(str(dev_add_response)), "DEBUG")
+                self.log("Response from API 'add device' for single device addition: {0}".format(str(dev_add_response)), "DEBUG")
                 claim_params = self.get_claim_params()
                 claim_params["deviceId"] = dev_add_response.get("id")
                 claim_response = self.dnac_apply['exec'](
@@ -852,7 +855,7 @@ class DnacPnp(DnacBase):
                     params=claim_params,
                 )
 
-                self.log("Single claiming response from the API 'claim a device to a site' is {0}".format(str(dev_add_response)), "DEBUG")
+                self.log("Response from API 'claim a device to a site' for a single claiming: {0}".format(str(dev_add_response)), "DEBUG")
                 if claim_response.get("response") == "Device Claimed" \
                         and self.have["deviceInfo"]:
                     self.result['msg'] = "Device Added and Claimed Successfully"
@@ -874,7 +877,7 @@ class DnacPnp(DnacBase):
             op_modifies=True,
             params=provisioned_count_params,
         )
-        self.log("Devices which are provisioned response from the API 'get device count' is {0}".format(str(prov_dev_response)), "DEBUG")
+        self.log("Response from 'get device count' API for provisioned devices: {0}".format(str(prov_dev_response)), "DEBUG")
 
         plan_dev_response = self.dnac_apply['exec'](
             family="device_onboarding_pnp",
@@ -882,17 +885,17 @@ class DnacPnp(DnacBase):
             op_modifies=True,
             params=planned_count_params,
         )
-        self.log("Devices which are in planned state response from the API 'get device count' is {0}".format(str(plan_dev_response)), "DEBUG")
+        self.log("Response from 'get_device_count' API for devices in planned state: {0}".format(str(plan_dev_response)), "DEBUG")
 
         dev_details_response = self.dnac_apply['exec'](
             family="device_onboarding_pnp",
             function="get_device_by_id",
             params={"id": self.have["device_id"]}
         )
-        self.log("Device's details from the API 'get device by id' is {0}".format(str(dev_details_response)), "DEBUG")
+        self.log("Response from 'get_device_by_id' API for device details: {0}".format(str(dev_details_response)), "DEBUG")
 
         pnp_state = dev_details_response.get("deviceInfo").get("state")
-        self.log("PnP state of the device is {0}".format(pnp_state), "INFO")
+        self.log("PnP state of the device: {0}".format(pnp_state), "INFO")
 
         if not self.want["site_name"]:
             self.result['response'] = self.have.get("device_found")
@@ -908,7 +911,7 @@ class DnacPnp(DnacBase):
                     "payload": update_payload},
             op_modifies=True,
         )
-        self.log("Update in the device's config API response is {0}".format(str(update_response)), "DEBUG")
+        self.log("Response from 'update_device' API for device's config update: {0}".format(str(update_response)), "DEBUG")
 
         if pnp_state == "Error":
             reset_paramters = self.get_reset_params()
@@ -918,7 +921,7 @@ class DnacPnp(DnacBase):
                 params={"payload": reset_paramters},
                 op_modifies=True,
             )
-            self.log("Errored state resolution response from the API is {0}".format(str(reset_response)), "DEBUG")
+            self.log("Response from 'update_device' API for errored state resolution: {0}".format(str(reset_response)), "DEBUG")
             self.result['msg'] = "Device reset done Successfully"
             self.log(self.result['msg'], "INFO")
             self.result['response'] = reset_response
@@ -938,7 +941,7 @@ class DnacPnp(DnacBase):
                 return self
 
         claim_params = self.get_claim_params()
-        self.log("Paramters for claiming the device are {0}".format(str(claim_params)), "DEBUG")
+        self.log("Parameters for claiming the device: {0}".format(str(claim_params)), "DEBUG")
 
         claim_response = self.dnac_apply['exec'](
             family="device_onboarding_pnp",
@@ -946,7 +949,7 @@ class DnacPnp(DnacBase):
             op_modifies=True,
             params=claim_params,
         )
-        self.log("Claiming response obtained from the API 'claim a device to a site' is {0}".format(str(claim_response)), "DEBUG")
+        self.log("Response from 'claim_a_device_to_a_site' API for claiming: {0}".format(str(claim_response)), "DEBUG")
         if claim_response.get("response") == "Device Claimed":
             self.result['msg'] = "Only Device Claimed Successfully"
             self.log(self.result['msg'], "INFO")
@@ -980,7 +983,7 @@ class DnacPnp(DnacBase):
                 function='get_device_list',
                 params={"serial_number": device["deviceInfo"]["serialNumber"]}
             )
-            self.log("Device details for the serial number {0} are {1}".format(device["deviceInfo"]["serialNumber"], str(multi_device_response)), "DEBUG")
+            self.log("Response from 'get_device_list' API for claiming: {0}".format(str(multi_device_response)), "DEBUG")
             if multi_device_response and len(multi_device_response) == 1:
                 device_id = multi_device_response[0].get("id")
 
@@ -990,10 +993,8 @@ class DnacPnp(DnacBase):
                     op_modifies=True,
                     params={"id": device_id},
                 )
-
-                self.log("Device details for the device deleted with \
-                    serial number {0} are {1}".format(device["deviceInfo"]["serialNumber"], str(response)), "DEBUG")
-
+                self.log("Device details for the deleted device with \
+                        serial number '{0}': {1}".format(device["deviceInfo"]["serialNumber"], str(response)), "DEBUG")
                 if response.get("deviceInfo", {}).get("state") == "Deleted":
                     devices_deleted.append(device["deviceInfo"]["serialNumber"])
                     self.want.get("pnp_params").remove(device)

--- a/plugins/modules/pnp_intent.py
+++ b/plugins/modules/pnp_intent.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+\#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2022, Cisco Systems
@@ -28,6 +28,11 @@ options:
     description: Set to True to verify the Cisco DNA Center config after applying the playbook config.
     type: bool
     default: False
+  dnac_log_level:
+    description: Specifies the log level for Cisco Catalyst Center logging, categorizing logs by severity.
+        Options- [CRITICAL, ERROR, WARNING, INFO, DEBUG]
+    type: str
+    default: WARNING
   state:
     description: The state of DNAC after module completion.
     type: str
@@ -149,6 +154,7 @@ EXAMPLES = r"""
     dnac_port: "{{dnac_port}}"
     dnac_version: "{{dnac_version}}"
     dnac_debug: "{{dnac_debug}}"
+    dnac_log_level: "{{dnac_log_level}}"
     dnac_log: True
     state: merged
     config_verify: True
@@ -280,13 +286,12 @@ class DnacPnp(DnacBase):
         if invalid_params:
             self.msg = "Invalid parameters in playbook: {0}".format(
                 "\n".join(invalid_params))
+            self.log(str(self.msg), "ERROR")
             self.status = "failed"
             return self
-
         self.validated_config = valid_pnp
-        self.log(str(valid_pnp))
-
-        self.msg = "Successfully validated input"
+        self.msg = "Successfully validated playbook config params: {0}".format(str(valid_pnp))
+        self.log(str(self.msg), "INFO")
         self.status = "success"
 
         return self
@@ -318,14 +323,16 @@ class DnacPnp(DnacBase):
                 params={"name": self.want.get("site_name")},
             )
         except Exception:
+            self.log("Site {0} not found".format(self.want.get("site_name")), "CRITICAL")
             self.module.fail_json(msg="Site not found", response=[])
 
         if response:
-            self.log(str(response))
+            self.log("Site details of {0} received are {1}".format(self.want.get("site_name"), str(response)), "DEBUG")
             site = response.get("response")
             if len(site) == 1:
                 site_id = site[0].get("id")
                 site_exists = True
+                self.log("Site Id is {0} and site name is {1}".format(site_id, self.want.get("site_name")), "INFO")
 
         return (site_exists, site_id)
 
@@ -352,15 +359,17 @@ class DnacPnp(DnacBase):
                 params={"name": self.want.get("site_name")},
             )
         except Exception:
+            self.log("Site {0} not found".format(self.want.get("site_name")), "CRITICAL")
             self.module.fail_json(msg="Site not found", response=[])
 
         if response:
-            self.log(str(response))
+            self.log("Site details of {0} received are {1}".format(self.want.get("site_name"), str(response)), "DEBUG")
             site = response.get("response")
             site_additional_info = site[0].get("additionalInfo")
             for item in site_additional_info:
                 if item["nameSpace"] == "Location":
                     site_type = item.get("attributes").get("type")
+                    self.log("Site Type is {0}".format(site_type), "INFO")
 
         return site_type
 
@@ -392,6 +401,7 @@ class DnacPnp(DnacBase):
             device_dict["deviceInfo"] = param
             device_info_list.append(device_dict)
 
+        self.log("PnP paramters passed are {0}".format(str(params_list)), "INFO")
         return device_info_list
 
     def get_image_params(self, params):
@@ -416,6 +426,8 @@ class DnacPnp(DnacBase):
             'image_name': params.get('image_name'),
             'is_tagged_golden': params.get('golden_image')
         }
+
+        self.log("Image details are {0}".format(str(image_params)), "INFO")
         return image_params
 
     def get_claim_params(self):
@@ -479,6 +491,7 @@ class DnacPnp(DnacBase):
             claim_params["type"] = "AccessPoint"
             claim_params["rfProfile"] = self.validated_config[0]["rf_profile"]
 
+        self.log("Paramters used for claiming are {0}".format(str(claim_params)), "INFO")
         return claim_params
 
     def get_reset_params(self):
@@ -517,6 +530,7 @@ class DnacPnp(DnacBase):
             ]
         }
 
+        self.log("Paramters used for resetting from deleted state are {0}".format(str(reset_params)), "INFO")
         return reset_params
 
     def get_have(self):
@@ -545,9 +559,10 @@ class DnacPnp(DnacBase):
                 function='get_device_list',
                 params={"serial_number": self.want.get("serial_number")}
             )
-            self.log(str(device_response))
+            self.log("Device details of the device with serial number {0} are {1}".format(self.want.get("serial_number"), str(device_response)), "DEBUG")
 
             if not (device_response and (len(device_response) == 1)):
+                self.log("Device with with serial number {0} is not found in the inventory".format(self.want.get("serial_number")), "WARNING")
                 self.msg = "Adding the device to database"
                 self.status = "success"
                 self.have = have
@@ -566,7 +581,7 @@ class DnacPnp(DnacBase):
                     params=self.want.get("image_params"),
                 )
                 image_list = image_response.get("response")
-                self.log(str(image_response))
+                self.log("Image details obtained from the API 'get software image details' are {0}".format(str(image_response)), "DEBUG")
 
                 # check if project has templates or not
                 template_list = self.dnac_apply['exec'](
@@ -574,21 +589,23 @@ class DnacPnp(DnacBase):
                     function='gets_the_templates_available',
                     params={"project_names": self.want.get("project_name")},
                 )
-                self.log(str(template_list))
+                self.log("Templates list under the project {0} is {1}".format(self.want.get("project_name"), str(template_list)), "DEBUG")
 
                 dev_details_response = self.dnac_apply['exec'](
                     family="device_onboarding_pnp",
                     function="get_device_by_id",
                     params={"id": device_response[0].get("id")}
                 )
-
+                self.log("Device details of the existing device after calling the API 'get device by id' are {0}".format(str(dev_details_response)), "DEBUG")
                 install_mode = dev_details_response.get("deviceInfo").get("mode")
+                self.log("Installation mode of the device with the serial no. {0} is {1}".format(self.want.get("serial_number"), install_mode), "INFO")
 
                 # check if given site exits, if exists store current site info
                 site_exists = False
                 if not isinstance(self.want.get("site_name"), str) and \
                         not self.want.get('pnp_params')[0].get('deviceInfo'):
                     self.msg = "Name of the site must be a string"
+                    self.log(str(self.msg), "ERROR")
                     self.status = "failed"
                     return self
 
@@ -597,12 +614,13 @@ class DnacPnp(DnacBase):
 
                 if site_exists:
                     have["site_id"] = site_id
-                    self.log("Site Exists: " + str(site_exists) + "\n Site_id:" + str(site_id))
-                    self.log("Site Name:" + str(site_name))
+                    self.log("Site Exists: " + str(site_exists) + "\n Site_id:" + str(site_id), "INFO")
+                    self.log("Site Name:" + str(site_name), "INFO")
                     if self.want.get("pnp_type") == "access_point":
                         if self.get_site_type() != "floor":
                             self.msg = "Type of the site must \
                                 be a floor for claiming an AP"
+                            self.log(str(self.msg), "ERROR")
                             self.status = "failed"
                             return self
 
@@ -611,17 +629,19 @@ class DnacPnp(DnacBase):
                             self.msg = "Installation mode must be in \
                             INSTALL mode to upgrade the image. Current mode is\
                             {0}".format(install_mode)
+                            self.log(str(self.msg), "CRITICAL")
                             self.status = "failed"
                             return self
 
                         have["image_id"] = image_list[0].get("imageUuid")
-                        self.log("Image Id: " + str(have["image_id"]))
+                        self.log("Image Id is {0}".format(str(have["image_id"])), "INFO")
 
                     template_name = self.want.get("template_name")
                     if template_name:
                         if not (template_list and isinstance(template_list, list)):
                             self.msg = "Project Not Found \
                                 or Project is Empty"
+                            self.log(self.msg, "CRITICAL")
                             self.status = "failed"
                             return self
 
@@ -629,18 +649,21 @@ class DnacPnp(DnacBase):
                         if template_details:
                             have["template_id"] = template_details.get("templateId")
                         else:
-                            self.msg = "Template Not found"
+                            self.msg = "Template {0} Not found".format(template_name)
+                            self.log(self.msg, "CRITICAL")
                             self.status = "failed"
                             return self
 
                 else:
                     if not self.want.get('pnp_params')[0].get('deviceInfo'):
                         self.msg = "Either Site Name or Device details must be added"
+                        self.log(self.msg, "ERROR")
                         self.status = "failed"
                         return self
 
         self.msg = "Successfully collected all project and template \
                     parameters from dnac for comparison"
+        self.log(self.msg, "INFO")
         self.status = "success"
         self.have = have
         return self
@@ -694,6 +717,7 @@ class DnacPnp(DnacBase):
             self.want["rf_profile"] = config.get("rf_profile")
         self.msg = "Successfully collected all parameters from playbook " + \
             "for comparison"
+        self.log(self.msg, "INFO")
         self.status = "success"
 
         return self
@@ -717,6 +741,7 @@ class DnacPnp(DnacBase):
 
         if not isinstance(self.want.get("pnp_params"), list):
             self.msg = "Device Info must be passed as a list"
+            self.log(self.msg, "ERROR")
             self.status = "failed"
             return self
 
@@ -728,13 +753,16 @@ class DnacPnp(DnacBase):
                     function='get_device_list',
                     params={"serial_number": device["deviceInfo"]["serialNumber"]}
                 )
-
+                self.log("Device details for the serial number {0}\
+                    obtained from the API 'get device list'\
+                        are {1}".format(device["deviceInfo"]["serialNumber"], str(multi_device_response)), "DEBUG")
                 if (multi_device_response and (len(multi_device_response) == 1)):
                     devices_added.append(device)
-
+                    self.log("Details of the added device is {0}".format(str(device)), "INFO")
             if (len(self.want.get("pnp_params")) - len(devices_added)) == 0:
                 self.result['response'] = []
                 self.result['msg'] = "Devices are already added"
+                self.log(self.result['msg'], "WARNING")
                 return self
 
             bulk_list = [
@@ -748,15 +776,18 @@ class DnacPnp(DnacBase):
                 params={"payload": bulk_list},
                 op_modifies=True,
             )
+            self.log("Devices imported response from the API 'import_devices_in_bulk' is {0}".format(bulk_params), "DEBUG")
             if len(bulk_params.get("successList")) > 0:
                 self.result['msg'] = "{0} device(s) imported successfully".format(
                     len(bulk_params.get("successList")))
+                self.log(self.result['msg'], "INFO")
                 self.result['response'] = bulk_params
                 self.result['diff'] = self.validated_config
                 self.result['changed'] = True
                 return self
 
             self.msg = "Bulk import failed"
+            self.log(self.msg, "CRITICAL")
             self.status = "failed"
             return self
 
@@ -773,11 +804,12 @@ class DnacPnp(DnacBase):
         if not self.have.get("device_found"):
             if not self.want['pnp_params']:
                 self.msg = "Device needs to be added before claiming. Please add device_info"
+                self.log(self.msg, "ERROR")
                 self.status = "failed"
                 return self
 
             if not self.want["site_name"]:
-                self.log("Adding device to pnp database")
+                self.log("Adding device to pnp database", "INFO")
                 dev_add_response = self.dnac_apply['exec'](
                     family="device_onboarding_pnp",
                     function="add_device",
@@ -786,15 +818,17 @@ class DnacPnp(DnacBase):
                 )
 
                 self.have["deviceInfo"] = dev_add_response.get("deviceInfo")
-                self.log(str(dev_add_response))
+                self.log("Single device addition response from the API 'add device' is {0}".format(str(dev_add_response)), "DEBUG")
                 if self.have["deviceInfo"]:
                     self.result['msg'] = "Only Device Added Successfully"
+                    self.log(self.result['msg'], "INFO")
                     self.result['response'] = dev_add_response
                     self.result['diff'] = self.validated_config
                     self.result['changed'] = True
 
                 else:
                     self.msg = "Device Addition Failed"
+                    self.log(self.result['msg'], "CRITICAL")
                     self.status = "failed"
 
                 return self
@@ -808,7 +842,7 @@ class DnacPnp(DnacBase):
                     op_modifies=True,
                 )
                 self.have["deviceInfo"] = dev_add_response.get("deviceInfo")
-                self.log(str(dev_add_response))
+                self.log("Single device addition response from the API 'add device'is {0}".format(str(dev_add_response)), "DEBUG")
                 claim_params = self.get_claim_params()
                 claim_params["deviceId"] = dev_add_response.get("id")
                 claim_response = self.dnac_apply['exec'](
@@ -818,16 +852,18 @@ class DnacPnp(DnacBase):
                     params=claim_params,
                 )
 
-                self.log(str(claim_response))
+                self.log("Single claiming response from the API 'claim a device to a site' is {0}".format(str(dev_add_response)), "DEBUG")
                 if claim_response.get("response") == "Device Claimed" \
                         and self.have["deviceInfo"]:
                     self.result['msg'] = "Device Added and Claimed Successfully"
+                    self.log(self.result['msg'], "INFO")
                     self.result['response'] = claim_response
                     self.result['diff'] = self.validated_config
                     self.result['changed'] = True
 
                 else:
                     self.msg = "Device Claim Failed"
+                    self.log(self.result['msg'], "CRITICAL")
                     self.status = "failed"
 
                 return self
@@ -838,23 +874,30 @@ class DnacPnp(DnacBase):
             op_modifies=True,
             params=provisioned_count_params,
         )
+        self.log("Devices which are provisioned response from the API 'get device count' is {0}".format(str(prov_dev_response)), "DEBUG")
+
         plan_dev_response = self.dnac_apply['exec'](
             family="device_onboarding_pnp",
             function='get_device_count',
             op_modifies=True,
             params=planned_count_params,
         )
+        self.log("Devices which are in planned state response from the API 'get device count' is {0}".format(str(plan_dev_response)), "DEBUG")
+
         dev_details_response = self.dnac_apply['exec'](
             family="device_onboarding_pnp",
             function="get_device_by_id",
             params={"id": self.have["device_id"]}
         )
+        self.log("Device's details from the API 'get device by id' is {0}".format(str(dev_details_response)), "DEBUG")
 
         pnp_state = dev_details_response.get("deviceInfo").get("state")
+        self.log("PnP state of the device is {0}".format(pnp_state), "INFO")
 
         if not self.want["site_name"]:
             self.result['response'] = self.have.get("device_found")
             self.result['msg'] = "Device is already added"
+            self.log(self.result['msg'], "WARNING")
             return self
 
         update_payload = {"deviceInfo": self.want.get('pnp_params')[0].get("deviceInfo")}
@@ -865,7 +908,7 @@ class DnacPnp(DnacBase):
                     "payload": update_payload},
             op_modifies=True,
         )
-        self.log(str(update_response))
+        self.log("Update in the device's config API response is {0}".format(str(update_response)), "DEBUG")
 
         if pnp_state == "Error":
             reset_paramters = self.get_reset_params()
@@ -875,8 +918,9 @@ class DnacPnp(DnacBase):
                 params={"payload": reset_paramters},
                 op_modifies=True,
             )
-            self.log(str(reset_response))
+            self.log("Errored state resolution response from the API is {0}".format(str(reset_response)), "DEBUG")
             self.result['msg'] = "Device reset done Successfully"
+            self.log(self.result['msg'], "INFO")
             self.result['response'] = reset_response
             self.result['diff'] = self.validated_config
             self.result['changed'] = True
@@ -888,12 +932,13 @@ class DnacPnp(DnacBase):
         ):
             self.result['response'] = self.have.get("device_found")
             self.result['msg'] = "Device is already claimed"
+            self.log(self.result['msg'], "WARNING")
             if update_response.get("deviceInfo"):
                 self.result['changed'] = True
                 return self
 
         claim_params = self.get_claim_params()
-        self.log(str(claim_params))
+        self.log("Paramters for claiming the device are {0}".format(str(claim_params)), "DEBUG")
 
         claim_response = self.dnac_apply['exec'](
             family="device_onboarding_pnp",
@@ -901,9 +946,10 @@ class DnacPnp(DnacBase):
             op_modifies=True,
             params=claim_params,
         )
-        self.log(str(claim_response))
+        self.log("Claiming response obtained from the API 'claim a device to a site' is {0}".format(str(claim_response)), "DEBUG")
         if claim_response.get("response") == "Device Claimed":
             self.result['msg'] = "Only Device Claimed Successfully"
+            self.log(self.result['msg'], "INFO")
             self.result['response'] = claim_response
             self.result['diff'] = self.validated_config
             self.result['changed'] = True
@@ -934,7 +980,7 @@ class DnacPnp(DnacBase):
                 function='get_device_list',
                 params={"serial_number": device["deviceInfo"]["serialNumber"]}
             )
-
+            self.log("Device details for the serial number {0} are {1}".format(device["deviceInfo"]["serialNumber"], str(multi_device_response)), "DEBUG")
             if multi_device_response and len(multi_device_response) == 1:
                 device_id = multi_device_response[0].get("id")
 
@@ -945,7 +991,8 @@ class DnacPnp(DnacBase):
                     params={"id": device_id},
                 )
 
-                self.log(str(response))
+                self.log("Device details for the device deleted with \
+                    serial number {0} are {1}".format(device["deviceInfo"]["serialNumber"], str(response)), "DEBUG")
 
                 if response.get("deviceInfo", {}).get("state") == "Deleted":
                     devices_deleted.append(device["deviceInfo"]["serialNumber"])
@@ -953,14 +1000,17 @@ class DnacPnp(DnacBase):
                 else:
                     self.result['response'] = response
                     self.result['msg'] = "Error while deleting the device"
+                    self.log(self.result['msg'], "CRITICAL")
 
         if len(devices_deleted) > 0:
             self.result['changed'] = True
             self.result['response'] = devices_deleted
             self.result['diff'] = self.want.get("pnp_params")
             self.result['msg'] = "{0} Device(s) Deleted Successfully".format(len(devices_deleted))
+            self.log(self.result['msg'], "INFO")
         else:
             self.result['msg'] = "Device(s) Not Found"
+            self.log(self.result['msg'], "WARNING")
             self.result['response'] = devices_deleted
 
         return self
@@ -980,8 +1030,8 @@ class DnacPnp(DnacBase):
             Center configuration's PnP Database.
         """
 
-        self.log("Current State (have): {0}".format(self.have))
-        self.log("Desired State (want): {0}".format(self.want))
+        self.log("Current State (have): {0}".format(str(self.have)), "INFO")
+        self.log("Desired State (want): {0}".format(str(config)), "INFO")
         # Code to validate dnac config for merged state
         for device in self.want.get("pnp_params"):
             device_response = self.dnac_apply['exec'](
@@ -994,12 +1044,14 @@ class DnacPnp(DnacBase):
                     "Requested Device with Serial No. {0} is "
                     "present in Cisco DNA Center and"
                     " addition verified.".format(device["deviceInfo"]["serialNumber"]))
-                self.log(msg)
+                self.log(msg, "INFO")
+
             else:
                 msg = (
                     "Requested Device with Serial No. {0} is "
                     "not present in Cisco DNA "
                     "Center".format(device["deviceInfo"]["serialNumber"]))
+                self.log(msg, "WARNING")
 
         self.status = "success"
         return self
@@ -1018,8 +1070,8 @@ class DnacPnp(DnacBase):
             PnP Database.
         """
 
-        self.log("Current State (have): {0}".format(self.have))
-        self.log("Desired State (want): {0}".format(self.want))
+        self.log("Current State (have): {0}".format(str(self.have)), "INFO")
+        self.log("Desired State (want): {0}".format(str(config)), "INFO")
         # Code to validate dnac config for deleted state
         for device in self.want.get("pnp_params"):
             device_response = self.dnac_apply['exec'](
@@ -1032,11 +1084,13 @@ class DnacPnp(DnacBase):
                     "Requested Device with Serial No. {0} is "
                     "not present in the Cisco DNA"
                     "Center.".format(device["deviceInfo"]["serialNumber"]))
-                self.log(msg)
+                self.log(msg, "INFO")
+
             else:
                 msg = (
                     "Requested Device with Serial No. {0} is "
                     "present in Cisco DNA Center".format(device["deviceInfo"]["serialNumber"]))
+                self.log(msg, "WARNING")
 
         self.status = "success"
         return self
@@ -1055,6 +1109,7 @@ def main():
                     'dnac_version': {'type': 'str', 'default': '2.2.3.3'},
                     'dnac_debug': {'type': 'bool', 'default': False},
                     'dnac_log': {'type': 'bool', 'default': False},
+                    'dnac_log_level': {'type': 'str', 'default': 'WARNING'},
                     'validate_response_schema': {'type': 'bool', 'default': True},
                     'config_verify': {"type": 'bool', "default": False},
                     'config': {'required': True, 'type': 'list', 'elements': 'dict'},


### PR DESCRIPTION
Problem Description: Logging based on various levels (CRITICAL, ERROR, WARNING, INFO, DEBUG)
Fix: We have added dnac_log_levels
Test cases: Have tested for default (WARNING and DEBUG)
Results: 1. WARNING gives logs for WARNINGS, CRITICAL AND ERROR
              2.  DEBUG logs all the messages including CRITICAL, ERROR, WARNING and INFO as well.