### PR TITLE
Handle edge case while adding device with snmpVersion v2

### DIFF
--- a/plugins/modules/inventory_intent.py
+++ b/plugins/modules/inventory_intent.py
@@ -2998,6 +2998,12 @@ class DnacDevice(DnacBase):
                 params_to_remove = ["snmpAuthPassphrase", "snmpAuthProtocol", "snmpMode", "snmpPrivPassphrase", "snmpPrivProtocol", "snmpUserName"]
                 for param in params_to_remove:
                     device_params.pop(param, None)
+
+                if not device_params['snmpROCommunity']:
+                    self.status = "failed"
+                    self.msg = "Required parameter 'snmpROCommunity' for adding device with snmmp version v2 is not present"
+                    self.result['msg'] = self.msg
+                    self.log(self.msg, "ERROR")
             else:
                 if not device_params['snmpMode']:
                     device_params['snmpMode'] = "AUTHPRIV"

--- a/plugins/modules/inventory_workflow_manager.py
+++ b/plugins/modules/inventory_workflow_manager.py
@@ -2991,6 +2991,12 @@ class Inventory(DnacBase):
                 params_to_remove = ["snmpAuthPassphrase", "snmpAuthProtocol", "snmpMode", "snmpPrivPassphrase", "snmpPrivProtocol", "snmpUserName"]
                 for param in params_to_remove:
                     device_params.pop(param, None)
+
+                if not device_params['snmpROCommunity']:
+                    self.status = "failed"
+                    self.msg = "Required parameter 'snmpROCommunity' for adding device with snmmp version v2 is not present"
+                    self.result['msg'] = self.msg
+                    self.log(self.msg, "ERROR")
             else:
                 if not device_params['snmpMode']:
                     device_params['snmpMode'] = "AUTHPRIV"


### PR DESCRIPTION
In this commit -

-- Handle one case while adding the device in inventory with snmpVersion v2, the snmpROCommunity must be required parameter.