### PR TITLE
API get_image_name_from_id was returning image_id instead of name whi…

### DIFF
--- a/plugins/modules/swim_intent.py
+++ b/plugins/modules/swim_intent.py
@@ -567,7 +567,7 @@ class DnacSwims(DnacBase):
             self.log(error_message, "ERROR")
             self.module.fail_json(msg=error_message, response=image_response)
 
-        return image_id
+        return image_name
 
     def is_image_exist(self, name):
         """


### PR DESCRIPTION
…ch makes log messages complicated for customer to read.

In this commit -

-- Change the return parameter of 'get_image_name_from_id' API from image id to image name which makes log messages more clear as we use image name while logging messages.