### PR TITLE
Fixes for SNMP issue and records to return value

### DIFF
--- a/plugins/modules/discovery_intent.py
+++ b/plugins/modules/discovery_intent.py
@@ -70,9 +70,35 @@ options:
       http_read_credential:
         description: HTTP read credentials for hosting a device
         type: dict
+        suboptions:
+            password:
+                description: HTTP(S) password and is mandatory for using HTTP credentials.
+                type: str
+            port:
+                description: HTTP(S) port and is mandatory for using HTTP credentials.
+                type: int
+            secure:
+                description: Flag for HTTP(S) and is not mandatory for using HTTP credentials.
+                type: bool
+            username:
+                description: HTTP(S) username and is mandatory for using HTTP credentials.
+                type: str
       http_write_credential:
         description: HTTP write credentials for hosting a device
         type: dict
+        suboptions:
+            password:
+                description: HTTP(S) password and is mandatory for using HTTP credentials.
+                type: str
+            port:
+                description: HTTP(S) port and is mandatory for using HTTP credentials.
+                type: int
+            secure:
+                description: Flag for HTTP(S) and is not mandatory for using HTTP credentials.
+                type: bool
+            username:
+                description: HTTP(S) username and is mandatory for using HTTP credentials.
+                type: str
       ip_filter_list:
         description: List of IP adddrsess that needs to get filtered out from the IP addresses added
         type: list
@@ -195,8 +221,8 @@ EXAMPLES = r"""
           start_index: integer
           enable_password_list: list
           records_to_return: integer
-          http_read_credential: dict
-          http_write_credential: dict
+          http_read_credential: dictionary
+          http_write_credential: dictionary
           ip_filter_list: list
           discovery_name: string
           password_list: list
@@ -567,6 +593,32 @@ class DnacDiscovery(DnacBase):
         if credential_ids is None:
             credential_ids = []
 
+        http_read_credential = self.validated_config[0].get('http_read_credential')
+        http_write_credential = self.validated_config[0].get('http_write_credential')
+        if http_read_credential:
+            if not (http_read_credential.get('password') and isinstance(http_read_credential.get('password'), str)):
+                msg = "Http Read Credential must have a password of type string"
+            if not (http_read_credential.get('username') and isinstance(http_read_credential.get('username'), str)):
+                msg = "Http Read Credential must have a username of type string"
+            if not (http_read_credential.get('password') and isinstance(http_read_credential.get('password'), int)):
+                msg = "Http Read Credential must have port of type integer"
+            if not isinstance(http_read_credential.get('secure'), bool):
+                msg = "Secure must be of type bool"
+            self.log(msg, "CRITICAL")
+            self.module.fail_json(msg=msg)
+
+        if http_write_credential:
+            if not (http_write_credential.get('password') and isinstance(http_read_credential.get('password'), str)):
+                msg = "Http Write Credential must have a password of type string"
+            if not (http_write_credential.get('username') and isinstance(http_read_credential.get('username'), str)):
+                msg = "Http Write Credential must have a username of type string"
+            if not (http_write_credential.get('password') and isinstance(http_read_credential.get('password'), int)):
+                msg = "Http Write Credential must have port of type integer"
+            if not isinstance(http_write_credential.get('secure'), bool):
+                msg = "Secure must be of type bool"
+            self.log(msg, "CRITICAL")
+            self.module.fail_json(msg=msg)
+
         new_object_params = {}
         new_object_params['cdpLevel'] = self.validated_config[0].get('cdp_level')
         new_object_params['discoveryType'] = self.validated_config[0].get('discovery_type')
@@ -702,13 +754,13 @@ class DnacDiscovery(DnacBase):
         start_index = self.validated_config[0].get("start_index")
         records_to_return = self.validated_config[0].get("records_to_return")
 
-        response = {"response":[]}
+        response = {"response": []}
         if records_to_return > 500:
-            num_intervals = records_to_return//500
-            for num in range(0,num_intervals+1):
+            num_intervals = records_to_return // 500
+            for num in range(0, num_intervals + 1):
                 params = dict(
-                    start_index=1 + num*500,
-                    records_to_return =500,
+                    start_index=1 + num * 500,
+                    records_to_return=500,
                     headers=self.validated_config[0].get("headers")
                 )
                 response_part = self.dnac_apply['exec'](

--- a/plugins/modules/discovery_intent.py
+++ b/plugins/modules/discovery_intent.py
@@ -71,34 +71,34 @@ options:
         description: HTTP read credentials for hosting a device
         type: dict
         suboptions:
+            username:
+                description: The username for HTTP(S) authentication, which is mandatory when using HTTP credentials.
+                type: str
             password:
-                description: HTTP(S) password and is mandatory for using HTTP credentials.
+                description: The password for HTTP(S) authentication. Mandatory for utilizing HTTP credentials.
                 type: str
             port:
-                description: HTTP(S) port and is mandatory for using HTTP credentials.
+                description: The HTTP(S) port number, which is mandatory for using HTTP credentials.
                 type: int
             secure:
-                description: Flag for HTTP(S) and is not mandatory for using HTTP credentials.
+                description: This is a flag for HTTP(S). Its usage is not mandatory for HTTP credentials.
                 type: bool
-            username:
-                description: HTTP(S) username and is mandatory for using HTTP credentials.
-                type: str
       http_write_credential:
         description: HTTP write credentials for hosting a device
         type: dict
         suboptions:
+            username:
+                description: The username for HTTP(S) authentication, which is mandatory when using HTTP credentials.
+                type: str
             password:
-                description: HTTP(S) password and is mandatory for using HTTP credentials.
+                description: The password for HTTP(S) authentication. Mandatory for utilizing HTTP credentials.
                 type: str
             port:
-                description: HTTP(S) port and is mandatory for using HTTP credentials.
+                description: The HTTP(S) port number, which is mandatory for using HTTP credentials.
                 type: int
             secure:
-                description: Flag for HTTP(S) and is not mandatory for using HTTP credentials.
+                description: This is a flag for HTTP(S). Its usage is not mandatory for HTTP credentials.
                 type: bool
-            username:
-                description: HTTP(S) username and is mandatory for using HTTP credentials.
-                type: str
       ip_filter_list:
         description: List of IP adddrsess that needs to get filtered out from the IP addresses added
         type: list
@@ -574,6 +574,14 @@ class DnacDiscovery(DnacBase):
         self.log("IP Address list's length is longer than 1", "ERROR")
         self.module.fail_json(msg="IP Address list's length is longer than 1", response=[])
 
+    def http_cred_failure(self, msg=None):
+        """
+        Method for failing discovery if there is any discrepancy in the http credentials
+        passed by the user
+        """
+        self.log(msg, "CRITICAL")
+        self.module.fail_json(msg=msg)
+
     def create_params(self, credential_ids=None, ip_address_list=None):
         """
         Create a new parameter object based on the validated configuration,
@@ -597,27 +605,31 @@ class DnacDiscovery(DnacBase):
         http_write_credential = self.validated_config[0].get('http_write_credential')
         if http_read_credential:
             if not (http_read_credential.get('password') and isinstance(http_read_credential.get('password'), str)):
-                msg = "Http Read Credential must have a password of type string"
+                msg = "The password for the HTTP read credential must be of string type."
+                self.http_cred_failure(msg=msg)
             if not (http_read_credential.get('username') and isinstance(http_read_credential.get('username'), str)):
-                msg = "Http Read Credential must have a username of type string"
-            if not (http_read_credential.get('password') and isinstance(http_read_credential.get('password'), int)):
-                msg = "Http Read Credential must have port of type integer"
+                msg = "The username for the HTTP read credential must be of string type."
+                self.http_cred_failure(msg=msg)
+            if not (http_read_credential.get('port') and isinstance(http_read_credential.get('port'), int)):
+                msg = "The port for the HTTP read Credential must be of integer type."
+                self.http_cred_failure(msg=msg)
             if not isinstance(http_read_credential.get('secure'), bool):
-                msg = "Secure must be of type bool"
-            self.log(msg, "CRITICAL")
-            self.module.fail_json(msg=msg)
+                msg = "Secure for HTTP read Credential must be of type boolean."
+                self.http_cred_failure(msg=msg)
 
         if http_write_credential:
-            if not (http_write_credential.get('password') and isinstance(http_read_credential.get('password'), str)):
-                msg = "Http Write Credential must have a password of type string"
-            if not (http_write_credential.get('username') and isinstance(http_read_credential.get('username'), str)):
-                msg = "Http Write Credential must have a username of type string"
-            if not (http_write_credential.get('password') and isinstance(http_read_credential.get('password'), int)):
-                msg = "Http Write Credential must have port of type integer"
+            if not (http_write_credential.get('password') and isinstance(http_write_credential.get('password'), str)):
+                msg = "The password for the HTTP write credential must be of string type."
+                self.http_cred_failure(msg=msg)
+            if not (http_write_credential.get('username') and isinstance(http_write_credential.get('username'), str)):
+                msg = "The username for the HTTP write credential must be of string type."
+                self.http_cred_failure(msg=msg)
+            if not (http_write_credential.get('port') and isinstance(http_write_credential.get('port'), int)):
+                msg = "The port for the HTTP write Credential must be of integer type."
+                self.http_cred_failure(msg=msg)
             if not isinstance(http_write_credential.get('secure'), bool):
-                msg = "Secure must be of type bool"
-            self.log(msg, "CRITICAL")
-            self.module.fail_json(msg=msg)
+                msg = "Secure for HTTP write Credential must be of type boolean."
+                self.http_cred_failure(msg=msg)
 
         new_object_params = {}
         new_object_params['cdpLevel'] = self.validated_config[0].get('cdp_level')


### PR DESCRIPTION
Problem: If we are having null values in credentials (v2) it throws nonetype error. Also, we have issues in API if the start_index > 500.
Fix: Made null to empty list for resolution of the error related to credentials. For API, I have added one more case which dynamically checks the records_to_return. Additionally, have added documentation for the HTTP credentials dict.
Test cases: Muti range with records_to return value of 720 and empty SNMP lists for failure.