### PR TITLE
Removed the dnac_log_level from the documentation.

### DIFF
--- a/plugins/modules/device_credential_intent.py
+++ b/plugins/modules/device_credential_intent.py
@@ -25,11 +25,6 @@ extends_documentation_fragment:
 author: Muthu Rakesh (@MUTHU-RAKESH-27)
         Madhan Sankaranarayanan (@madhansansel)
 options:
-  dnac_log_level:
-    description: Specifies the desired log level for Cisco Catalyst Center logging.
-                    Options - [CRITICAL, ERROR, WARNING, INFO, DEBUG]
-    type: str
-    default: INFO
   config_verify:
     description: Set to True to verify the Cisco DNA Center after applying the playbook config.
     type: bool
@@ -2572,7 +2567,7 @@ def main():
         "dnac_version": {"type": 'str', "default": '2.2.3.3'},
         "dnac_debug": {"type": 'bool', "default": False},
         "dnac_log": {"type": 'bool', "default": False},
-        "dnac_log_level": {"type": "str", "default": "INFO"},
+        "dnac_log_level": {"type": 'str', "default": 'WARNING'},
         "config_verify": {"type": 'bool', "default": False},
         "config": {"type": 'list', "required": True, "elements": 'dict'},
         "state": {"default": 'merged', "choices": ['merged', 'deleted']},

--- a/plugins/modules/network_settings_intent.py
+++ b/plugins/modules/network_settings_intent.py
@@ -25,11 +25,6 @@ extends_documentation_fragment:
 author: Muthu Rakesh (@MUTHU-RAKESH-27)
         Madhan Sankaranarayanan (@madhansansel)
 options:
-  dnac_log_level:
-    description: Specifies the desired log level for Cisco Catalyst Center logging.
-                    Options - [CRITICAL, ERROR, WARNING, INFO, DEBUG]
-    type: str
-    default: INFO
   config_verify:
     description: Set to True to verify the Cisco DNA Center after applying the playbook config.
     type: bool
@@ -2129,7 +2124,7 @@ def main():
         "dnac_version": {"type": 'str', "default": '2.2.3.3'},
         "dnac_debug": {"type": 'bool', "default": False},
         "dnac_log": {"type": 'bool', "default": False},
-        "dnac_log_level": {"type": "str", "default": "INFO"},
+        "dnac_log_level": {"type": 'str', "default": 'WARNING'},
         "config_verify": {"type": 'bool', "default": False},
         "config": {"type": 'list', "required": True, "elements": 'dict'},
         "state": {"default": 'merged', "choices": ['merged', 'deleted']},

--- a/plugins/modules/provision_intent.py
+++ b/plugins/modules/provision_intent.py
@@ -21,12 +21,6 @@ extends_documentation_fragment:
   - cisco.dnac.intent_params
 author: Abinash Mishra (@abimishr)
 options:
-  dnac_log_level:
-    description:
-        - Specifies the desired log level for Cisco Catalyst Center logging.
-            Options - [CRITICAL, ERROR, WARNING, INFO, DEBUG]
-    type: str
-    default: WARNING
   config_verify:
     description: Set to True to verify the Cisco Catalyst Center config after applying the playbook config.
     type: bool

--- a/plugins/modules/site_intent.py
+++ b/plugins/modules/site_intent.py
@@ -29,11 +29,6 @@ options:
     description: Set to True to verify the Cisco Catalyst Center config after applying the playbook config.
     type: bool
     default: False
-  dnac_log_level:
-    description: Specifies the log level for Cisco Catalyst Center logging, categorizing logs by severity.
-        Options- [CRITICAL, ERROR, WARNING, INFO, DEBUG]
-    type: str
-    default: INFO
   state:
     description: The state of Catalyst Center after module completion.
     type: str
@@ -1030,7 +1025,7 @@ def main():
                     'dnac_verify': {'type': 'bool', 'default': 'True'},
                     'dnac_version': {'type': 'str', 'default': '2.2.3.3'},
                     'dnac_debug': {'type': 'bool', 'default': False},
-                    'dnac_log_level': {'type': 'str', 'default': 'INFO'},
+                    'dnac_log_level': {'type': 'str', 'default': 'WARNING'},
                     'dnac_log': {'type': 'bool', 'default': False},
                     'validate_response_schema': {'type': 'bool', 'default': True},
                     'config_verify': {'type': 'bool', "default": False},

--- a/plugins/modules/template_intent.py
+++ b/plugins/modules/template_intent.py
@@ -30,11 +30,6 @@ author: Madhan Sankaranarayanan (@madhansansel)
         Akash Bhaskaran (@akabhask)
         Muthu Rakesh (@MUTHU-RAKESH-27)
 options:
-  dnac_log_level:
-    description: Specifies the desired log level for Cisco Catalyst Center logging.
-                    Options - [CRITICAL, ERROR, WARNING, INFO, DEBUG]
-    type: str
-    default: INFO
   config_verify:
     description: Set to True to verify the Cisco DNA Center after applying the playbook config.
     type: bool
@@ -2766,7 +2761,7 @@ def main():
                     'dnac_version': {'type': 'str', 'default': '2.2.3.3'},
                     'dnac_debug': {'type': 'bool', 'default': False},
                     'dnac_log': {'type': 'bool', 'default': False},
-                    "dnac_log_level": {"type": "str", "default": "INFO"},
+                    "dnac_log_level": {"type": 'str', "default": 'WARNING'},
                     'validate_response_schema': {'type': 'bool', 'default': True},
                     "config_verify": {"type": 'bool', "default": False},
                     'config': {'required': True, 'type': 'list', 'elements': 'dict'},


### PR DESCRIPTION
Removed the dnac_log_level from the documentation part because it is added in the global documentation part (doc_fragments/intent_params.py)