### PR TITLE
Remove snmp mode default value of AUTHPRIV while updating device and …

### DIFF
--- a/plugins/modules/inventory_intent.py
+++ b/plugins/modules/inventory_intent.py
@@ -106,7 +106,6 @@ options:
       snmp_mode:
         description: Device's snmp Mode.
         type: str
-        default: "AUTHPRIV"
       snmp_priv_passphrase:
         description: Device's snmp Private Passphrase. Required for Adding Network, Compute, Third Party Devices.
         type: str
@@ -754,7 +753,7 @@ class DnacDevice(DnacBase):
             'serial_number': {'type': 'str'},
             'snmp_auth_passphrase': {'type': 'str'},
             'snmp_auth_protocol': {'default': "SHA", 'type': 'str'},
-            'snmp_mode': {'default': "AUTHPRIV", 'type': 'str'},
+            'snmp_mode': {'type': 'str'},
             'snmp_priv_passphrase': {'type': 'str'},
             'snmp_priv_protocol': {'type': 'str'},
             'snmp_ro_community': {'default': "public", 'type': 'str'},
@@ -2708,6 +2707,18 @@ class DnacDevice(DnacBase):
                     playbook_params = self.want.get("device_params").copy()
                     playbook_params['ipAddress'] = [device_ip]
                     device_data = device_details[device_ip]
+                    if device_data['snmpv3_privacy_password'] == ' ':
+                        device_data['snmpv3_privacy_password'] = None
+                    if device_data['snmpv3_auth_password'] == ' ':
+                        device_data['snmpv3_auth_password'] = None
+
+                    if not playbook_params['snmpMode']:
+                        if device_data['snmpv3_privacy_password']:
+                            playbook_params['snmpMode'] = "AUTHPRIV"
+                        elif device_data['snmpv3_auth_password']:
+                            playbook_params['snmpMode'] = "AUTHNOPRIV"
+                        else:
+                            playbook_params['snmpMode'] = "NOAUTHNOPRIV"
 
                     if not playbook_params['cliTransport']:
                         if device_data['protocol'] == "ssh2":
@@ -2877,6 +2888,8 @@ class DnacDevice(DnacBase):
         if device_added:
             config['ip_address'] = devices_to_add
             device_params = self.want.get("device_params")
+            if not device_params['snmpMode']:
+                device_params['snmpMode'] = "AUTHPRIV"
 
             if not device_params['cliTransport']:
                 device_params['cliTransport'] = "ssh"


### PR DESCRIPTION
…add check in the code to set snmpMode while updating device if not given in playbook.

In this commit - 

-- Since export device list is not returning the snmpMode so make check in the code based on snmp_privacy_password and snmp_auth_password and set the snmpMode based on that.

-- Remove snmp mode default value of AUTHPRIV while updating device and add check in the code to set snmpMode while updating device if not given in playbook.

-- Remove default value of snmp_mode from documentation and add in the code itself while adding the device in inventory.