### PR TITLE
Adding fix for SWIM upgrade in PnP

### DIFF
--- a/plugins/modules/pnp_intent.py
+++ b/plugins/modules/pnp_intent.py
@@ -664,7 +664,7 @@ class PnP(DnacBase):
                     self.log("Site Exists: {0}\nSite Name: {1}\nSite ID: {2}".format(site_exists, site_name, site_id), "INFO")
                     if self.want.get("pnp_type") == "AccessPoint":
                         if self.get_site_type() != "floor":
-                            self.msg =  "Please ensure that the site type is specified as 'floor' when claiming an AP."\
+                            self.msg = "Please ensure that the site type is specified as 'floor' when claiming an AP."\
                                 " The site type is given as '{0}'. Please change the 'site_type' into 'floor' to "\
                                 "proceed.".format(self.get_site_type())
                             self.log(str(self.msg), "ERROR")

--- a/plugins/modules/pnp_intent.py
+++ b/plugins/modules/pnp_intent.py
@@ -693,7 +693,7 @@ class PnP(DnacBase):
                     if template_name:
                         if not (template_list and isinstance(template_list, list)):
                             self.msg = "Either project not found"\
-                                " or it is Empty".
+                                " or it is Empty."
                             self.log(self.msg, "CRITICAL")
                             self.status = "failed"
                             return self

--- a/plugins/modules/pnp_intent.py
+++ b/plugins/modules/pnp_intent.py
@@ -665,7 +665,7 @@ class PnP(DnacBase):
                     if self.want.get("pnp_type") == "AccessPoint":
                         if self.get_site_type() != "floor":
                             self.msg =  "Please ensure that the site type is specified as 'floor' when claiming an AP."\
-                                "The site type is given as '{0}'. Please change the 'site_type' into 'floor' to"\
+                                " The site type is given as '{0}'. Please change the 'site_type' into 'floor' to "\
                                 "proceed.".format(self.get_site_type())
                             self.log(str(self.msg), "ERROR")
                             self.status = "failed"

--- a/plugins/modules/pnp_intent.py
+++ b/plugins/modules/pnp_intent.py
@@ -519,11 +519,11 @@ class PnP(DnacBase):
             if not (self.validated_config[0].get('ip_interface_name')):
                 msg = "Please provide the Interface Name to claim a wireless controller. This information is necessary"\
                     " for making it a logical interface post claiming which can used to help manage the Wireless SSIDs "\
-                    "broadcasted by the access points, manage the controller, access point and user data, plus more"
+                    "broadcasted by the access points, manage the controller, access point and user data, plus more."
                 self.pnp_cred_failure(msg=msg)
             if not (self.validated_config[0].get('vlan_id')):
                 msg = "Please provide the Vlan ID to claim a wireless controller. This is a required field for the process"\
-                    " to create and set the specified port as trunk during PnP"
+                    " to create and set the specified port as trunk during PnP."
                 self.pnp_cred_failure(msg=msg)
             claim_params["staticIP"] = self.validated_config[0]['static_ip']
             claim_params["subnetMask"] = self.validated_config[0]['subnet_mask']
@@ -679,7 +679,7 @@ class PnP(DnacBase):
                     if len(image_list) == 1:
                         if install_mode != "INSTALL":
                             self.msg = "The system must be in INSTALL mode to upgrade the image. The current mode is '{0}'."\
-                                " Please switch to INSTALL mode to proceed".format(install_mode)
+                                " Please switch to INSTALL mode to proceed.".format(install_mode)
                             self.log(str(self.msg), "CRITICAL")
                             self.status = "failed"
                             return self
@@ -691,7 +691,7 @@ class PnP(DnacBase):
                     if template_name:
                         if not (template_list and isinstance(template_list, list)):
                             self.msg = "Either project not found" \
-                                "or it is Empty"
+                                "or it is Empty".
                             self.log(self.msg, "CRITICAL")
                             self.status = "failed"
                             return self
@@ -707,7 +707,7 @@ class PnP(DnacBase):
 
                 else:
                     if not self.want.get('pnp_params')[0].get('deviceInfo'):
-                        self.msg = "Either Site Name or Device details must be added"
+                        self.msg = "Either Site Name or Device details must be added."
                         self.log(self.msg, "ERROR")
                         self.status = "failed"
                         return self

--- a/plugins/modules/pnp_intent.py
+++ b/plugins/modules/pnp_intent.py
@@ -507,19 +507,23 @@ class PnP(DnacBase):
 
         if claim_params["type"] == "CatalystWLC":
             if not (self.validated_config[0].get('static_ip')):
-                msg = "The static IP for claiming a wireless controller must be passed"
+                msg = "A static IP address is required to claim a wireless controller. Please provide one."
                 self.pnp_cred_failure(msg=msg)
             if not (self.validated_config[0].get('subnet_mask')):
-                msg = "The subnet mask for claiming a wireless controller must be passed"
+                msg = "Please provide a subnet mask to claim a wireless controller. "\
+                    "This information is mandatory for the configuration."
                 self.pnp_cred_failure(msg=msg)
             if not (self.validated_config[0].get('gateway')):
-                msg = "The gateway IP for claiming a wireless controller must be of passed"
+                msg = "A gateway IP is required to claim a wireless controller. Please ensure to provide it."
                 self.pnp_cred_failure(msg=msg)
             if not (self.validated_config[0].get('ip_interface_name')):
-                msg = "The Interface Name for claiming a wireless controller must be passed"
+                msg = "Please provide the Interface Name to claim a wireless controller. This information is necessary"\
+                    " for making it a logical interface post claiming which can used to help manage the Wireless SSIDs "\
+                    "broadcasted by the access points, manage the controller, access point and user data, plus more"
                 self.pnp_cred_failure(msg=msg)
             if not (self.validated_config[0].get('vlan_id')):
-                msg = "The Vlan Id for claiming a wireless controller must be passed"
+                msg = "Please provide the Vlan ID to claim a wireless controller. This is a required field for the process"\
+                    " to create and set the specified port as trunk during PnP"
                 self.pnp_cred_failure(msg=msg)
             claim_params["staticIP"] = self.validated_config[0]['static_ip']
             claim_params["subnetMask"] = self.validated_config[0]['subnet_mask']
@@ -666,15 +670,16 @@ class PnP(DnacBase):
                             return self
 
                     if len(image_list) == 0:
-                        self.msg = "Either Image {0} is not present or is not tagged Golden"\
-                            " in Cisco Catalyst Center".format(self.validated_config[0].get("image_name"))
+                        self.msg = "The image '{0}' is either not present or not tagged as 'Golden' in the Cisco Catalyst Center."\
+                            " Please verify its existence and its tag status.".format(self.validated_config[0].get("image_name"))
                         self.log(self.msg, "CRITICAL")
                         self.status = "failed"
                         return self
 
                     if len(image_list) == 1:
                         if install_mode != "INSTALL":
-                            self.msg = "Installation mode must be in INSTALL mode to upgrade the image. Current mode is {0}".format(install_mode)
+                            self.msg = "The system must be in INSTALL mode to upgrade the image. The current mode is '{0}'."\
+                                " Please switch to INSTALL mode to proceed".format(install_mode)
                             self.log(str(self.msg), "CRITICAL")
                             self.status = "failed"
                             return self
@@ -685,8 +690,8 @@ class PnP(DnacBase):
                     template_name = self.want.get("template_name")
                     if template_name:
                         if not (template_list and isinstance(template_list, list)):
-                            self.msg = "Either project not found \
-                                or it is Empty"
+                            self.msg = "Either project not found" \
+                                "or it is Empty"
                             self.log(self.msg, "CRITICAL")
                             self.status = "failed"
                             return self

--- a/plugins/modules/pnp_intent.py
+++ b/plugins/modules/pnp_intent.py
@@ -664,7 +664,9 @@ class PnP(DnacBase):
                     self.log("Site Exists: {0}\nSite Name: {1}\nSite ID: {2}".format(site_exists, site_name, site_id), "INFO")
                     if self.want.get("pnp_type") == "AccessPoint":
                         if self.get_site_type() != "floor":
-                            self.msg = "The site type must be specified as 'floor' for claiming an AP"
+                            self.msg =  "Please ensure that the site type is specified as 'floor' when claiming an AP."\
+                                "The site type is given as '{0}'. Please change the 'site_type' into 'floor' to"\
+                                "proceed.".format(self.get_site_type())
                             self.log(str(self.msg), "ERROR")
                             self.status = "failed"
                             return self
@@ -690,8 +692,8 @@ class PnP(DnacBase):
                     template_name = self.want.get("template_name")
                     if template_name:
                         if not (template_list and isinstance(template_list, list)):
-                            self.msg = "Either project not found" \
-                                "or it is Empty".
+                            self.msg = "Either project not found"\
+                                " or it is Empty".
                             self.log(self.msg, "CRITICAL")
                             self.status = "failed"
                             return self

--- a/plugins/modules/pnp_workflow_manager.py
+++ b/plugins/modules/pnp_workflow_manager.py
@@ -664,7 +664,7 @@ class PnP(DnacBase):
                     self.log("Site Exists: {0}\nSite Name: {1}\nSite ID: {2}".format(site_exists, site_name, site_id), "INFO")
                     if self.want.get("pnp_type") == "AccessPoint":
                         if self.get_site_type() != "floor":
-                            self.msg =  "Please ensure that the site type is specified as 'floor' when claiming an AP."\
+                            self.msg = "Please ensure that the site type is specified as 'floor' when claiming an AP."\
                                 " The site type is given as '{0}'. Please change the 'site_type' into 'floor' to "\
                                 "proceed.".format(self.get_site_type())
                             self.log(str(self.msg), "ERROR")

--- a/plugins/modules/pnp_workflow_manager.py
+++ b/plugins/modules/pnp_workflow_manager.py
@@ -693,7 +693,7 @@ class PnP(DnacBase):
                     if template_name:
                         if not (template_list and isinstance(template_list, list)):
                             self.msg = "Either project not found"\
-                                " or it is Empty".
+                                " or it is Empty."
                             self.log(self.msg, "CRITICAL")
                             self.status = "failed"
                             return self

--- a/plugins/modules/pnp_workflow_manager.py
+++ b/plugins/modules/pnp_workflow_manager.py
@@ -665,7 +665,7 @@ class PnP(DnacBase):
                     if self.want.get("pnp_type") == "AccessPoint":
                         if self.get_site_type() != "floor":
                             self.msg =  "Please ensure that the site type is specified as 'floor' when claiming an AP."\
-                                "The site type is given as '{0}'. Please change the 'site_type' into 'floor' to"\
+                                " The site type is given as '{0}'. Please change the 'site_type' into 'floor' to "\
                                 "proceed.".format(self.get_site_type())
                             self.log(str(self.msg), "ERROR")
                             self.status = "failed"

--- a/plugins/modules/pnp_workflow_manager.py
+++ b/plugins/modules/pnp_workflow_manager.py
@@ -519,11 +519,11 @@ class PnP(DnacBase):
             if not (self.validated_config[0].get('ip_interface_name')):
                 msg = "Please provide the Interface Name to claim a wireless controller. This information is necessary"\
                     " for making it a logical interface post claiming which can used to help manage the Wireless SSIDs "\
-                    "broadcasted by the access points, manage the controller, access point and user data, plus more"
+                    "broadcasted by the access points, manage the controller, access point and user data, plus more."
                 self.pnp_cred_failure(msg=msg)
             if not (self.validated_config[0].get('vlan_id')):
                 msg = "Please provide the Vlan ID to claim a wireless controller. This is a required field for the process"\
-                    " to create and set the specified port as trunk during PnP"
+                    " to create and set the specified port as trunk during PnP."
                 self.pnp_cred_failure(msg=msg)
             claim_params["staticIP"] = self.validated_config[0]['static_ip']
             claim_params["subnetMask"] = self.validated_config[0]['subnet_mask']
@@ -679,7 +679,7 @@ class PnP(DnacBase):
                     if len(image_list) == 1:
                         if install_mode != "INSTALL":
                             self.msg = "The system must be in INSTALL mode to upgrade the image. The current mode is '{0}'."\
-                                " Please switch to INSTALL mode to proceed".format(install_mode)
+                                " Please switch to INSTALL mode to proceed.".format(install_mode)
                             self.log(str(self.msg), "CRITICAL")
                             self.status = "failed"
                             return self
@@ -691,7 +691,7 @@ class PnP(DnacBase):
                     if template_name:
                         if not (template_list and isinstance(template_list, list)):
                             self.msg = "Either project not found" \
-                                "or it is Empty"
+                                "or it is Empty".
                             self.log(self.msg, "CRITICAL")
                             self.status = "failed"
                             return self
@@ -707,7 +707,7 @@ class PnP(DnacBase):
 
                 else:
                     if not self.want.get('pnp_params')[0].get('deviceInfo'):
-                        self.msg = "Either Site Name or Device details must be added"
+                        self.msg = "Either Site Name or Device details must be added."
                         self.log(self.msg, "ERROR")
                         self.status = "failed"
                         return self

--- a/plugins/modules/pnp_workflow_manager.py
+++ b/plugins/modules/pnp_workflow_manager.py
@@ -507,19 +507,23 @@ class PnP(DnacBase):
 
         if claim_params["type"] == "CatalystWLC":
             if not (self.validated_config[0].get('static_ip')):
-                msg = "The static IP for claiming a wireless controller must be passed"
+                msg = "A static IP address is required to claim a wireless controller. Please provide one."
                 self.pnp_cred_failure(msg=msg)
             if not (self.validated_config[0].get('subnet_mask')):
-                msg = "The subnet mask for claiming a wireless controller must be passed"
+                msg = "Please provide a subnet mask to claim a wireless controller. "\
+                    "This information is mandatory for the configuration."
                 self.pnp_cred_failure(msg=msg)
             if not (self.validated_config[0].get('gateway')):
-                msg = "The gateway IP for claiming a wireless controller must be of passed"
+                msg = "A gateway IP is required to claim a wireless controller. Please ensure to provide it."
                 self.pnp_cred_failure(msg=msg)
             if not (self.validated_config[0].get('ip_interface_name')):
-                msg = "The Interface Name for claiming a wireless controller must be passed"
+                msg = "Please provide the Interface Name to claim a wireless controller. This information is necessary"\
+                    " for making it a logical interface post claiming which can used to help manage the Wireless SSIDs "\
+                    "broadcasted by the access points, manage the controller, access point and user data, plus more"
                 self.pnp_cred_failure(msg=msg)
             if not (self.validated_config[0].get('vlan_id')):
-                msg = "The Vlan Id for claiming a wireless controller must be passed"
+                msg = "Please provide the Vlan ID to claim a wireless controller. This is a required field for the process"\
+                    " to create and set the specified port as trunk during PnP"
                 self.pnp_cred_failure(msg=msg)
             claim_params["staticIP"] = self.validated_config[0]['static_ip']
             claim_params["subnetMask"] = self.validated_config[0]['subnet_mask']
@@ -666,15 +670,16 @@ class PnP(DnacBase):
                             return self
 
                     if len(image_list) == 0:
-                        self.msg = "Either Image {0} is not present or is not tagged Golden"\
-                            " in Cisco Catalyst Center".format(self.validated_config[0].get("image_name"))
+                        self.msg = "The image '{0}' is either not present or not tagged as 'Golden' in the Cisco Catalyst Center."\
+                            " Please verify its existence and its tag status.".format(self.validated_config[0].get("image_name"))
                         self.log(self.msg, "CRITICAL")
                         self.status = "failed"
                         return self
 
                     if len(image_list) == 1:
                         if install_mode != "INSTALL":
-                            self.msg = "Installation mode must be in INSTALL mode to upgrade the image. Current mode is {0}".format(install_mode)
+                            self.msg = "The system must be in INSTALL mode to upgrade the image. The current mode is '{0}'."\
+                                " Please switch to INSTALL mode to proceed".format(install_mode)
                             self.log(str(self.msg), "CRITICAL")
                             self.status = "failed"
                             return self
@@ -685,8 +690,8 @@ class PnP(DnacBase):
                     template_name = self.want.get("template_name")
                     if template_name:
                         if not (template_list and isinstance(template_list, list)):
-                            self.msg = "Either project not found \
-                                or it is Empty"
+                            self.msg = "Either project not found" \
+                                "or it is Empty"
                             self.log(self.msg, "CRITICAL")
                             self.status = "failed"
                             return self

--- a/plugins/modules/pnp_workflow_manager.py
+++ b/plugins/modules/pnp_workflow_manager.py
@@ -664,7 +664,9 @@ class PnP(DnacBase):
                     self.log("Site Exists: {0}\nSite Name: {1}\nSite ID: {2}".format(site_exists, site_name, site_id), "INFO")
                     if self.want.get("pnp_type") == "AccessPoint":
                         if self.get_site_type() != "floor":
-                            self.msg = "The site type must be specified as 'floor' for claiming an AP"
+                            self.msg =  "Please ensure that the site type is specified as 'floor' when claiming an AP."\
+                                "The site type is given as '{0}'. Please change the 'site_type' into 'floor' to"\
+                                "proceed.".format(self.get_site_type())
                             self.log(str(self.msg), "ERROR")
                             self.status = "failed"
                             return self
@@ -690,8 +692,8 @@ class PnP(DnacBase):
                     template_name = self.want.get("template_name")
                     if template_name:
                         if not (template_list and isinstance(template_list, list)):
-                            self.msg = "Either project not found" \
-                                "or it is Empty".
+                            self.msg = "Either project not found"\
+                                " or it is Empty".
                             self.log(self.msg, "CRITICAL")
                             self.status = "failed"
                             return self


### PR DESCRIPTION
Problem: If Image is absent in the Cisco Catalyst Center, no error is thrown.
Fix: Have added a check for the length of image_list we fetch from the API get all software details. If the length is 0, it will throw a message showing that either image is absent or is not golden tagged, making the user aware of the possible issues.
Test cases: 1. With Cisco Catalyst 9800 WLC with wrong image name (Failed)
                    2.  With Cisco Catalyst 9800 WLC with correct image name but not golden tagged (Failed)
                    3. With Cisco Catalyst 9800 WLC with correct image name and golden tagged (Passed)
