### PR TITLE
Setup a logger method

### DIFF
--- a/plugins/module_utils/dnac.py
+++ b/plugins/module_utils/dnac.py
@@ -287,7 +287,7 @@ class DnacBase():
             params={"task_id": task_id}
         )
 
-        log("Retrieving task details by the API 'get_task_by_id' using task ID: {0}, Response: {1}".format(str(response)), 'DEBUG')
+        self.dnac_file_logger.debug("Retrieving task details by the API 'get_task_by_id' using task ID: {0}, Response: {1}".format(str(response)))
 
         if response and isinstance(response, dict):
             result = response.get('response')

--- a/plugins/module_utils/dnac.py
+++ b/plugins/module_utils/dnac.py
@@ -66,22 +66,22 @@ class DnacBase():
                                         }
         self.dnac_log = dnac_params.get("dnac_log")
 
-        if self.dnac_log and DnacBase.__is_log_init is False:
-            self.dnac_log_level = dnac_params.get("dnac_log_level") or 'INFO'
+        if self.dnac_log and not DnacBase.__is_log_init:
+            self.dnac_log_level = dnac_params.get("dnac_log_level") or 'WARNING'
             self.validate_dnac_log_level()
+            self.dnac_log_level = self.dnac_log_level.upper()
             self.dnac_log_file_path = dnac_params.get("dnac_log_file_path") or 'dnac.log'
             self.validate_dnac_log_file_path()
-
-            if dnac_params.get("dnac_log_append") is False:
-                self.dnac_log_append = False
-                self.dnac_log_mode = 'w'
-            else:
-                self.dnac_log_append = True
-                self.dnac_log_mode = 'a'
-            self.log_file = open(self.dnac_log_file_path, self.dnac_log_mode)
+            self.dnac_log_mode = 'w' if not dnac_params.get("dnac_log_append") else 'a'
+            self.setup_logger('dnac_file_logger')
+            self.dnac_file_logger = logging.getLogger('dnac_file_logger')
             DnacBase.__is_log_init = True
+            self.dnac_file_logger.debug('Logging configured and initiated')
+        elif not self.dnac_log:
+            # If dnac_log is False, return an empty logger
+            self.dnac_file_logger = logging.getLogger('empty_logger')
 
-        self.log('Dnac parameters: {0}'.format(str(dnac_params)), 'DEBUG')
+        self.dnac_file_logger.debug('Dnac parameters: {0}'.format(str(dnac_params)))
         self.supported_states = ["merged", "deleted", "replaced", "overridden", "gathered", "rendered", "parsed"]
         self.result = {"changed": False, "diff": [], "response": [], "warnings": []}
 
@@ -162,6 +162,26 @@ class DnacBase():
         self.parsed = True
         return self
 
+    def setup_logger(self, logger_name):
+        """Set up a logger with specified name and configuration based on dnac_log_level"""
+        level_mapping = {
+            'INFO': logging.INFO,
+            'DEBUG': logging.DEBUG,
+            'WARNING': logging.WARNING,
+            'ERROR': logging.ERROR,
+            'CRITICAL': logging.CRITICAL
+        }
+        level = level_mapping.get(self.dnac_log_level, logging.WARNING)
+
+        logger = logging.getLogger(logger_name)
+        formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(module)s:%(funcName)s:%(lineno)d --- %(message)s', datefmt='%m-%d-%Y %H:%M:%S')
+
+        file_handler = logging.FileHandler(self.dnac_log_file_path, mode=self.dnac_log_mode)
+        file_handler.setFormatter(formatter)
+
+        logger.setLevel(level)
+        logger.addHandler(file_handler)
+
     def validate_dnac_log_level(self):
         """Validates if the logging level is string and of expected value"""
         if self.dnac_log_level not in ('INFO', 'DEBUG', 'WARNING', 'ERROR', 'CRITICAL'):
@@ -180,13 +200,6 @@ class DnacBase():
         if not os.path.exists(log_directory):
             raise FileNotFoundError("The directory for log file '{0}' does not exist.".format(dnac_log_file_path))
 
-    def validate_level(self, message, level):
-        """Validates if the specified log level is a string and one of the expected values"""
-        if not isinstance(level, str):
-            raise ValueError("Invalid log level type passed when logging the following msg: {0} level:{1}. Expected a string.".format(message, level))
-        if level.upper() not in ('INFO', 'DEBUG', 'WARNING', 'ERROR', 'CRITICAL'):
-            raise ValueError("Invalid log level passed when logging the following msg: {0} level:{1}.".format(message, level))
-
     def log(self, message, level="WARNING", frameIncrement=0):
         """Logs formatted messages with specified log level and incrementing the call stack frame
         Args:
@@ -194,30 +207,22 @@ class DnacBase():
             message (str, required): The log message to be recorded.
             level (str, optional): The log level, default is "info".
                                    The log level can be one of 'DEBUG', 'INFO', 'WARNING', 'ERROR', or 'CRITICAL'.
-            frameIncrement (int, optional): The number of frames to increment in the call stack, default is 0.
         """
 
         if self.dnac_log:
-            self.validate_level(message, level)
-            level = level.upper()
-            self.dnac_log_level = self.dnac_log_level.upper()
-
-            if logging.getLevelName(level) >= logging.getLevelName(self.dnac_log_level):
-                message = "Module: " + self.__class__.__name__ + ", " + message
-                callerframerecord = inspect.stack()[frameIncrement]
-                frame = callerframerecord[0]
-                info = inspect.getframeinfo(frame)
-                current_datetime = datetime.datetime.now().replace(microsecond=0).isoformat()
-                self.log_file.write("---- {0} ---- {1}@{2} ---- {3}: {4}\n".format(current_datetime, info.lineno, info.function, level, message))
-
-    def close_log_file(self):
-        """Closes the open log file"""
-        self.log_file.close()
+            message = "Module: " + self.__class__.__name__ + ", " + message
+            callerframerecord = inspect.stack()[frameIncrement]
+            frame = callerframerecord[0]
+            info = inspect.getframeinfo(frame)
+            #log_message = "{0}@{1} --- {2}".format(info.lineno, info.function, message)
+            log_method = getattr(self.dnac_file_logger, level.lower())
+            log_method(message)
 
     def check_return_status(self):
         """API to check the return status value and exit/fail the module"""
 
-        self.log("status: {0}, msg:{1}".format(self.status, self.msg), frameIncrement=1)
+        #self.log("status: {0}, msg:{1}".format(self.status, self.msg), frameIncrement=1)
+        self.dnac_file_logger.debug("status: {0}, msg:{1}".format(self.status, self.msg))
         if "failed" in self.status:
             self.module.fail_json(msg=self.msg, response=[])
         elif "exited" in self.status:
@@ -282,7 +287,7 @@ class DnacBase():
             params={"task_id": task_id}
         )
 
-        self.log('Tas Details: {0}'.format(str(response)), 'DEBUG')
+        log("Retrieving task details by the API 'get_task_by_id' using task ID: {0}, Response: {1}".format(str(response)), 'DEBUG')
 
         if response and isinstance(response, dict):
             result = response.get('response')
@@ -321,7 +326,7 @@ class DnacBase():
         task_id = response.get("taskId")
         while True:
             task_details = self.get_task_details(task_id)
-            self.log('Task details: {0}'.format(str(task_details)), 'DEBUG')
+            self.dnac_file_logger.debug('Getting task details from task ID {1}: {0}'.format(str(task_details), task_id))
 
             if task_details.get("isError") is True:
                 if task_details.get("failureReason"):
@@ -338,7 +343,7 @@ class DnacBase():
                 self.status = "success"
                 break
 
-            self.log("progress set to {0} for taskid: {1}"
+            self.dnac_file_logger.debug("progress set to {0} for taskid: {1}"
                      .format(task_details.get('progress'), task_id))
 
         return self
@@ -360,13 +365,13 @@ class DnacBase():
             response (dict) - Status for API execution
         """
 
-        self.log("Execution Id " + str(execid))
+        self.dnac_file_logger.debug("Execution Id " + str(execid))
         response = self.dnac._exec(
             family="task",
             function='get_business_api_execution_details',
             params={"execution_id": execid}
         )
-        self.log("Response for the current execution" + str(response))
+        self.dnac_file_logger.debug("Response for the current execution" + str(response))
         return response
 
     def check_execution_response_status(self, response):
@@ -380,7 +385,7 @@ class DnacBase():
             self
         """
 
-        self.log(str(response))
+        self.dnac_file_logger.debug(str(response))
         if not response:
             self.msg = "response is empty"
             self.status = "failed"
@@ -442,7 +447,7 @@ class DnacBase():
             for key, value in config.items():
                 new_key = re.sub(r'([a-z0-9])([A-Z])', r'\1_\2', key).lower()
                 if new_key != key:
-                    self.log("{0} will be deprecated soon. Please use {1}.".format(key, new_key))
+                    self.dnac_file_logger.debug("{0} will be deprecated soon. Please use {1}.".format(key, new_key))
                 new_value = self.camel_to_snake_case(value)
                 new_config[new_key] = new_value
         elif isinstance(config, list):
@@ -450,11 +455,6 @@ class DnacBase():
         else:
             return config
         return new_config
-
-    def __del__(self):
-        """Destructor method to close the log file when the object is deleted"""
-        if hasattr(self, 'log_file') and self.log_file is not None:
-            self.close_log_file()
 
 
 def is_list_complex(x):

--- a/plugins/module_utils/dnac.py
+++ b/plugins/module_utils/dnac.py
@@ -327,7 +327,6 @@ class DnacBase():
             task_details = self.get_task_details(task_id)
             self.dnac_file_logger.debug('Getting task details from task ID %s: %s', task_id, str(task_details))
 
-
             if task_details.get("isError") is True:
                 if task_details.get("failureReason"):
                     self.msg = str(task_details.get("failureReason"))

--- a/plugins/module_utils/dnac.py
+++ b/plugins/module_utils/dnac.py
@@ -24,7 +24,7 @@ else:
 import os.path
 import copy
 import json
-import datetime
+# import datetime
 import inspect
 import re
 
@@ -81,7 +81,7 @@ class DnacBase():
             # If dnac_log is False, return an empty logger
             self.dnac_file_logger = logging.getLogger('empty_logger')
 
-        self.dnac_file_logger.debug('Dnac parameters: {0}'.format(str(dnac_params)))
+        self.dnac_file_logger.debug('Dnac parameters: %s', str(dnac_params))
         self.supported_states = ["merged", "deleted", "replaced", "overridden", "gathered", "rendered", "parsed"]
         self.result = {"changed": False, "diff": [], "response": [], "warnings": []}
 
@@ -214,15 +214,15 @@ class DnacBase():
             callerframerecord = inspect.stack()[frameIncrement]
             frame = callerframerecord[0]
             info = inspect.getframeinfo(frame)
-            #log_message = "{0}@{1} --- {2}".format(info.lineno, info.function, message)
+            # log_message = "{0}@{1} --- {2}".format(info.lineno, info.function, message)
             log_method = getattr(self.dnac_file_logger, level.lower())
             log_method(message)
 
     def check_return_status(self):
         """API to check the return status value and exit/fail the module"""
 
-        #self.log("status: {0}, msg:{1}".format(self.status, self.msg), frameIncrement=1)
-        self.dnac_file_logger.debug("status: {0}, msg:{1}".format(self.status, self.msg))
+        # self.log("status: {0}, msg:{1}".format(self.status, self.msg), frameIncrement=1)
+        self.dnac_file_logger.debug("status: %s, msg: %s", self.status, self.msg)
         if "failed" in self.status:
             self.module.fail_json(msg=self.msg, response=[])
         elif "exited" in self.status:
@@ -286,8 +286,7 @@ class DnacBase():
             function='get_task_by_id',
             params={"task_id": task_id}
         )
-
-        self.dnac_file_logger.debug("Retrieving task details by the API 'get_task_by_id' using task ID: {0}, Response: {1}".format(str(response)))
+        self.dnac_file_logger.debug("Retrieving task details by the API 'get_task_by_id' using task ID: %s, Response: %s", str(task_id), str(response))
 
         if response and isinstance(response, dict):
             result = response.get('response')
@@ -326,7 +325,8 @@ class DnacBase():
         task_id = response.get("taskId")
         while True:
             task_details = self.get_task_details(task_id)
-            self.dnac_file_logger.debug('Getting task details from task ID {1}: {0}'.format(str(task_details), task_id))
+            self.dnac_file_logger.debug('Getting task details from task ID %s: %s', task_id, str(task_details))
+
 
             if task_details.get("isError") is True:
                 if task_details.get("failureReason"):
@@ -343,8 +343,7 @@ class DnacBase():
                 self.status = "success"
                 break
 
-            self.dnac_file_logger.debug("progress set to {0} for taskid: {1}"
-                     .format(task_details.get('progress'), task_id))
+            self.dnac_file_logger.debug("progress set to %s for taskid: %s", task_details.get('progress'), task_id)
 
         return self
 
@@ -365,13 +364,13 @@ class DnacBase():
             response (dict) - Status for API execution
         """
 
-        self.dnac_file_logger.debug("Execution Id " + str(execid))
+        self.dnac_file_logger.debug("Execution Id %s", str(execid))
         response = self.dnac._exec(
             family="task",
             function='get_business_api_execution_details',
             params={"execution_id": execid}
         )
-        self.dnac_file_logger.debug("Response for the current execution" + str(response))
+        self.dnac_file_logger.debug("Response for the current execution %s", str(response))
         return response
 
     def check_execution_response_status(self, response):
@@ -447,7 +446,7 @@ class DnacBase():
             for key, value in config.items():
                 new_key = re.sub(r'([a-z0-9])([A-Z])', r'\1_\2', key).lower()
                 if new_key != key:
-                    self.dnac_file_logger.debug("{0} will be deprecated soon. Please use {1}.".format(key, new_key))
+                    self.dnac_file_logger.debug("%s will be deprecated soon. Please use %s.", key, new_key)
                 new_value = self.camel_to_snake_case(value)
                 new_config[new_key] = new_value
         elif isinstance(config, list):


### PR DESCRIPTION
**PR Summary**

Changes have been strictly in dnac.py 

- Supports logging using both 
   self.log(message, 'INFO')
   self.dnac_file_logger.info(message)
- Added a setup_logger method which configures the logger to the specified dnac_log_file_path and sets the logging level based on the specidied dnac_log_level. Also added the filename:function:lineno in the logger formatter directly, no need to add it in every message. 
- Have retained the def log() method for backward compatibility till we change the log lines in all the method
- Also, handles the situation if dnac_log is False and we are using seld.dnac_file_logger directly. 