### PR TITLE
Replace device_type in swim module for tagging/un-tagging image with …

### DIFF
--- a/playbooks/swim_workflow_manager.yml
+++ b/playbooks/swim_workflow_manager.yml
@@ -31,7 +31,7 @@
             site_name: "{{item.site_name}}"
             device_role: "{{ item.device_role }}"
             device_image_family_name: "{{ item.device_image_family_name }}"
-            tagging: false
+            tagging: False
           image_distribution_details:
             image_name: "{{item.image_name}}"
             site_name: "{{item.site_name}}"

--- a/playbooks/swim_workflow_manager.yml
+++ b/playbooks/swim_workflow_manager.yml
@@ -16,9 +16,9 @@
         dnac_port: "{{dnac_port}}"
         dnac_version: "{{dnac_version}}"
         dnac_debug: "{{dnac_debug}}"
-        dnac_log: true
+        dnac_log: True
         dnac_log_level: DEBUG
-        config_verify: true
+        config_verify: True
         config:
         - import_image_details:
             type: "{{ item.type }}"
@@ -30,8 +30,7 @@
             image_name: "{{item.image_name}}"
             site_name: "{{item.site_name}}"
             device_role: "{{ item.device_role }}"
-            device_family_name: "{{ item.device_family_name }}"
-            device_type: "{{item.device_type}}"
+            device_image_family_name: "{{ item.device_image_family_name }}"
             tagging: false
           image_distribution_details:
             image_name: "{{item.image_name}}"
@@ -42,8 +41,8 @@
             site_name: "{{item.site_name}}"
             device_role: "{{ item.device_role }}"
             device_family_name: "{{ item.device_family_name }}"
-            scehdule_validate: false
-            distribute_if_needed: true
+            scehdule_validate: False
+            distribute_if_needed: True
 
       with_items: "{{ image_details }}"
       tags:

--- a/plugins/modules/inventory_intent.py
+++ b/plugins/modules/inventory_intent.py
@@ -181,6 +181,19 @@ options:
         default: false
       role:
         description: Role of device which can be ACCESS, CORE, DISTRIBUTION, BORDER ROUTER, UNKNOWN.
+            ALL - This role typically represents all devices within the network, regardless of their specific roles or functions.
+            UNKNOWN - This role is assigned to devices whose roles or functions have not been identified or classified within Cisco Catalsyt Center.
+                This could happen if the platform is unable to determine the device's role based on available information.
+            ACCESS - This role typically represents switches or access points that serve as access points for end-user devices to connect to the network.
+                These devices are often located at the edge of the network and provide connectivity to end-user devices.
+            BORDER ROUTER - These are devices that connect different network domains or segments together. They often serve as
+                gateways between different networks, such as connecting an enterprise network to the internet or connecting
+                multiple branch offices.
+            DISTRIBUTION - This role represents function as distribution switches or routers in hierarchical network designs. They aggregate traffic
+                from access switches and route it toward the core of the network or toward other distribution switches.
+            CORE - This role typically represents high-capacity switches or routers that form the backbone of the network. They handle large volumes
+                of traffic and provide connectivity between different parts of network, such as connecting distribution switches or
+                providing interconnection between different network segments.
         type: str
         default: "ACCESS"
       role_source:
@@ -315,7 +328,7 @@ EXAMPLES = r"""
         snmp_username: string
         snmp_version: string
         type: string
-        device_added: true
+        device_added: True
         username: string
 
 - name: Add new Compute device in Inventory with full credentials.Inputs needed for Compute Device
@@ -344,9 +357,9 @@ EXAMPLES = r"""
         snmp_retry:  3
         snmp_timeout: 5
         snmp_username: string
-        compute_device: true
+        compute_device: True
         username: string
-        device_added: true
+        device_added: True
         type: "COMPUTE_DEVICE"
 
 - name: Add new Meraki device in Inventory with full credentials.Inputs needed for Meraki Device.
@@ -363,7 +376,7 @@ EXAMPLES = r"""
     state: merged
     config:
       - http_password: string
-        device_added: true
+        device_added: True
         type: "MERAKI_DASHBOARD"
 
 - name: Add new Firepower Management device in Inventory with full credentials.Input needed to add Device.
@@ -384,7 +397,7 @@ EXAMPLES = r"""
         http_username: string
         http_password: string
         http_port: string
-        device_added: true
+        device_added: True
         type: "FIREPOWER_MANAGEMENT_SYSTEM"
 
 - name: Add new Third Party device in Inventory with full credentials.Input needed to add Device.
@@ -410,7 +423,7 @@ EXAMPLES = r"""
         snmp_retry:  3
         snmp_timeout: 5
         snmp_username: string
-        device_added: true
+        device_added: True
         type: "THIRD_PARTY_DEVICE"
 
 - name: Update device details or credentails in Inventory
@@ -447,8 +460,8 @@ EXAMPLES = r"""
         snmp_username: string
         snmp_version: string
         type: string
-        device_updated: true
-        credential_update: true
+        device_updated: True
+        credential_update: True
         update_mgmt_ipaddresslist:
         - exist_mgmt_ipaddress: string
           new_mgmt_ipaddress: string
@@ -467,10 +480,10 @@ EXAMPLES = r"""
     dnac_log: False
     state: merged
     config:
-      - device_updated: true
+      - device_updated: True
         ip_address:
         - string
-        credential_update: true
+        credential_update: True
         update_mgmt_ipaddresslist:
         - exist_mgmt_ipaddress: string
           new_mgmt_ipaddress: string
@@ -535,7 +548,7 @@ EXAMPLES = r"""
     config:
       - ip_address:
         - string
-        device_updated: true
+        device_updated: True
         update_device_role:
           role: string
           role_source: string
@@ -555,7 +568,7 @@ EXAMPLES = r"""
     config:
       - ip_address:
         - string
-        device_updated: true
+        device_updated: True
         update_interface_details:
           description: str
           admin_status: str
@@ -619,7 +632,7 @@ EXAMPLES = r"""
     config:
       - ip_address:
         - string
-        device_resync: true
+        device_resync: True
         force_sync: false
 
 - name: Reboot AP Devices with IP Addresses
@@ -637,7 +650,7 @@ EXAMPLES = r"""
     config:
       - ip_address:
         - string
-        reboot_device: true
+        reboot_device: True
 
 - name: Delete Provision/Unprovision Devices by IP Address
   cisco.dnac.inventory_intent:
@@ -1755,9 +1768,9 @@ class DnacDevice(DnacBase):
                     site_type = item.get("attributes").get("type")
 
         except Exception as e:
-            self.msg = "Error while fetching the site '{0}'.".format(site_name)
+            self.msg = "Error while fetching the site '{0}' and given site not found in Cisco Catalyst Center".format(site_name)
             self.log(self.msg, "ERROR")
-            self.module.fail_json(msg="Site not found", response=[])
+            self.module.fail_json(msg=self.msg, response=[self.msg])
 
         return site_type
 

--- a/plugins/modules/inventory_intent.py
+++ b/plugins/modules/inventory_intent.py
@@ -44,28 +44,32 @@ options:
             protocol (either SSH or Telnet) used by the device.
         type: str
       compute_device:
-        description: Compute Device flag.
+        description: Indicates whether a device is a compute device.
         type: bool
+      password:
+        description: Password for accessing the device and for file encryption during device export. Required for
+            adding Network Device. Also needed for file encryption while exporting device in a csv file.
+        type: str
       enable_password:
-        description: Device's enable password.
+        description: Password required for enabling configurations on the device.
         type: str
       extended_discovery_info:
-        description: Device's extended discovery info.
+        description: Additional discovery information for the device.
         type: str
       http_password:
-        description: Device's http password. Required for Adding Compute, Meraki, Firepower Management Devices.
+        description: HTTP password required for adding compute, Meraki, and Firepower Management Devices.
         type: str
       http_port:
-        description: Device's http port number. Required for Adding Compute, Firepower Management Devices.
+        description: HTTP port number required for adding compute and Firepower Management Devices.
         type: str
       http_secure:
-        description: HttpSecure flag.
+        description: Flag indicating HTTP security.
         type: bool
       http_username:
-        description: Device's http username. Required for Adding Compute,Firepower Management Devices.
+        description: HTTP username required for adding compute and Firepower Management Devices.
         type: str
       ip_address:
-        description: Device's ipAddress. Required for Adding/Updating/Deleting/Resyncing Device except Meraki Devices.
+        description: IP address of the device. Required for Adding/Updating/Deleting/Resyncing Device except Meraki Devices.
         elements: str
         type: list
       hostname_list:
@@ -84,53 +88,58 @@ options:
         elements: str
         type: list
       netconf_port:
-        description: Device's netconf port.
+        description: Netconf port number.
         type: str
       username:
-        description: Network Device's username. Required for Adding Network Device.
-        type: str
-      password:
-        description: Device's password. Required for Adding Network Device.
-            Also needed for file encryption while exporting device in a csv file.
+        description: Username for accessing the device. Required for Adding Network Device.
         type: str
       serial_number:
-        description: Device's serial number.
+        description: Serial number of the device.
         type: str
       snmp_auth_passphrase:
-        description: Device's snmp auth passphrase. Required for Adding Network, Compute, Third Party Devices.
+        description: SNMP authentication passphrase required for adding network, compute, and third-party devices.
         type: str
       snmp_auth_protocol:
-        description: Device's snmp Auth Protocol.
+        description: SNMP authentication protocol.
+            SHA (Secure Hash Algorithm) - cryptographic hash function commonly used for data integrity verification and authentication purposes.
+            MD5 (Message Digest Algorithm 5) - cryptographic hash function commonly used for data integrity verification and authentication purposes.
         type: str
         default: "SHA"
       snmp_mode:
-        description: Device's snmp Mode.
+        description: Device's snmp Mode refer to different SNMP (Simple Network Management Protocol) versions and their corresponding security levels.
+            NOAUTHNOPRIV - This mode provides no authentication or encryption for SNMP messages. It means that devices communicating using SNMPv1 do
+                not require any authentication (username/password) or encryption (data confidentiality). This makes it the least secure option.
+            AUTHNOPRIV - This mode provides authentication but no encryption for SNMP messages. Authentication involves validating the source of the
+                SNMP messages using a community string (similar to a password). However, the data transmitted between devices is not encrypted,
+                so it's susceptible to eavesdropping.
+            AUTHPRIV - This mode provides both authentication and encryption for SNMP messages. It offers the highest level of security among the three
+                options. Authentication ensures that the source of the messages is genuine, and encryption ensures that the data exchanged between
+                devices is confidential and cannot be intercepted by unauthorized parties.
         type: str
       snmp_priv_passphrase:
-        description: Device's snmp Private Passphrase. Required for Adding Network, Compute, Third Party Devices.
+        description: SNMP private passphrase required for adding network, compute, and third-party devices.
         type: str
       snmp_priv_protocol:
-        description: Device's snmp Private Protocol. Required for Adding Network, Compute, Third Party Devices.
-            Must be given in playbook if you are updating the device credentails.
+        description: SNMP private protocol required for adding network, compute, and third-party devices.
         type: str
       snmp_ro_community:
-        description: Device's snmp ROCommunity. Required for Adding V2C Devices.
+        description: SNMP Read-Only community required for adding V2C devices.
         type: str
         default: public
       snmp_rw_community:
-        description: Device's snmp RWCommunity. Required for Adding V2C Devices.
+        description: SNMP Read-Write community required for adding V2C devices.
         type: str
         default: private
       snmp_retry:
-        description: Device's snmp Retry.
+        description: SNMP retry count.
         type: int
         default: 3
       snmp_timeout:
-        description: Device's snmp Timeout.
+        description: SNMP timeout duration.
         type: int
         default: 5
       snmp_username:
-        description: Device's snmp Username. Required for Adding Network, Compute, Third Party Devices.
+        description: SNMP username required for adding network, compute, and third-party devices.
         type: str
       snmp_version:
         description: Device's snmp Version.
@@ -138,10 +147,22 @@ options:
         default: "v3"
       type:
         description: Select Device's type from NETWORK_DEVICE, COMPUTE_DEVICE, MERAKI_DASHBOARD, THIRD_PARTY_DEVICE, FIREPOWER_MANAGEMENT_SYSTEM.
+            NETWORK_DEVICE - This refers to traditional networking equipment such as routers, switches, access points, and firewalls. These devices
+                are responsible for routing, switching, and providing connectivity within the network.
+            COMPUTE_DEVICE - These are computing resources such as servers, virtual machines, or containers that are part of the network infrastructure.
+                Cisco DNA Center can integrate with compute devices to provide visibility and management capabilities, ensuring that the network and
+                 compute resources work together seamlessly to support applications and services.
+            MERAKI_DASHBOARD - It is cloud-based platform used to manage Meraki networking devices, including wireless access points, switches, security
+                appliances, and cameras.
+            THIRD_PARTY_DEVICE - This category encompasses devices from vendors other than Cisco or Meraki. Cisco DNA Center is designed to support
+                integration with third-party devices through open standards and APIs. This allows organizations to manage heterogeneous network
+                environments efficiently using Cisco DNA Center's centralized management and automation capabilities.
+            FIREPOWER_MANAGEMENT_SYSTEM - It is a centralized management console used to manage Cisco's Firepower Next-Generation Firewall (NGFW) devices.
+                It provides features such as policy management, threat detection, and advanced security analytics.
         type: str
         default: "NETWORK_DEVICE"
       update_mgmt_ipaddresslist:
-        description: Network Device's update Mgmt IPaddress List.
+        description: List of updated management IP addresses for network devices.
         type: list
         elements: dict
         suboptions:
@@ -197,7 +218,7 @@ options:
         type: str
         default: "ACCESS"
       role_source:
-        description: role source for the Device.
+        description: Role source for the device.
         type: str
         default: "AUTO"
       name:
@@ -229,6 +250,8 @@ options:
         type: str
       operation_enum:
         description: enum(CREDENTIALDETAILS, DEVICEDETAILS) 0 to export Device Credential Details Or 1 to export Device Details.
+            CREDENTIALDETAILS - Used for exporting device credentials details like snpm credntials, device crdentails etc.
+            DEVICEDETAILS - Used for exporting device specific details like device hostname, serial number, type, family etc.
         type: str
       parameters:
         description: List of device parameters that needs to be exported to file.
@@ -1768,8 +1791,7 @@ class DnacDevice(DnacBase):
                     site_type = item.get("attributes").get("type")
 
         except Exception as e:
-            self.msg = "Error while fetching the site '{0}' and given site not found in Cisco Catalyst Center".format(site_name)
-            self.log(self.msg, "ERROR")
+            self.msg = "Error while fetching the site '{0}' and the specified site was not found in Cisco Catalyst Center.".format(site_name)
             self.module.fail_json(msg=self.msg, response=[self.msg])
 
         return site_type

--- a/plugins/modules/inventory_workflow_manager.py
+++ b/plugins/modules/inventory_workflow_manager.py
@@ -181,6 +181,19 @@ options:
         default: false
       role:
         description: Role of device which can be ACCESS, CORE, DISTRIBUTION, BORDER ROUTER, UNKNOWN.
+            ALL - This role typically represents all devices within the network, regardless of their specific roles or functions.
+            UNKNOWN - This role is assigned to devices whose roles or functions have not been identified or classified within Cisco Catalsyt Center.
+                This could happen if the platform is unable to determine the device's role based on available information.
+            ACCESS - This role typically represents switches or access points that serve as access points for end-user devices to connect to the network.
+                These devices are often located at the edge of the network and provide connectivity to end-user devices.
+            BORDER ROUTER - These are devices that connect different network domains or segments together. They often serve as
+                gateways between different networks, such as connecting an enterprise network to the internet or connecting
+                multiple branch offices.
+            DISTRIBUTION - This role represents function as distribution switches or routers in hierarchical network designs. They aggregate traffic
+                from access switches and route it toward the core of the network or toward other distribution switches.
+            CORE - This role typically represents high-capacity switches or routers that form the backbone of the network. They handle large volumes
+                of traffic and provide connectivity between different parts of network, such as connecting distribution switches or
+                providing interconnection between different network segments.
         type: str
         default: "ACCESS"
       role_source:
@@ -315,7 +328,7 @@ EXAMPLES = r"""
         snmp_username: string
         snmp_version: string
         type: string
-        device_added: true
+        device_added: True
         username: string
 
 - name: Add new Compute device in Inventory with full credentials.Inputs needed for Compute Device
@@ -344,9 +357,9 @@ EXAMPLES = r"""
         snmp_retry:  3
         snmp_timeout: 5
         snmp_username: string
-        compute_device: true
+        compute_device: True
         username: string
-        device_added: true
+        device_added: True
         type: "COMPUTE_DEVICE"
 
 - name: Add new Meraki device in Inventory with full credentials.Inputs needed for Meraki Device.
@@ -363,7 +376,7 @@ EXAMPLES = r"""
     state: merged
     config:
       - http_password: string
-        device_added: true
+        device_added: True
         type: "MERAKI_DASHBOARD"
 
 - name: Add new Firepower Management device in Inventory with full credentials.Input needed to add Device.
@@ -384,7 +397,7 @@ EXAMPLES = r"""
         http_username: string
         http_password: string
         http_port: string
-        device_added: true
+        device_added: True
         type: "FIREPOWER_MANAGEMENT_SYSTEM"
 
 - name: Add new Third Party device in Inventory with full credentials.Input needed to add Device.
@@ -410,7 +423,7 @@ EXAMPLES = r"""
         snmp_retry:  3
         snmp_timeout: 5
         snmp_username: string
-        device_added: true
+        device_added: True
         type: "THIRD_PARTY_DEVICE"
 
 - name: Update device details or credentails in Inventory
@@ -447,8 +460,8 @@ EXAMPLES = r"""
         snmp_username: string
         snmp_version: string
         type: string
-        device_updated: true
-        credential_update: true
+        device_updated: True
+        credential_update: True
         update_mgmt_ipaddresslist:
         - exist_mgmt_ipaddress: string
           new_mgmt_ipaddress: string
@@ -467,10 +480,10 @@ EXAMPLES = r"""
     dnac_log: False
     state: merged
     config:
-      - device_updated: true
+      - device_updated: True
         ip_address:
         - string
-        credential_update: true
+        credential_update: True
         update_mgmt_ipaddresslist:
         - exist_mgmt_ipaddress: string
           new_mgmt_ipaddress: string
@@ -535,7 +548,7 @@ EXAMPLES = r"""
     config:
       - ip_address:
         - string
-        device_updated: true
+        device_updated: True
         update_device_role:
           role: string
           role_source: string
@@ -555,7 +568,7 @@ EXAMPLES = r"""
     config:
       - ip_address:
         - string
-        device_updated: true
+        device_updated: True
         update_interface_details:
           description: str
           admin_status: str
@@ -619,7 +632,7 @@ EXAMPLES = r"""
     config:
       - ip_address:
         - string
-        device_resync: true
+        device_resync: True
         force_sync: false
 
 - name: Reboot AP Devices with IP Addresses
@@ -637,7 +650,7 @@ EXAMPLES = r"""
     config:
       - ip_address:
         - string
-        reboot_device: true
+        reboot_device: True
 
 - name: Delete Provision/Unprovision Devices by IP Address
   cisco.dnac.inventory_workflow_manager:
@@ -1755,9 +1768,9 @@ class Inventory(DnacBase):
                     site_type = item.get("attributes").get("type")
 
         except Exception as e:
-            self.msg = "Error while fetching the site '{0}'.".format(site_name)
+            self.msg = "Error while fetching the site '{0}' and given site not found in Cisco Catalyst Center".format(site_name)
             self.log(self.msg, "ERROR")
-            self.module.fail_json(msg="Site not found", response=[])
+            self.module.fail_json(msg=self.msg, response=[self.msg])
 
         return site_type
 

--- a/plugins/modules/inventory_workflow_manager.py
+++ b/plugins/modules/inventory_workflow_manager.py
@@ -44,28 +44,32 @@ options:
             protocol (either SSH or Telnet) used by the device.
         type: str
       compute_device:
-        description: Compute Device flag.
+        description: Indicates whether a device is a compute device.
         type: bool
+      password:
+        description: Password for accessing the device and for file encryption during device export. Required for
+            adding Network Device. Also needed for file encryption while exporting device in a csv file.
+        type: str
       enable_password:
-        description: Device's enable password.
+        description: Password required for enabling configurations on the device.
         type: str
       extended_discovery_info:
-        description: Device's extended discovery info.
+        description: Additional discovery information for the device.
         type: str
       http_password:
-        description: Device's http password. Required for Adding Compute, Meraki, Firepower Management Devices.
+        description: HTTP password required for adding compute, Meraki, and Firepower Management Devices.
         type: str
       http_port:
-        description: Device's http port number. Required for Adding Compute, Firepower Management Devices.
+        description: HTTP port number required for adding compute and Firepower Management Devices.
         type: str
       http_secure:
-        description: HttpSecure flag.
+        description: Flag indicating HTTP security.
         type: bool
       http_username:
-        description: Device's http username. Required for Adding Compute,Firepower Management Devices.
+        description: HTTP username required for adding compute and Firepower Management Devices.
         type: str
       ip_address:
-        description: Device's ipAddress. Required for Adding/Updating/Deleting/Resyncing Device except Meraki Devices.
+        description: IP address of the device. Required for Adding/Updating/Deleting/Resyncing Device except Meraki Devices.
         elements: str
         type: list
       hostname_list:
@@ -84,53 +88,58 @@ options:
         elements: str
         type: list
       netconf_port:
-        description: Device's netconf port.
+        description: Netconf port number.
         type: str
       username:
-        description: Network Device's username. Required for Adding Network Device.
-        type: str
-      password:
-        description: Device's password. Required for Adding Network Device.
-            Also needed for file encryption while exporting device in a csv file.
+        description: Username for accessing the device. Required for Adding Network Device.
         type: str
       serial_number:
-        description: Device's serial number.
+        description: Serial number of the device.
         type: str
       snmp_auth_passphrase:
-        description: Device's snmp auth passphrase. Required for Adding Network, Compute, Third Party Devices.
+        description: SNMP authentication passphrase required for adding network, compute, and third-party devices.
         type: str
       snmp_auth_protocol:
-        description: Device's snmp Auth Protocol.
+        description: SNMP authentication protocol.
+            SHA (Secure Hash Algorithm) - cryptographic hash function commonly used for data integrity verification and authentication purposes.
+            MD5 (Message Digest Algorithm 5) - cryptographic hash function commonly used for data integrity verification and authentication purposes.
         type: str
         default: "SHA"
       snmp_mode:
-        description: Device's snmp Mode.
+        description: Device's snmp Mode refer to different SNMP (Simple Network Management Protocol) versions and their corresponding security levels.
+            NOAUTHNOPRIV - This mode provides no authentication or encryption for SNMP messages. It means that devices communicating using SNMPv1 do
+                not require any authentication (username/password) or encryption (data confidentiality). This makes it the least secure option.
+            AUTHNOPRIV - This mode provides authentication but no encryption for SNMP messages. Authentication involves validating the source of the
+                SNMP messages using a community string (similar to a password). However, the data transmitted between devices is not encrypted,
+                so it's susceptible to eavesdropping.
+            AUTHPRIV - This mode provides both authentication and encryption for SNMP messages. It offers the highest level of security among the three
+                options. Authentication ensures that the source of the messages is genuine, and encryption ensures that the data exchanged between
+                devices is confidential and cannot be intercepted by unauthorized parties.
         type: str
       snmp_priv_passphrase:
-        description: Device's snmp Private Passphrase. Required for Adding Network, Compute, Third Party Devices.
+        description: SNMP private passphrase required for adding network, compute, and third-party devices.
         type: str
       snmp_priv_protocol:
-        description: Device's snmp Private Protocol. Required for Adding Network, Compute, Third Party Devices.
-            Must be given in playbook if you are updating the device credentails.
+        description: SNMP private protocol required for adding network, compute, and third-party devices.
         type: str
       snmp_ro_community:
-        description: Device's snmp ROCommunity. Required for Adding V2C Devices.
+        description: SNMP Read-Only community required for adding V2C devices.
         type: str
         default: public
       snmp_rw_community:
-        description: Device's snmp RWCommunity. Required for Adding V2C Devices.
+        description: SNMP Read-Write community required for adding V2C devices.
         type: str
         default: private
       snmp_retry:
-        description: Device's snmp Retry.
+        description: SNMP retry count.
         type: int
         default: 3
       snmp_timeout:
-        description: Device's snmp Timeout.
+        description: SNMP timeout duration.
         type: int
         default: 5
       snmp_username:
-        description: Device's snmp Username. Required for Adding Network, Compute, Third Party Devices.
+        description: SNMP username required for adding network, compute, and third-party devices.
         type: str
       snmp_version:
         description: Device's snmp Version.
@@ -138,10 +147,22 @@ options:
         default: "v3"
       type:
         description: Select Device's type from NETWORK_DEVICE, COMPUTE_DEVICE, MERAKI_DASHBOARD, THIRD_PARTY_DEVICE, FIREPOWER_MANAGEMENT_SYSTEM.
+            NETWORK_DEVICE - This refers to traditional networking equipment such as routers, switches, access points, and firewalls. These devices
+                are responsible for routing, switching, and providing connectivity within the network.
+            COMPUTE_DEVICE - These are computing resources such as servers, virtual machines, or containers that are part of the network infrastructure.
+                Cisco DNA Center can integrate with compute devices to provide visibility and management capabilities, ensuring that the network and
+                 compute resources work together seamlessly to support applications and services.
+            MERAKI_DASHBOARD - It is cloud-based platform used to manage Meraki networking devices, including wireless access points, switches, security
+                appliances, and cameras.
+            THIRD_PARTY_DEVICE - This category encompasses devices from vendors other than Cisco or Meraki. Cisco DNA Center is designed to support
+                integration with third-party devices through open standards and APIs. This allows organizations to manage heterogeneous network
+                environments efficiently using Cisco DNA Center's centralized management and automation capabilities.
+            FIREPOWER_MANAGEMENT_SYSTEM - It is a centralized management console used to manage Cisco's Firepower Next-Generation Firewall (NGFW) devices.
+                It provides features such as policy management, threat detection, and advanced security analytics.
         type: str
         default: "NETWORK_DEVICE"
       update_mgmt_ipaddresslist:
-        description: Network Device's update Mgmt IPaddress List.
+        description: List of updated management IP addresses for network devices.
         type: list
         elements: dict
         suboptions:
@@ -197,7 +218,7 @@ options:
         type: str
         default: "ACCESS"
       role_source:
-        description: role source for the Device.
+        description: Role source for the device.
         type: str
         default: "AUTO"
       name:
@@ -229,6 +250,8 @@ options:
         type: str
       operation_enum:
         description: enum(CREDENTIALDETAILS, DEVICEDETAILS) 0 to export Device Credential Details Or 1 to export Device Details.
+            CREDENTIALDETAILS - Used for exporting device credentials details like snpm credntials, device crdentails etc.
+            DEVICEDETAILS - Used for exporting device specific details like device hostname, serial number, type, family etc.
         type: str
       parameters:
         description: List of device parameters that needs to be exported to file.
@@ -1768,7 +1791,7 @@ class Inventory(DnacBase):
                     site_type = item.get("attributes").get("type")
 
         except Exception as e:
-            self.msg = "Error while fetching the site '{0}' and given site not found in Cisco Catalyst Center".format(site_name)
+            self.msg = "Error while fetching the site '{0}' and the specified site was not found in Cisco Catalyst Center.".format(site_name)
             self.log(self.msg, "ERROR")
             self.module.fail_json(msg=self.msg, response=[self.msg])
 

--- a/plugins/modules/swim_intent.py
+++ b/plugins/modules/swim_intent.py
@@ -50,26 +50,26 @@ options:
         type: dict
         suboptions:
           type:
-            description: The source of import, supports remote import or local import.
+            description: Specifies the import source, supporting local file import (local) or remote url import (remote).
             type: str
           local_image_details:
             description: Details of the local path of the image to be imported.
             type: dict
             suboptions:
               file_path:
-                description: Give the file absolute path required while importing image from local.
+                description: Provide the absolute file path needed to import an image from your local system (Eg "/path/to/your/file").
                 type: str
               is_third_party:
-                description: IsThirdParty query parameter. Third party Image check (Optional).
+                description: Query parameter to determine if the image is from a third party (optional).
                 type: bool
               third_party_application_type:
-                description: ThirdPartyApplicationType query parameter. Third Party Application Type (Optional).
+                description: Specify the ThirdPartyApplicationType query parameter to indicate the type of third-party application.(optional)
                 type: str
               third_party_image_family:
-                description: ThirdPartyImageFamily query parameter. Third Party image family (Optional).
+                description: Provide the ThirdPartyImageFamily query parameter to identify the family of the third-party image. (optional)
                 type: str
               third_party_vendor:
-                description: ThirdPartyVendor query parameter (Optional).
+                description: Include the ThirdPartyVendor query parameter to specify the vendor of the third party.
                 type: str
           url_details:
             description: URL details for SWIM import
@@ -81,20 +81,21 @@ options:
                 elements: dict
                 suboptions:
                   application_type:
-                    description: Optional parameter indicating the type of application with permitted values(WLC, LINUX, FILREWALL, WINDOWS,
-                      LOADBALANCER, THIRDPARTY etc) applicable only for third party image types.
+                    description: An optional parameter that specifies the type of application. Allowed values include WLC, LINUX, FIREWALL, WINDOWS,
+                        LOADBALANCER, THIRDPARTY, etc. This is only applicable for third-party image types.
                     type: str
                   image_family:
-                    description: The name of image family applicable only in case of third party images upload (Optional).
+                    description: Represents the name of the image family and is applicable only when uploading third-party images (Optional).
                     type: str
                   source_url:
-                    description: Required parameter for importing swim image via remote url.
+                    description: A mandatory parameter for importing a SWIM image via a remote URL. This parameter is required when using a URL
+                        to import an image.
                     type: str
                   is_third_party:
-                    description: Set the boolean value if image is uploaded from third party (Optional).
+                    description: Flag indicates whether the image is uploaded from a third party (optional).
                     type: bool
                   vendor:
-                    description: Name of vendor applicable only for third party image types (Optional).
+                    description: The name of the vendor, that applies only to third-party image types when importing via URL (Optional).
                     type: str
               schedule_at:
                 description: ScheduleAt query parameter. Epoch Time (The number of milli-seconds since
@@ -114,8 +115,8 @@ options:
             description: SWIM image name which will be tagged or untagged as golden.
             type: str
           device_role:
-            description: Device Role. Permissible Values ALL, UNKNOWN, ACCESS, BORDER ROUTER,
-              DISTRIBUTION and CORE.
+            description: Defines the device role, with permissible values including ALL, UNKNOWN, ACCESS, BORDER ROUTER,
+              DISTRIBUTION, and CORE.
               ALL - This role typically represents all devices within the network, regardless of their specific roles or functions.
               UNKNOWN - This role is assigned to devices whose roles or functions have not been identified or classified within Cisco Catalsyt Center.
                 This could happen if the platform is unable to determine the device's role based on available information.
@@ -149,8 +150,8 @@ options:
         type: dict
         suboptions:
           device_role:
-            description: Device Role. Permissible Values ALL, UNKNOWN, ACCESS, BORDER ROUTER,
-              DISTRIBUTION and CORE.
+            description: Defines the device role, with permissible values including ALL, UNKNOWN, ACCESS, BORDER ROUTER,
+              DISTRIBUTION, and CORE.
               ALL - This role typically represents all devices within the network, regardless of their specific roles or functions.
               UNKNOWN - This role is assigned to devices whose roles or functions have not been identified or classified within Cisco Catalsyt Center.
                 This could happen if the platform is unable to determine the device's role based on available information.
@@ -166,7 +167,7 @@ options:
                 providing interconnection between different network segments.
             type: str
           device_family_name:
-            description: Name of the device family(Switches and Hubs etc.)
+            description: Specify the name of the device family such as Switches and Hubs, etc.
             type: str
           site_name:
             description: Used to get device details associated to this site.
@@ -193,8 +194,8 @@ options:
         type: dict
         suboptions:
           device_role:
-            description: Device Role and  permissible Values are ALL, UNKNOWN, ACCESS, BORDER ROUTER,
-              DISTRIBUTION and CORE.
+            description: Defines the device role, with permissible values including ALL, UNKNOWN, ACCESS, BORDER ROUTER,
+              DISTRIBUTION, and CORE.
               ALL - This role typically represents all devices within the network, regardless of their specific roles or functions.
               UNKNOWN - This role is assigned to devices whose roles or functions have not been identified or classified within Cisco Catalsyt Center.
                 This could happen if the platform is unable to determine the device's role based on available information.
@@ -210,7 +211,7 @@ options:
                 providing interconnection between different network segments.
             type: str
           device_family_name:
-            description: Name of the device family(Switches and Hubs etc.)
+            description: Specify the name of the device family such as Switches and Hubs, etc.
             type: str
           site_name:
             description: Used to get device details associated to this site.
@@ -224,15 +225,15 @@ options:
                 When this mode is selected, the existing image on the device is completely replaced with the new image during the upgrade process.
                 This ensures that the device runs only the new image version after the upgrade is completed.
               bundle - This mode instructs Cisco Catalyst Center bundles the new image with the existing image on the device before initiating
-                the upgrade process.This mode allows for a more efficient upgrade process by preserving the existing image on the device while
-                adding the new image as an additional bundle.After the upgrade, the device can run either the existing image or the new bundled
+                the upgrade process. This mode allows for a more efficient upgrade process by preserving the existing image on the device while
+                adding the new image as an additional bundle. After the upgrade, the device can run either the existing image or the new bundled
                 image, depending on the configuration.
               currentlyExists - This mode instructs Cisco Catalyst Center to checks if the target devices already have the desired image version
                 installed. If image already present on devices, no action is taken and upgrade process is skipped for those devices. This mode
                 is useful for avoiding unnecessary upgrades on devices that already have the correct image version installed, thereby saving time.
             type: str
           distribute_if_needed:
-            description: Set the distribute_if_needed flag while activating the swim image.
+            description: Enable the distribute_if_needed option when activating the SWIM image.
             type: bool
           image_name:
             description: SWIM image's name

--- a/plugins/modules/swim_intent.py
+++ b/plugins/modules/swim_intent.py
@@ -50,26 +50,26 @@ options:
         type: dict
         suboptions:
           type:
-            description: The source of import, supports url import or local import.
+            description: The source of import, supports remote import or local import.
             type: str
           local_image_details:
             description: Details of the local path of the image to be imported.
             type: dict
             suboptions:
               file_path:
-                description: File absolute path.
+                description: Give the file absolute path required while importing image from local.
                 type: str
               is_third_party:
-                description: IsThirdParty query parameter. Third party Image check.
+                description: IsThirdParty query parameter. Third party Image check (Optional).
                 type: bool
               third_party_application_type:
-                description: ThirdPartyApplicationType query parameter. Third Party Application Type.
+                description: ThirdPartyApplicationType query parameter. Third Party Application Type (Optional).
                 type: str
               third_party_image_family:
-                description: ThirdPartyImageFamily query parameter. Third Party image family.
+                description: ThirdPartyImageFamily query parameter. Third Party image family (Optional).
                 type: str
               third_party_vendor:
-                description: ThirdPartyVendor query parameter. Third Party Vendor.
+                description: ThirdPartyVendor query parameter (Optional).
                 type: str
           url_details:
             description: URL details for SWIM import
@@ -81,19 +81,20 @@ options:
                 elements: dict
                 suboptions:
                   application_type:
-                    description: Swim Import Via Url's applicationType.
+                    description: Optional parameter indicating the type of application with permitted values(WLC, LINUX, FILREWALL, WINDOWS,
+                      LOADBALANCER, THIRDPARTY etc) applicable only for third party image types.
                     type: str
                   image_family:
-                    description: Swim Import Via Url's imageFamily.
+                    description: The name of image family applicable only in case of third party images upload (Optional).
                     type: str
                   source_url:
-                    description: Swim Import Image Via Url.
+                    description: Required parameter for importing swim image via remote url.
                     type: str
                   is_third_party:
-                    description: ThirdParty flag.
+                    description: Set the boolean value if image is uploaded from third party (Optional).
                     type: bool
                   vendor:
-                    description: Swim Import Via Url's vendor.
+                    description: Name of vendor applicable only for third party image types (Optional).
                     type: str
               schedule_at:
                 description: ScheduleAt query parameter. Epoch Time (The number of milli-seconds since
@@ -115,12 +116,22 @@ options:
           device_role:
             description: Device Role. Permissible Values ALL, UNKNOWN, ACCESS, BORDER ROUTER,
               DISTRIBUTION and CORE.
+              ALL - This role typically represents all devices within the network, regardless of their specific roles or functions.
+              UNKNOWN - This role is assigned to devices whose roles or functions have not been identified or classified within Cisco Catalsyt Center.
+                This could happen if the platform is unable to determine the device's role based on available information.
+              ACCESS - This role typically represents switches or access points that serve as access points for end-user devices to connect to the network.
+                These devices are often located at the edge of the network and provide connectivity to end-user devices.
+              BORDER ROUTER - These are devices that connect different network domains or segments together. They often serve as
+                gateways between different networks, such as connecting an enterprise network to the internet or connecting
+                multiple branch offices.
+              DISTRIBUTION - This role represents function as distribution switches or routers in hierarchical network designs. They aggregate traffic
+                from access switches and route it toward the core of the network or toward other distribution switches.
+              CORE - This role typically represents high-capacity switches or routers that form the backbone of the network. They handle large volumes
+                of traffic and provide connectivity between different parts of network, such as connecting distribution switches or
+                providing interconnection between different network segments.
             type: str
-          device_family_name:
-            description: Device family name(Eg Switches and Hubs)
-            type: str
-          device_type:
-            description: Type of the device (Eg Cisco Catalyst 9300 Switch)
+          device_image_family_name:
+            description: Device Image family name(Eg Cisco Catalyst 9300 Switch)
             type: str
           site_name:
             description: Site name for which SWIM image will be tagged/untagged as golden.
@@ -140,9 +151,22 @@ options:
           device_role:
             description: Device Role. Permissible Values ALL, UNKNOWN, ACCESS, BORDER ROUTER,
               DISTRIBUTION and CORE.
+              ALL - This role typically represents all devices within the network, regardless of their specific roles or functions.
+              UNKNOWN - This role is assigned to devices whose roles or functions have not been identified or classified within Cisco Catalsyt Center.
+                This could happen if the platform is unable to determine the device's role based on available information.
+              ACCESS - This role typically represents switches or access points that serve as access points for end-user devices to connect to the network.
+                These devices are often located at the edge of the network and provide connectivity to end-user devices.
+              BORDER ROUTER - These are devices that connect different network domains or segments together. They often serve as
+                gateways between different networks, such as connecting an enterprise network to the internet or connecting
+                multiple branch offices.
+              DISTRIBUTION - This role represents function as distribution switches or routers in hierarchical network designs. They aggregate traffic
+                from access switches and route it toward the core of the network or toward other distribution switches.
+              CORE - This role typically represents high-capacity switches or routers that form the backbone of the network. They handle large volumes
+                of traffic and provide connectivity between different parts of network, such as connecting distribution switches or
+                providing interconnection between different network segments.
             type: str
           device_family_name:
-            description: Device family name
+            description: Name of the device family(Switches and Hubs etc.)
             type: str
           site_name:
             description: Used to get device details associated to this site.
@@ -169,11 +193,24 @@ options:
         type: dict
         suboptions:
           device_role:
-            description: Device Role. Permissible Values ALL, UNKNOWN, ACCESS, BORDER ROUTER,
+            description: Device Role and  permissible Values are ALL, UNKNOWN, ACCESS, BORDER ROUTER,
               DISTRIBUTION and CORE.
+              ALL - This role typically represents all devices within the network, regardless of their specific roles or functions.
+              UNKNOWN - This role is assigned to devices whose roles or functions have not been identified or classified within Cisco Catalsyt Center.
+                This could happen if the platform is unable to determine the device's role based on available information.
+              ACCESS - This role typically represents switches or access points that serve as access points for end-user devices to connect to the network.
+                These devices are often located at the edge of the network and provide connectivity to end-user devices.
+              BORDER ROUTER - These are devices that connect different network domains or segments together. They often serve as
+                gateways between different networks, such as connecting an enterprise network to the internet or connecting
+                multiple branch offices.
+              DISTRIBUTION - This role represents function as distribution switches or routers in hierarchical network designs. They aggregate traffic
+                from access switches and route it toward the core of the network or toward other distribution switches.
+              CORE - This role typically represents high-capacity switches or routers that form the backbone of the network. They handle large volumes
+                of traffic and provide connectivity between different parts of network, such as connecting distribution switches or
+                providing interconnection between different network segments.
             type: str
           device_family_name:
-            description: Device family name
+            description: Name of the device family(Switches and Hubs etc.)
             type: str
           site_name:
             description: Used to get device details associated to this site.
@@ -182,10 +219,20 @@ options:
             description: ActivateLowerImageVersion flag.
             type: bool
           device_upgrade_mode:
-            description: Swim Trigger Activation's deviceUpgradeMode.
+            description: It specifies the mode of upgrade to be applied to the devices having the following values - 'install', 'bundle', and 'currentlyExists'.
+              install - This mode instructs Cisco Catalyst Center to perform a clean installation of the new image on the target devices.
+                When this mode is selected, the existing image on the device is completely replaced with the new image during the upgrade process.
+                This ensures that the device runs only the new image version after the upgrade is completed.
+              bundle - This mode instructs Cisco Catalyst Center bundles the new image with the existing image on the device before initiating
+                the upgrade process.This mode allows for a more efficient upgrade process by preserving the existing image on the device while
+                adding the new image as an additional bundle.After the upgrade, the device can run either the existing image or the new bundled
+                image, depending on the configuration.
+              currentlyExists - This mode instructs Cisco Catalyst Center to checks if the target devices already have the desired image version
+                installed. If image already present on devices, no action is taken and upgrade process is skipped for those devices. This mode
+                is useful for avoiding unnecessary upgrades on devices that already have the correct image version installed, thereby saving time.
             type: str
-          distributeIfNeeded:
-            description: DistributeIfNeeded flag.
+          distribute_if_needed:
+            description: Set the distribute_if_needed flag while activating the swim image.
             type: bool
           image_name:
             description: SWIM image's name
@@ -252,7 +299,7 @@ EXAMPLES = r"""
       tagging_details:
         image_name: string
         device_role: string
-        device_family_name: string
+        device_image_family_name: string
         site_name: string
         tagging: bool
       image_distribution_details:
@@ -288,8 +335,7 @@ EXAMPLES = r"""
       tagging_details:
         image_name: string
         device_role: string
-        device_family_name: string
-        device_type: string
+        device_image_family_name: string
         site_name: string
         tagging: bool
 
@@ -308,9 +354,9 @@ EXAMPLES = r"""
     - tagging_details:
         image_name: string
         device_role: string
-        device_type: string
+        device_image_family_name: string
         site_name: string
-        tagging: true
+        tagging: True
 
 - name: Un-tagged the given image as golden and load it on device
   cisco.dnac.swim_intent:
@@ -327,9 +373,9 @@ EXAMPLES = r"""
     - tagging_details:
         image_name: string
         device_role: string
-        device_type: string
+        device_image_family_name: string
         site_name: string
-        tagging: false
+        tagging: False
 
 - name: Distribute the given image on devices associated to that site with specified role.
   cisco.dnac.swim_intent:
@@ -490,8 +536,9 @@ class DnacSwims(DnacBase):
                 params={"name": site_name},
             )
         except Exception as e:
-            self.log("An exception occurred: Site '{0}' does not exist in the Cisco Catalyst Center".format(site_name), "ERROR")
-            self.module.fail_json(msg="Site not found")
+            self.msg = "An exception occurred: Site '{0}' does not exist in the Cisco Catalyst Center".format(site_name)
+            self.log(self.msg, "ERROR")
+            self.module.fail_json(msg=self.msg)
 
         if response:
             self.log("Received API response from 'get_site': {0}".format(str(response)), "DEBUG")
@@ -625,7 +672,8 @@ class DnacSwims(DnacBase):
             device_id = device_list[0].get("id")
             self.log("Device Id: {0}".format(str(device_id)), "INFO")
         else:
-            self.log("Device not found", "WARNING")
+            self.msg = "Device with params: '{0}' not found in Cisco Catalyst Center so can't fetch the device id".format(str(params))
+            self.log(self.msg, "WARNING")
 
         return device_id
 
@@ -707,8 +755,9 @@ class DnacSwims(DnacBase):
                 have["device_family_identifier"] = device_family_identifier
                 self.log("Family device indentifier: {0}".format(str(device_family_identifier)), "INFO")
             else:
-                self.log("Device Family: {0} not found".format(str(family_name)), "ERROR")
-                self.module.fail_json(msg="Family Device Name not found", response=[])
+                self.msg = "Device Family: {0} not found".format(str(family_name))
+                self.log(self.msg, "ERROR")
+                self.module.fail_json(msg=self.msg, response=[self.msg])
             self.have.update(have)
 
     def get_have(self):
@@ -755,7 +804,7 @@ class DnacSwims(DnacBase):
 
             self.have.update(have)
             # check if given device family name exists, store indentifier value
-            family_name = tagging_details.get("device_type")
+            family_name = tagging_details.get("device_image_family_name")
             self.get_device_family_identifier(family_name)
 
         if self.want.get("distribution_details"):
@@ -852,13 +901,13 @@ class DnacSwims(DnacBase):
         if config.get("import_image_details"):
             want["import_image"] = True
             want["import_type"] = config.get("import_image_details").get("type").lower()
-            if want["import_type"] == "url":
+            if want["import_type"] == "remote":
                 want["url_import_details"] = config.get("import_image_details").get("url_details")
             elif want["import_type"] == "local":
                 want["local_import_details"] = config.get("import_image_details").get("local_image_details")
             else:
-                self.log("The import type '{0}' provided is incorrect. Only 'local' or 'url' are supported.".format(want["import_type"]), "CRITICAL")
-                self.module.fail_json(msg="Incorrect import type. Supported Values: local or url")
+                self.log("The import type '{0}' provided is incorrect. Only 'local' or 'remote' are supported.".format(want["import_type"]), "CRITICAL")
+                self.module.fail_json(msg="Incorrect import type. Supported Values: local or remote")
 
         want["tagging_details"] = config.get("tagging_details")
         want["distribution_details"] = config.get("image_distribution_details")
@@ -895,7 +944,7 @@ class DnacSwims(DnacBase):
                 self.result['changed'] = False
                 return self
 
-            if import_type == "url":
+            if import_type == "remote":
                 image_name = self.want.get("url_import_details").get("payload")[0].get("source_url")
             else:
                 image_name = self.want.get("local_import_details").get("file_path")
@@ -921,7 +970,7 @@ class DnacSwims(DnacBase):
                 self.result['changed'] = False
                 return self
 
-            if self.want.get("import_type") == "url":
+            if self.want.get("import_type") == "remote":
                 import_payload_dict = {}
                 temp_payload = self.want.get("url_import_details").get("payload")[0]
                 keys_to_change = list(import_key_mapping.keys())
@@ -1466,7 +1515,7 @@ class DnacSwims(DnacBase):
         Verify the successful import of a software image into Cisco Catalyst Center.
         Args:
             self (object): An instance of a class used for interacting with Cisco Catalyst Center.
-            import_type (str): The type of import, either 'url' or 'local'.
+            import_type (str): The type of import, either 'remote' or 'local'.
         Returns:
             self (object): An instance of a class used for interacting with Cisco Catalyst Center.
         Description:
@@ -1476,7 +1525,7 @@ class DnacSwims(DnacBase):
             If the image does not exist, a warning message is logged indicating a potential import failure.
         """
 
-        if import_type == "url":
+        if import_type == "remote":
             image_name = self.want.get("url_import_details").get("payload")[0].get("source_url")
         else:
             image_name = self.want.get("local_import_details").get("file_path")

--- a/plugins/modules/swim_workflow_manager.py
+++ b/plugins/modules/swim_workflow_manager.py
@@ -50,26 +50,26 @@ options:
         type: dict
         suboptions:
           type:
-            description: The source of import, supports remote import or local import.
+            description: Specifies the import source, supporting local file import (local) or remote url import (remote).
             type: str
           local_image_details:
             description: Details of the local path of the image to be imported.
             type: dict
             suboptions:
               file_path:
-                description: Give the file absolute path required while importing image from local.
+                description: Provide the absolute file path needed to import an image from your local system (Eg "/path/to/your/file").
                 type: str
               is_third_party:
-                description: IsThirdParty query parameter. Third party Image check (Optional).
+                description: Query parameter to determine if the image is from a third party (optional).
                 type: bool
               third_party_application_type:
-                description: ThirdPartyApplicationType query parameter. Third Party Application Type (Optional).
+                description: Specify the ThirdPartyApplicationType query parameter to indicate the type of third-party application.(optional)
                 type: str
               third_party_image_family:
-                description: ThirdPartyImageFamily query parameter. Third Party image family (Optional).
+                description: Provide the ThirdPartyImageFamily query parameter to identify the family of the third-party image. (optional)
                 type: str
               third_party_vendor:
-                description: ThirdPartyVendor query parameter (Optional).
+                description: Include the ThirdPartyVendor query parameter to specify the vendor of the third party.
                 type: str
           url_details:
             description: URL details for SWIM import
@@ -81,20 +81,21 @@ options:
                 elements: dict
                 suboptions:
                   application_type:
-                    description: Optional parameter indicating the type of application with permitted values(WLC, LINUX, FILREWALL, WINDOWS,
-                      LOADBALANCER, THIRDPARTY etc) applicable only for third party image types.
+                    description: An optional parameter that specifies the type of application. Allowed values include WLC, LINUX, FIREWALL, WINDOWS,
+                        LOADBALANCER, THIRDPARTY, etc. This is only applicable for third-party image types.
                     type: str
                   image_family:
-                    description: The name of image family applicable only in case of third party images upload (Optional).
+                    description: Represents the name of the image family and is applicable only when uploading third-party images (Optional).
                     type: str
                   source_url:
-                    description: Required parameter for importing swim image via remote url.
+                    description: A mandatory parameter for importing a SWIM image via a remote URL. This parameter is required when using a URL
+                        to import an image.
                     type: str
                   is_third_party:
-                    description: Set the boolean value if image is uploaded from third party (Optional).
+                    description: Flag indicates whether the image is uploaded from a third party (optional).
                     type: bool
                   vendor:
-                    description: Name of vendor applicable only for third party image types (Optional).
+                    description: The name of the vendor, that applies only to third-party image types when importing via URL (Optional).
                     type: str
               schedule_at:
                 description: ScheduleAt query parameter. Epoch Time (The number of milli-seconds since
@@ -114,8 +115,8 @@ options:
             description: SWIM image name which will be tagged or untagged as golden.
             type: str
           device_role:
-            description: Device Role. Permissible Values ALL, UNKNOWN, ACCESS, BORDER ROUTER,
-              DISTRIBUTION and CORE.
+            description: Defines the device role, with permissible values including ALL, UNKNOWN, ACCESS, BORDER ROUTER,
+              DISTRIBUTION, and CORE.
               ALL - This role typically represents all devices within the network, regardless of their specific roles or functions.
               UNKNOWN - This role is assigned to devices whose roles or functions have not been identified or classified within Cisco Catalsyt Center.
                 This could happen if the platform is unable to determine the device's role based on available information.
@@ -166,7 +167,7 @@ options:
                 providing interconnection between different network segments.
             type: str
           device_family_name:
-            description: Name of the device family(Switches and Hubs etc.)
+            description: Specify the name of the device family such as Switches and Hubs, etc.
             type: str
           site_name:
             description: Used to get device details associated to this site.
@@ -193,11 +194,11 @@ options:
         type: dict
         suboptions:
           device_role:
-            description: Device Role and  permissible Values are ALL, UNKNOWN, ACCESS, BORDER ROUTER,
-              DISTRIBUTION and CORE.
+            description: Defines the device role, with permissible values including ALL, UNKNOWN, ACCESS, BORDER ROUTER,
+              DISTRIBUTION, and CORE.
             type: str
           device_family_name:
-            description: Name of the device family(Switches and Hubs etc.)
+            description: Specify the name of the device family such as Switches and Hubs, etc.
             type: str
           site_name:
             description: Used to get device details associated to this site.
@@ -211,15 +212,15 @@ options:
                 When this mode is selected, the existing image on the device is completely replaced with the new image during the upgrade process.
                 This ensures that the device runs only the new image version after the upgrade is completed.
               bundle - This mode instructs Cisco Catalyst Center bundles the new image with the existing image on the device before initiating
-                the upgrade process.This mode allows for a more efficient upgrade process by preserving the existing image on the device while
-                adding the new image as an additional bundle.After the upgrade, the device can run either the existing image or the new bundled
+                the upgrade process. This mode allows for a more efficient upgrade process by preserving the existing image on the device while
+                adding the new image as an additional bundle. After the upgrade, the device can run either the existing image or the new bundled
                 image, depending on the configuration.
               currentlyExists - This mode instructs Cisco Catalyst Center to checks if the target devices already have the desired image version
                 installed. If image already present on devices, no action is taken and upgrade process is skipped for those devices. This mode
                 is useful for avoiding unnecessary upgrades on devices that already have the correct image version installed, thereby saving time.
             type: str
           distribute_if_needed:
-            description: Set the distribute_if_needed flag while activating the swim image.
+            description: Enable the distribute_if_needed option when activating the SWIM image.
             type: bool
           image_name:
             description: SWIM image's name

--- a/plugins/modules/swim_workflow_manager.py
+++ b/plugins/modules/swim_workflow_manager.py
@@ -50,26 +50,26 @@ options:
         type: dict
         suboptions:
           type:
-            description: The source of import, supports url import or local import.
+            description: The source of import, supports remote import or local import.
             type: str
           local_image_details:
             description: Details of the local path of the image to be imported.
             type: dict
             suboptions:
               file_path:
-                description: File absolute path.
+                description: Give the file absolute path required while importing image from local.
                 type: str
               is_third_party:
-                description: IsThirdParty query parameter. Third party Image check.
+                description: IsThirdParty query parameter. Third party Image check (Optional).
                 type: bool
               third_party_application_type:
-                description: ThirdPartyApplicationType query parameter. Third Party Application Type.
+                description: ThirdPartyApplicationType query parameter. Third Party Application Type (Optional).
                 type: str
               third_party_image_family:
-                description: ThirdPartyImageFamily query parameter. Third Party image family.
+                description: ThirdPartyImageFamily query parameter. Third Party image family (Optional).
                 type: str
               third_party_vendor:
-                description: ThirdPartyVendor query parameter. Third Party Vendor.
+                description: ThirdPartyVendor query parameter (Optional).
                 type: str
           url_details:
             description: URL details for SWIM import
@@ -81,19 +81,20 @@ options:
                 elements: dict
                 suboptions:
                   application_type:
-                    description: Swim Import Via Url's applicationType.
+                    description: Optional parameter indicating the type of application with permitted values(WLC, LINUX, FILREWALL, WINDOWS,
+                      LOADBALANCER, THIRDPARTY etc) applicable only for third party image types.
                     type: str
                   image_family:
-                    description: Swim Import Via Url's imageFamily.
+                    description: The name of image family applicable only in case of third party images upload (Optional).
                     type: str
                   source_url:
-                    description: Swim Import Image Via Url.
+                    description: Required parameter for importing swim image via remote url.
                     type: str
                   is_third_party:
-                    description: ThirdParty flag.
+                    description: Set the boolean value if image is uploaded from third party (Optional).
                     type: bool
                   vendor:
-                    description: Swim Import Via Url's vendor.
+                    description: Name of vendor applicable only for third party image types (Optional).
                     type: str
               schedule_at:
                 description: ScheduleAt query parameter. Epoch Time (The number of milli-seconds since
@@ -115,12 +116,22 @@ options:
           device_role:
             description: Device Role. Permissible Values ALL, UNKNOWN, ACCESS, BORDER ROUTER,
               DISTRIBUTION and CORE.
+              ALL - This role typically represents all devices within the network, regardless of their specific roles or functions.
+              UNKNOWN - This role is assigned to devices whose roles or functions have not been identified or classified within Cisco Catalsyt Center.
+                This could happen if the platform is unable to determine the device's role based on available information.
+              ACCESS - This role typically represents switches or access points that serve as access points for end-user devices to connect to the network.
+                These devices are often located at the edge of the network and provide connectivity to end-user devices.
+              BORDER ROUTER - These are devices that connect different network domains or segments together. They often serve as
+                gateways between different networks, such as connecting an enterprise network to the internet or connecting
+                multiple branch offices.
+              DISTRIBUTION - This role represents function as distribution switches or routers in hierarchical network designs. They aggregate traffic
+                from access switches and route it toward the core of the network or toward other distribution switches.
+              CORE - This role typically represents high-capacity switches or routers that form the backbone of the network. They handle large volumes
+                of traffic and provide connectivity between different parts of network, such as connecting distribution switches or
+                providing interconnection between different network segments.
             type: str
-          device_family_name:
-            description: Device family name(Eg Switches and Hubs)
-            type: str
-          device_type:
-            description: Type of the device (Eg Cisco Catalyst 9300 Switch)
+          device_image_family_name:
+            description: Device Image family name(Eg Cisco Catalyst 9300 Switch)
             type: str
           site_name:
             description: Site name for which SWIM image will be tagged/untagged as golden.
@@ -138,11 +149,24 @@ options:
         type: dict
         suboptions:
           device_role:
-            description: Device Role. Permissible Values ALL, UNKNOWN, ACCESS, BORDER ROUTER,
+            description: Device Role and  permissible Values are ALL, UNKNOWN, ACCESS, BORDER ROUTER,
               DISTRIBUTION and CORE.
+              ALL - This role typically represents all devices within the network, regardless of their specific roles or functions.
+              UNKNOWN - This role is assigned to devices whose roles or functions have not been identified or classified within Cisco Catalsyt Center.
+                This could happen if the platform is unable to determine the device's role based on available information.
+              ACCESS - This role typically represents switches or access points that serve as access points for end-user devices to connect to the network.
+                These devices are often located at the edge of the network and provide connectivity to end-user devices.
+              BORDER ROUTER - These are devices that connect different network domains or segments together. They often serve as
+                gateways between different networks, such as connecting an enterprise network to the internet or connecting
+                multiple branch offices.
+              DISTRIBUTION - This role represents function as distribution switches or routers in hierarchical network designs. They aggregate traffic
+                from access switches and route it toward the core of the network or toward other distribution switches.
+              CORE - This role typically represents high-capacity switches or routers that form the backbone of the network. They handle large volumes
+                of traffic and provide connectivity between different parts of network, such as connecting distribution switches or
+                providing interconnection between different network segments.
             type: str
           device_family_name:
-            description: Device family name
+            description: Name of the device family(Switches and Hubs etc.)
             type: str
           site_name:
             description: Used to get device details associated to this site.
@@ -169,11 +193,11 @@ options:
         type: dict
         suboptions:
           device_role:
-            description: Device Role. Permissible Values ALL, UNKNOWN, ACCESS, BORDER ROUTER,
+            description: Device Role and  permissible Values are ALL, UNKNOWN, ACCESS, BORDER ROUTER,
               DISTRIBUTION and CORE.
             type: str
           device_family_name:
-            description: Device family name
+            description: Name of the device family(Switches and Hubs etc.)
             type: str
           site_name:
             description: Used to get device details associated to this site.
@@ -182,10 +206,20 @@ options:
             description: ActivateLowerImageVersion flag.
             type: bool
           device_upgrade_mode:
-            description: Swim Trigger Activation's deviceUpgradeMode.
+            description: It specifies the mode of upgrade to be applied to the devices having the following values - 'install', 'bundle', and 'currentlyExists'.
+              install - This mode instructs Cisco Catalyst Center to perform a clean installation of the new image on the target devices.
+                When this mode is selected, the existing image on the device is completely replaced with the new image during the upgrade process.
+                This ensures that the device runs only the new image version after the upgrade is completed.
+              bundle - This mode instructs Cisco Catalyst Center bundles the new image with the existing image on the device before initiating
+                the upgrade process.This mode allows for a more efficient upgrade process by preserving the existing image on the device while
+                adding the new image as an additional bundle.After the upgrade, the device can run either the existing image or the new bundled
+                image, depending on the configuration.
+              currentlyExists - This mode instructs Cisco Catalyst Center to checks if the target devices already have the desired image version
+                installed. If image already present on devices, no action is taken and upgrade process is skipped for those devices. This mode
+                is useful for avoiding unnecessary upgrades on devices that already have the correct image version installed, thereby saving time.
             type: str
-          distributeIfNeeded:
-            description: DistributeIfNeeded flag.
+          distribute_if_needed:
+            description: Set the distribute_if_needed flag while activating the swim image.
             type: bool
           image_name:
             description: SWIM image's name
@@ -252,7 +286,7 @@ EXAMPLES = r"""
       tagging_details:
         image_name: string
         device_role: string
-        device_family_name: string
+        device_image_family_name: string
         site_name: string
         tagging: bool
       image_distribution_details:
@@ -288,8 +322,7 @@ EXAMPLES = r"""
       tagging_details:
         image_name: string
         device_role: string
-        device_family_name: string
-        device_type: string
+        device_image_family_name: string
         site_name: string
         tagging: bool
 
@@ -308,9 +341,9 @@ EXAMPLES = r"""
     - tagging_details:
         image_name: string
         device_role: string
-        device_type: string
+        device_image_family_name: string
         site_name: string
-        tagging: true
+        tagging: True
 
 - name: Un-tagged the given image as golden and load it on device
   cisco.dnac.swim_workflow_manager:
@@ -327,9 +360,9 @@ EXAMPLES = r"""
     - tagging_details:
         image_name: string
         device_role: string
-        device_type: string
+        device_image_family_name: string
         site_name: string
-        tagging: false
+        tagging: False
 
 - name: Distribute the given image on devices associated to that site with specified role.
   cisco.dnac.swim_workflow_manager:
@@ -489,8 +522,9 @@ class Swim(DnacBase):
                 params={"name": site_name},
             )
         except Exception as e:
-            self.log("An exception occurred: Site '{0}' does not exist in the Cisco Catalyst Center".format(site_name), "ERROR")
-            self.module.fail_json(msg="Site not found")
+            self.msg = "An exception occurred: Site '{0}' does not exist in the Cisco Catalyst Center".format(site_name)
+            self.log(self.msg, "ERROR")
+            self.module.fail_json(msg=self.msg)
 
         if response:
             self.log("Received API response from 'get_site': {0}".format(str(response)), "DEBUG")
@@ -624,7 +658,8 @@ class Swim(DnacBase):
             device_id = device_list[0].get("id")
             self.log("Device Id: {0}".format(str(device_id)), "INFO")
         else:
-            self.log("Device not found", "WARNING")
+            self.msg = "Device with params: '{0}' not found in Cisco Catalyst Center so can't fetch the device id".format(str(params))
+            self.log(self.msg, "WARNING")
 
         return device_id
 
@@ -706,8 +741,9 @@ class Swim(DnacBase):
                 have["device_family_identifier"] = device_family_identifier
                 self.log("Family device indentifier: {0}".format(str(device_family_identifier)), "INFO")
             else:
-                self.log("Device Family: {0} not found".format(str(family_name)), "ERROR")
-                self.module.fail_json(msg="Family Device Name not found", response=[])
+                self.msg = "Device Family: {0} not found".format(str(family_name))
+                self.log(self.msg, "ERROR")
+                self.module.fail_json(msg=self.msg, response=self.msg)
             self.have.update(have)
 
     def get_have(self):
@@ -754,7 +790,7 @@ class Swim(DnacBase):
 
             self.have.update(have)
             # check if given device family name exists, store indentifier value
-            family_name = tagging_details.get("device_type")
+            family_name = tagging_details.get("device_image_family_name")
             self.get_device_family_identifier(family_name)
 
         if self.want.get("distribution_details"):
@@ -851,13 +887,13 @@ class Swim(DnacBase):
         if config.get("import_image_details"):
             want["import_image"] = True
             want["import_type"] = config.get("import_image_details").get("type").lower()
-            if want["import_type"] == "url":
+            if want["import_type"] == "remote":
                 want["url_import_details"] = config.get("import_image_details").get("url_details")
             elif want["import_type"] == "local":
                 want["local_import_details"] = config.get("import_image_details").get("local_image_details")
             else:
-                self.log("The import type '{0}' provided is incorrect. Only 'local' or 'url' are supported.".format(want["import_type"]), "CRITICAL")
-                self.module.fail_json(msg="Incorrect import type. Supported Values: local or url")
+                self.log("The import type '{0}' provided is incorrect. Only 'local' or 'remote' are supported.".format(want["import_type"]), "CRITICAL")
+                self.module.fail_json(msg="Incorrect import type. Supported Values: local or remote")
 
         want["tagging_details"] = config.get("tagging_details")
         want["distribution_details"] = config.get("image_distribution_details")
@@ -894,7 +930,7 @@ class Swim(DnacBase):
                 self.result['changed'] = False
                 return self
 
-            if import_type == "url":
+            if import_type == "remote":
                 image_name = self.want.get("url_import_details").get("payload")[0].get("source_url")
             else:
                 image_name = self.want.get("local_import_details").get("file_path")
@@ -920,7 +956,7 @@ class Swim(DnacBase):
                 self.result['changed'] = False
                 return self
 
-            if self.want.get("import_type") == "url":
+            if self.want.get("import_type") == "remote":
                 import_payload_dict = {}
                 temp_payload = self.want.get("url_import_details").get("payload")[0]
                 keys_to_change = list(import_key_mapping.keys())
@@ -1465,7 +1501,7 @@ class Swim(DnacBase):
         Verify the successful import of a software image into Cisco Catalyst Center.
         Args:
             self (object): An instance of a class used for interacting with Cisco Catalyst Center.
-            import_type (str): The type of import, either 'url' or 'local'.
+            import_type (str): The type of import, either 'remote' or 'local'.
         Returns:
             self (object): An instance of a class used for interacting with Cisco Catalyst Center.
         Description:
@@ -1475,7 +1511,7 @@ class Swim(DnacBase):
             If the image does not exist, a warning message is logged indicating a potential import failure.
         """
 
-        if import_type == "url":
+        if import_type == "remote":
             image_name = self.want.get("url_import_details").get("payload")[0].get("source_url")
         else:
             image_name = self.want.get("local_import_details").get("file_path")
@@ -1553,7 +1589,6 @@ class Swim(DnacBase):
         Verify the distribution status of a software image in Cisco Catalyst Center.
         Args:
             self (object): An instance of a class used for interacting with Cisco Catalyst Center.
-            import_type (str): The type of import, either 'url' or 'local'.
         Returns:
             self (object): An instance of a class used for interacting with Cisco Catalyst Center.
         Description:


### PR DESCRIPTION
…device_image_family_name, add brief description for enum or choices for parameter, changed boolean value from true/false to True/False in all modules.

In this commit -
 
 
-- Remove device_type from the swim_workflow_module and swim_intent and add device_image_family_name attribute for tagging/un-tagging the image as golden in order to avoid confusion.
 
-- For other swim operation only device family is needed which is like "Switches and Hubs" and add the same examples in documentation as well.
 
-- Improve the error log messages for like Site/Device not found in swim workflow module.
 
-- For each parameter in documentation having the choices like device_upgrade_mode( 'install', 'bundle' and 'currentlyExists' ) elaborate these terms in detail for customer ease etc. for other parameter as well.
 
-- For importing the image in Cisco Catalyst Center, two options get changes to remote/local from url/local.
 
-- Updated all the changes in both intent modules and workflow_manager module and updated the respective playbooks as well.

-- Changes all boolean value in modules and inventory workflow playbook from true/false to True/False.

