### PR TITLE
Added the dnac_log_level documentation in the doc_fragments.intent_params.py file

### DIFF
--- a/plugins/doc_fragments/intent_params.py
+++ b/plugins/doc_fragments/intent_params.py
@@ -54,6 +54,12 @@ options:
               If set to true the log file will be created at the location of the execution with the name dnac.log
         type: bool
         default: false
+    dnac_log_level:
+        description:
+            - Specifies the desired log level for Cisco Catalyst Center logging.
+              Options - [CRITICAL, ERROR, WARNING, INFO, DEBUG]
+        type: str
+        default: WARNING
     validate_response_schema:
         description:
           - Flag for Cisco DNA Center SDK to enable the validation of request bodies against a JSON schema.


### PR DESCRIPTION
Since we are using the documentation of dnac_log_level in every intent modules and it is associated with the DNAC credentials, we are adding that part to the doc_fragments/intent_params.py