### PR TITLE
Adding option to specify global credentials while performing discovery

### DIFF
--- a/playbooks/discovery_intent.yml
+++ b/playbooks/discovery_intent.yml
@@ -20,6 +20,76 @@
       dnac_log_level: DEBUG
 
   tasks:
+
+    - name: Execute discovery devices using MULTI RANGE with various global credentials
+      cisco.dnac.discovery_intent:
+        <<: *dnac_login
+        state: merged
+        config_verify: True
+        config:
+          - ip_address_list:
+            - 204.1.2.1-204.1.2.5
+            - 204.192.3.40
+            - 204.192.4.200
+            - 204.1.2.6
+            - 204.1.2.7
+            - 204.1.2.8
+            - 204.1.2.9
+            - 204.1.2.10
+            - 204.1.2.11
+            discovery_type: MULTI RANGE
+            protocol_order: ssh
+            state: merged
+            discovery_name: Multi_global
+            global_credentials:
+              cli_credentials_list:
+                - description: ISE
+                  username: cisco
+                - description: CLI1234 #Incorrect name passed
+                  username: cli
+              http_read_credential_list:
+                - description: HTTP Read
+                  username: HTTP_Read
+              snmp_v3_credential_list:
+                - description: snmpV3
+                  username: snmpV3
+
+    - name: Execute discovery of single device using various discovery specific credentials
+      cisco.dnac.discovery_intent:
+        <<: *dnac_login
+        state: merged
+        config_verify: True
+        config:
+          - discovery_name: Single IP Discovery
+            discovery_type: "SINGLE"
+            ip_address_list:
+              - 204.1.2.5
+            protocol_order: ssh
+            discovery_specific_credentials:
+              cli_credentials_list:
+              - username: cisco
+                password: Cisco#123
+                enable_password: Cisco#123
+              http_read_credential:
+                username: string
+                password: Lablab#123
+                port: 443
+                secure: True
+              snmp_v2_read_credential:
+                desc: string
+                community: string
+                snmp_v2_write_credential:
+                desc: string
+                community: string
+              snmp_v3_credential:
+                username: v3Public2
+                snmp_mode: AUTHPRIV
+                auth_type: SHA
+                auth_password: Lablab#1234
+                privacy_type: AES256
+                privacy_password: Lablab#1234
+                global_cli_len: 3
+
     - name: Execute discovery devices using MULTI RANGE with various discovery specific credentials
       cisco.dnac.discovery_intent:
         <<: *dnac_login
@@ -68,7 +138,7 @@
           - ip_address_list:   #List length should be one
               - 204.1.2.1
             discovery_type: "CDP" #Can be LLDP and CIDR
-            cdp_level: 16 #Instead use lldp for LLDP and prefix length for CIDR
+            cdp_level: 2 #Instead use lldp for LLDP and prefix length for CIDR
             discovery_name: CDP_Test_1
             discovery_specific_credentials:
               cli_credentials_list:

--- a/playbooks/discovery_intent.yml
+++ b/playbooks/discovery_intent.yml
@@ -27,7 +27,9 @@
         state: merged
         config_verify: True
         config:
-          - ip_address_list:
+          - discovery_name: Multi_global
+            discovery_type: MULTI RANGE
+            ip_address_list:
             - 204.1.2.1-204.1.2.5
             - 204.192.3.40
             - 204.192.4.200
@@ -37,10 +39,6 @@
             - 204.1.2.9
             - 204.1.2.10
             - 204.1.2.11
-            discovery_type: MULTI RANGE
-            protocol_order: ssh
-            state: merged
-            discovery_name: Multi_global
             global_credentials:
               cli_credentials_list:
                 - description: ISE
@@ -53,6 +51,7 @@
               snmp_v3_credential_list:
                 - description: snmpV3
                   username: snmpV3
+            protocol_order: ssh
 
     - name: Execute discovery of single device using various discovery specific credentials
       cisco.dnac.discovery_intent:
@@ -64,7 +63,6 @@
             discovery_type: "SINGLE"
             ip_address_list:
               - 204.1.2.5
-            protocol_order: ssh
             discovery_specific_credentials:
               cli_credentials_list:
               - username: cisco
@@ -89,6 +87,7 @@
                 privacy_type: AES256
                 privacy_password: Lablab#1234
                 global_cli_len: 3
+            protocol_order: ssh
 
     - name: Execute discovery devices using MULTI RANGE with various discovery specific credentials
       cisco.dnac.discovery_intent:
@@ -96,7 +95,9 @@
         state: merged
         config_verify: True
         config:
-          - ip_address_list:
+          - discovery_type: "MULTI RANGE"
+            discovery_name: Multi_range
+            ip_address_list:
               - 204.1.2.1-204.1.2.100 #It will be taken as 204.1.2.1 - 204.1.2.1
               - 205.2.1.1-205.2.1.10
             ip_filter_list:
@@ -121,13 +122,10 @@
                 auth_type: SHA
                 privacy_type: AES192
                 privacy_password: cisco#123
-            discovery_type: "MULTI RANGE"
-            discovery_name: Multi_range
             protocol_order: ssh
             start_index: 1
             records_to_return: 1000
             snmp_version: v2
-            global_cli_len: 5
 
     - name: Execute discovery devices using CDP/LLDP/CIDR
       cisco.dnac.discovery_intent:
@@ -135,17 +133,25 @@
         state: merged
         config_verify: True
         config:
-          - ip_address_list:   #List length should be one
-              - 204.1.2.1
+          - discovery_name: CDP_Test_1
             discovery_type: "CDP" #Can be LLDP and CIDR
-            cdp_level: 2 #Instead use lldp for LLDP and prefix length for CIDR
-            discovery_name: CDP_Test_1
+            ip_address_list:   #List length should be one
+              - 204.1.2.1
+            cdp_level: 2 #Instead use lldp_level for LLDP and prefix length for CIDR
             discovery_specific_credentials:
               cli_credentials_list:
                 - username: admin
                   password: maglev123
                   enable_password: maglev123
             protocol_order: ssh
+
+    - name: Execute deletion of single discovery from the dashboard
+      cisco.dnac.discovery_intent:
+        <<: *dnac_login
+        state: deleted
+        config_verify: True
+        config:
+          - discovery_name: CDP_Test_1
 
     - name: Execute deletion of all the discoveries from the dashboard
       cisco.dnac.discovery_intent:

--- a/playbooks/discovery_intent.yml
+++ b/playbooks/discovery_intent.yml
@@ -78,7 +78,7 @@
               snmp_v2_read_credential:
                 desc: string
                 community: string
-                snmp_v2_write_credential:
+              snmp_v2_write_credential:
                 desc: string
                 community: string
               snmp_v3_credential:

--- a/playbooks/discovery_workflow_manager.yml
+++ b/playbooks/discovery_workflow_manager.yml
@@ -27,7 +27,9 @@
         state: merged
         config_verify: True
         config:
-          - ip_address_list:
+          - discovery_name: Multi_global
+            discovery_type: MULTI RANGE
+            ip_address_list:
             - 204.1.2.1-204.1.2.5
             - 204.192.3.40
             - 204.192.4.200
@@ -37,10 +39,6 @@
             - 204.1.2.9
             - 204.1.2.10
             - 204.1.2.11
-            discovery_type: MULTI RANGE
-            protocol_order: ssh
-            state: merged
-            discovery_name: Multi_global
             global_credentials:
               cli_credentials_list:
                 - description: ISE
@@ -53,6 +51,7 @@
               snmp_v3_credential_list:
                 - description: snmpV3
                   username: snmpV3
+            protocol_order: ssh
 
     - name: Execute discovery of single device using various discovery specific credentials
       cisco.dnac.discovery_workflow_manager:
@@ -64,7 +63,6 @@
             discovery_type: "SINGLE"
             ip_address_list:
               - 204.1.2.5
-            protocol_order: ssh
             discovery_specific_credentials:
               cli_credentials_list:
               - username: cisco
@@ -89,6 +87,7 @@
                 privacy_type: AES256
                 privacy_password: Lablab#1234
                 global_cli_len: 3
+            protocol_order: ssh
 
     - name: Execute discovery devices using MULTI RANGE with various discovery specific credentials
       cisco.dnac.discovery_workflow_manager:
@@ -96,7 +95,9 @@
         state: merged
         config_verify: True
         config:
-          - ip_address_list:
+          - discovery_type: "MULTI RANGE"
+            discovery_name: Multi_range
+            ip_address_list:
               - 204.1.2.1-204.1.2.100 #It will be taken as 204.1.2.1 - 204.1.2.1
               - 205.2.1.1-205.2.1.10
             ip_filter_list:
@@ -121,13 +122,10 @@
                 auth_type: SHA
                 privacy_type: AES192
                 privacy_password: cisco#123
-            discovery_type: "MULTI RANGE"
-            discovery_name: Multi_range
             protocol_order: ssh
             start_index: 1
             records_to_return: 1000
             snmp_version: v2
-            global_cli_len: 5
 
     - name: Execute discovery devices using CDP/LLDP/CIDR
       cisco.dnac.discovery_workflow_manager:
@@ -135,17 +133,25 @@
         state: merged
         config_verify: True
         config:
-          - ip_address_list:   #List length should be one
-              - 204.1.2.1
+          - discovery_name: CDP_Test_1
             discovery_type: "CDP" #Can be LLDP and CIDR
-            cdp_level: 2 #Instead use lldp for LLDP and prefix length for CIDR
-            discovery_name: CDP_Test_1
+            ip_address_list:   #List length should be one
+              - 204.1.2.1
+            cdp_level: 2 #Instead use lldp_level for LLDP and prefix length for CIDR
             discovery_specific_credentials:
               cli_credentials_list:
                 - username: admin
                   password: maglev123
                   enable_password: maglev123
             protocol_order: ssh
+
+    - name: Execute deletion of single discovery from the dashboard
+      cisco.dnac.discovery_workflow_manager:
+        <<: *dnac_login
+        state: deleted
+        config_verify: True
+        config:
+          - discovery_name: CDP_Test_1
 
     - name: Execute deletion of all the discoveries from the dashboard
       cisco.dnac.discovery_workflow_manager:

--- a/playbooks/discovery_workflow_manager.yml
+++ b/playbooks/discovery_workflow_manager.yml
@@ -78,7 +78,7 @@
               snmp_v2_read_credential:
                 desc: string
                 community: string
-                snmp_v2_write_credential:
+              snmp_v2_write_credential:
                 desc: string
                 community: string
               snmp_v3_credential:

--- a/playbooks/discovery_workflow_manager.yml
+++ b/playbooks/discovery_workflow_manager.yml
@@ -20,6 +20,76 @@
       dnac_log_level: DEBUG
 
   tasks:
+
+    - name: Execute discovery devices using MULTI RANGE with various global credentials
+      cisco.dnac.discovery_workflow_manager:
+        <<: *dnac_login
+        state: merged
+        config_verify: True
+        config:
+          - ip_address_list:
+            - 204.1.2.1-204.1.2.5
+            - 204.192.3.40
+            - 204.192.4.200
+            - 204.1.2.6
+            - 204.1.2.7
+            - 204.1.2.8
+            - 204.1.2.9
+            - 204.1.2.10
+            - 204.1.2.11
+            discovery_type: MULTI RANGE
+            protocol_order: ssh
+            state: merged
+            discovery_name: Multi_global
+            global_credentials:
+              cli_credentials_list:
+                - description: ISE
+                  username: cisco
+                - description: CLI1234 #Incorrect name passed
+                  username: cli
+              http_read_credential_list:
+                - description: HTTP Read
+                  username: HTTP_Read
+              snmp_v3_credential_list:
+                - description: snmpV3
+                  username: snmpV3
+
+    - name: Execute discovery of single device using various discovery specific credentials
+      cisco.dnac.discovery_workflow_manager:
+        <<: *dnac_login
+        state: merged
+        config_verify: True
+        config:
+          - discovery_name: Single IP Discovery
+            discovery_type: "SINGLE"
+            ip_address_list:
+              - 204.1.2.5
+            protocol_order: ssh
+            discovery_specific_credentials:
+              cli_credentials_list:
+              - username: cisco
+                password: Cisco#123
+                enable_password: Cisco#123
+              http_read_credential:
+                username: string
+                password: Lablab#123
+                port: 443
+                secure: True
+              snmp_v2_read_credential:
+                desc: string
+                community: string
+                snmp_v2_write_credential:
+                desc: string
+                community: string
+              snmp_v3_credential:
+                username: v3Public2
+                snmp_mode: AUTHPRIV
+                auth_type: SHA
+                auth_password: Lablab#1234
+                privacy_type: AES256
+                privacy_password: Lablab#1234
+                global_cli_len: 3
+
     - name: Execute discovery devices using MULTI RANGE with various discovery specific credentials
       cisco.dnac.discovery_workflow_manager:
         <<: *dnac_login
@@ -68,7 +138,7 @@
           - ip_address_list:   #List length should be one
               - 204.1.2.1
             discovery_type: "CDP" #Can be LLDP and CIDR
-            cdp_level: 16 #Instead use lldp for LLDP and prefix length for CIDR
+            cdp_level: 2 #Instead use lldp for LLDP and prefix length for CIDR
             discovery_name: CDP_Test_1
             discovery_specific_credentials:
               cli_credentials_list:

--- a/plugins/modules/discovery_intent.py
+++ b/plugins/modules/discovery_intent.py
@@ -206,29 +206,29 @@ options:
                 type: str
       global_credentials:
         description:
-            - Credentials that are already created by the user under Device Credentials in Cisco Catalyst Center.
+            - Set of various credential types, including CLI, SNMP, HTTP, and NETCONF, that a user has pre-configured in
+                the Device Credentials section of the Cisco Catalyst Center.
             - If user doesn't pass any global credentials in the playbook, then by default, we will use all the global
                 credentials present in the Cisco Catalyst Center of each type for performing discovery. (Max 5 allowed)
         type: dict
         suboptions:
             cli_credentials_list:
                 description:
-                    - List of Global CLI credentials to be used during device discovery.
-                    - Generally it is advised to create device credentials with unique username or description.
+                   - Accepts a list of global CLI credentials for use in device discovery.
+                   - It's recommended to create device credentials with both a unique username and a clear description.
                 type: list
                 elements: dict
                 suboptions:
                     username:
-                        description: Username for CLI authentication, mandatory when using global CLI credentials.
+                        description: Username required for CLI authentication and is mandatory when using global CLI credentials.
                         type: str
                     description:
                         description: Name of the CLI credential, mandatory when using global CLI credentials.
                         type: str
             http_read_credential_list:
                 description:
-                    - List of Global HTTP Read credentials to be used during device discovery.
-                    - Generally it is advised to create device credentials with unique username or description.
-                type: list
+                    - List of global HTTP Read credentials that will be used in the process of discovering devices.
+                    - It's recommended to create device credentials with both a unique username and a clear description for easy identification.
                 elements: dict
                 suboptions:
                     username:
@@ -239,8 +239,8 @@ options:
                         type: str
             http_write_credential_list:
                 description:
-                    - List of Global HTTP Write credentials to be used during device discovery.
-                    - Generally it is advised to create device credentials with unique username or description.
+                    - List of global HTTP Write credentials that will be used in the process of discovering devices.
+                    - It's recommended to create device credentials with both a unique username and a clear description for easy identification.
                 type: list
                 elements: dict
                 suboptions:
@@ -253,7 +253,7 @@ options:
             snmp_v2_read_credential_list:
                 description:
                     - List of Global SNMP V2 Read credentials to be used during device discovery.
-                    - Generally it is advised to create device credentials with unique username or description.
+                    - It's recommended to create device credentials with both a unique username and a clear description for easy identification.
                 type: list
                 elements: dict
                 suboptions:
@@ -266,7 +266,7 @@ options:
             snmp_v2_write_credential_list:
                 description:
                     - List of Global SNMP V2 Write credentials to be used during device discovery.
-                    - Generally it is advised to create device credentials with unique username or description.
+                    - It's recommended to create device credentials with both a unique username and a clear description for easy identification.
                 type: list
                 elements: dict
                 suboptions:
@@ -279,7 +279,7 @@ options:
             snmp_v3_credential_list:
                 description:
                     - List of Global SNMP V3 credentials to be used during device discovery, giving read and write mode.
-                    - Generally it is advised to create device credentials with unique username or description.
+                    - It's recommended to create device credentials with both a unique username and a clear description for easy identification.
                 type: list
                 elements: dict
                 suboptions:
@@ -292,7 +292,7 @@ options:
             net_conf_port_list:
                 description:
                     - List of Global Net conf ports to be used during device discovery.
-                    - Generally it is advised to create device credentials with unique description.
+                    - It's recommended to create device credentials with unique description.
                 type: list
                 elements: dict
                 suboptions:
@@ -555,8 +555,7 @@ class Discovery(DnacBase):
             'retry': {'type': 'int', 'required': False},
             'timeout': {'type': 'str', 'required': False},
             'global_credentials': {'type': 'dict', 'required': False},
-            'protocol_order': {'type': 'str', 'required': False,
-                                'default': 'ssh'}
+            'protocol_order': {'type': 'str', 'required': False, 'default': 'ssh'}
         }
 
         if state == "merged":
@@ -615,17 +614,12 @@ class Discovery(DnacBase):
         """
 
         global_credentials = self.validated_config[0].get("global_credentials")
-        cli_credentials_list = global_credentials.get('cli_credentials_list')
-        http_read_credential_list = global_credentials.get('http_read_credential_list')
-        http_write_credential_list = global_credentials.get('http_write_credential_list')
-        snmp_v2_read_credential_list = global_credentials.get('snmp_v2_read_credential_list')
-        snmp_v2_write_credential_list = global_credentials.get('snmp_v2_write_credential_list')
-        snmp_v3_credential_list = global_credentials.get('snmp_v3_credential_list')
-        net_conf_port_list = global_credentials.get('net_conf_port_list')
         global_credentails_all = {}
+
+        cli_credentials_list = global_credentials.get('cli_credentials_list')
         if cli_credentials_list:
             if not isinstance(cli_credentials_list, list):
-                msg = "Global ClI credentials must be passed as a list"
+                msg = "Global CLI credentials must be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(cli_credentials_list) > 0:
                 global_credentails_all["cliCredential"] = []
@@ -642,6 +636,7 @@ class Discovery(DnacBase):
                         msg = "Kindly ensure you include both the description and the username for the Global CLI credential to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
 
+        http_read_credential_list = global_credentials.get('http_read_credential_list')
         if http_read_credential_list:
             if not isinstance(http_read_credential_list, list):
                 msg = "Global HTTP read credentials must be passed as a list"
@@ -661,6 +656,7 @@ class Discovery(DnacBase):
                         msg = "Kindly ensure you include both the description and the username for the Global HTTP Read credential to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
 
+        http_write_credential_list = global_credentials.get('http_write_credential_list')
         if http_write_credential_list:
             if not isinstance(http_write_credential_list, list):
                 msg = "Global HTTP write credentials must be passed as a list"
@@ -680,6 +676,7 @@ class Discovery(DnacBase):
                         msg = "Kindly ensure you include both the description and the username for the Global HTTP Write credential to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
 
+        snmp_v2_read_credential_list = global_credentials.get('snmp_v2_read_credential_list')
         if snmp_v2_read_credential_list:
             if not isinstance(snmp_v2_read_credential_list, list):
                 msg = "Global SNMPV2 read credentials must be passed as a list"
@@ -700,6 +697,27 @@ class Discovery(DnacBase):
                                 credential to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
 
+        snmp_v2_write_credential_list = global_credentials.get('snmp_v2_write_credential_list')
+        if snmp_v2_write_credential_list:
+            if not isinstance(snmp_v2_write_credential_list, list):
+                msg = "Global SNMPV2 write credentials must be passed as a list"
+                self.discovery_specific_cred_failure(msg=msg)
+            if len(snmp_v2_write_credential_list) > 0:
+                global_credentails_all["snmpV2cWrite"] = []
+                cred_len = len(snmp_v2_write_credential_list)
+                if cred_len > 5:
+                    cred_len = 5
+                for snmp_cred in snmp_v2_write_credential_list:
+                    if snmp_cred.get('description'):
+                        for snmp in response.get("snmpV2cWrite"):
+                            if snmp.get("description") == snmp_cred.get('description'):
+                                global_credentails_all["snmpV2cWrite"].append(snmp.get("id"))
+                        global_credentails_all["snmpV2cWrite"] = global_credentails_all["snmpV2cWrite"][:cred_len]
+                    else:
+                        msg = "Kindly ensure you include both the description and the username for the Global SNMPV2 credential to discover the devices"
+                        self.discovery_specific_cred_failure(msg=msg)
+
+        snmp_v3_credential_list = global_credentials.get('snmp_v3_credential_list')
         if snmp_v3_credential_list:
             if not isinstance(snmp_v3_credential_list, list):
                 msg = "Global SNMPV3 write credentials must be passed as a list"
@@ -720,25 +738,7 @@ class Discovery(DnacBase):
                                 to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
 
-        if snmp_v2_write_credential_list:
-            if not isinstance(snmp_v2_write_credential_list, list):
-                msg = "Global SNMPV2 write credentials must be passed as a list"
-                self.discovery_specific_cred_failure(msg=msg)
-            if len(snmp_v2_write_credential_list) > 0:
-                global_credentails_all["snmpV2cWrite"] = []
-                cred_len = len(snmp_v2_write_credential_list)
-                if cred_len > 5:
-                    cred_len = 5
-                for snmp_cred in snmp_v2_write_credential_list:
-                    if snmp_cred.get('description'):
-                        for snmp in response.get("snmpV2cWrite"):
-                            if snmp.get("description") == snmp_cred.get('description'):
-                                global_credentails_all["snmpV2cWrite"].append(snmp.get("id"))
-                        global_credentails_all["snmpV2cWrite"] = global_credentails_all["snmpV2cWrite"][:cred_len]
-                    else:
-                        msg = "Kindly ensure you include both the description and the username for the Global SNMPV2 credential to discover the devices"
-                        self.discovery_specific_cred_failure(msg=msg)
-
+        net_conf_port_list = global_credentials.get('net_conf_port_list')
         if net_conf_port_list:
             if not isinstance(net_conf_port_list, list):
                 msg = "Global net Conf Ports be passed as a list"

--- a/plugins/modules/discovery_intent.py
+++ b/plugins/modules/discovery_intent.py
@@ -39,14 +39,9 @@ options:
     elements: dict
     required: true
     suboptions:
-      ip_address_list:
-        description: List of IP addresses to be discovered. For CDP/LLDP/SINGLE based discovery, we should
-            pass a list with single element like - 10.197.156.22. For CIDR based discovery, we should pass a list with
-            single element like - 10.197.156.22/22. For RANGE based discovery, we should pass a list with single element
-            and range like - 10.197.156.1-10.197.156.100. For MULTI RANGE based discovery, we should pass a list with multiple
-            elementd like - 10.197.156.1-10.197.156.100 and in next line - 10.197.157.1-10.197.157.100.
-        type: list
-        elements: str
+      discovery_name:
+        description: Name of the discovery task
+        type: str
         required: true
       discovery_type:
         description: Determines the method of device discovery. Here are the available options.
@@ -59,6 +54,19 @@ options:
         type: str
         required: true
         choices: [ 'SINGLE', 'RANGE', 'MULTI RANGE', 'CDP', 'LLDP', 'CIDR']
+      ip_address_list:
+        description: List of IP addresses to be discovered. For CDP/LLDP/SINGLE based discovery, we should
+            pass a list with single element like - 10.197.156.22. For CIDR based discovery, we should pass a list with
+            single element like - 10.197.156.22/22. For RANGE based discovery, we should pass a list with single element
+            and range like - 10.197.156.1-10.197.156.100. For MULTI RANGE based discovery, we should pass a list with multiple
+            elementd like - 10.197.156.1-10.197.156.100 and in next line - 10.197.157.1-10.197.157.100.
+        type: list
+        elements: str
+        required: true
+      ip_filter_list:
+        description: List of IP adddrsess that needs to get filtered out from the IP addresses passed.
+        type: list
+        elements: str
       cdp_level:
         description: Total number of levels that are there in cdp's method of discovery
         type: int
@@ -67,14 +75,10 @@ options:
         description: Total number of levels that are there in lldp's method of discovery
         type: int
         default: 16
-      start_index:
-        description: Start index for the header in fetching SNMP v2 credentials
-        type: int
-        default: 1
-      records_to_return:
-        description: Number of records to return for the header in fetching global v2 credentials
-        type: int
-        default: 100
+      preferred_mgmt_ip_method:
+        description: Preferred method for the management of the IP (None/UseLoopBack)
+        type: str
+        default: None
       discovery_specific_credentials:
         description: Credentials specifically created by the user for performing device discovery.
         type: dict
@@ -203,8 +207,8 @@ options:
       global_credentials:
         description:
             - Credentials that are already created by the user under Device Credentials in Cisco Catalyst Center.
-            - If user doesn't pass any global credentials in the playbook.
-            - By default we will use all the global credentials present in the Cisco Catalyst Center of each type for performing discovery. (Max 5 allowed)
+            - If user doesn't pass any global credentials in the playbook, then by default, we will use all the global
+                credentials present in the Cisco Catalyst Center of each type for performing discovery. (Max 5 allowed)
         type: dict
         suboptions:
             cli_credentials_list:
@@ -295,24 +299,20 @@ options:
                     description:
                         description: Name of the Net Conf Port credential, mandatory when using global Net conf port.
                         type: str
-      ip_filter_list:
-        description: List of IP adddrsess that needs to get filtered out from the IP addresses passed.
-        type: list
-        elements: str
-      discovery_name:
-        description: Name of the discovery task
-        type: str
-        required: true
-      preferred_mgmt_ip_method:
-        description: Preferred method for the management of the IP (None/UseLoopBack)
-        type: str
-        default: None
+      start_index:
+        description: Start index for the header in fetching SNMP v2 credentials
+        type: int
+        default: 1
+      records_to_return:
+        description: Number of records to return for the header in fetching global v2 credentials
+        type: int
+        default: 100
       protocol_order:
         description: Determines the order in which device connections will be attempted. Here are the options
             - "telnet" Only telnet connections will be tried.
             - "ssh, telnet" SSH (Secure Shell) will be attempted first, followed by telnet if SSH fails.
         type: str
-        required: true
+        default: ssh
       retry:
         description: Number of times to try establishing connection to device
         type: int
@@ -364,19 +364,13 @@ EXAMPLES = r"""
     state: merged
     config_verify: True
     config:
-        - ip_address_list: list
+        - discovery_name: string
           discovery_type: string
+          ip_address_list: list
+          ip_filter_list: list
           cdp_level: string
           lldp_level: string
-          start_index: integer
-          records_to_return: integer
-          ip_filter_list: list
-          discovery_name: string
-          password_list: list
           prefered_mgmt_ip_method: string
-          protocol_order: string
-          retry: integer
-          timeout: integer
           discovery_specific_credentials:
             cli_credentials_list:
                 - username: string
@@ -427,6 +421,11 @@ EXAMPLES = r"""
                   username: string
             net_conf_port_list:
                 - description: string
+          start_index: integer
+          records_to_return: integer
+          protocol_order: string
+          retry: integer
+          timeout: integer
 
 - name: Delete disovery by name
   cisco.dnac.discovery_intent:
@@ -555,14 +554,15 @@ class Discovery(DnacBase):
                                          'default': 'None'},
             'retry': {'type': 'int', 'required': False},
             'timeout': {'type': 'str', 'required': False},
-            'global_credentials': {'type': 'dict', 'required': False}
+            'global_credentials': {'type': 'dict', 'required': False},
+            'protocol_order': {'type': 'str', 'required': False,
+                                'default': 'ssh'}
         }
 
         if state == "merged":
             discovery_spec["ip_address_list"] = {'type': 'list', 'required': True,
                                                  'elements': 'str'}
             discovery_spec["discovery_type"] = {'type': 'str', 'required': True}
-            discovery_spec["protocol_order"] = {'type': 'str', 'required': True}
 
         elif state == "deleted":
             if self.config[0].get("delete_all") is True:
@@ -610,7 +610,7 @@ class Discovery(DnacBase):
             - response: The response collected from the get_all_global_credentials_v2 API
 
         Returns:
-            - global_cred_dict  : The dictionary containing list of IDs of various types of
+            - global_credentails_all  : The dictionary containing list of IDs of various types of
                                     Global credentials.
         """
 
@@ -622,13 +622,13 @@ class Discovery(DnacBase):
         snmp_v2_write_credential_list = global_credentials.get('snmp_v2_write_credential_list')
         snmp_v3_credential_list = global_credentials.get('snmp_v3_credential_list')
         net_conf_port_list = global_credentials.get('net_conf_port_list')
-        global_cred_dict = {}
+        global_credentails_all = {}
         if cli_credentials_list:
             if not isinstance(cli_credentials_list, list):
                 msg = "Global ClI credentials must be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(cli_credentials_list) > 0:
-                global_cred_dict["cliCredential"] = []
+                global_credentails_all["cliCredential"] = []
                 cred_len = len(cli_credentials_list)
                 if cred_len > 5:
                     cred_len = 5
@@ -636,10 +636,10 @@ class Discovery(DnacBase):
                     if cli_cred.get('description') and cli_cred.get('username'):
                         for cli in response.get("cliCredential"):
                             if cli.get("description") == cli_cred.get('description') and cli.get("username") == cli_cred.get('username'):
-                                global_cred_dict["cliCredential"].append(cli.get("id"))
-                        global_cred_dict["cliCredential"] = global_cred_dict["cliCredential"][:cred_len]
+                                global_credentails_all["cliCredential"].append(cli.get("id"))
+                        global_credentails_all["cliCredential"] = global_credentails_all["cliCredential"][:cred_len]
                     else:
-                        msg = "Please provide description and username of the Global CLI credential to be used"
+                        msg = "Kindly ensure you include both the description and the username for the Global CLI credential to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
 
         if http_read_credential_list:
@@ -647,7 +647,7 @@ class Discovery(DnacBase):
                 msg = "Global HTTP read credentials must be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(http_read_credential_list) > 0:
-                global_cred_dict["httpsRead"] = []
+                global_credentails_all["httpsRead"] = []
                 cred_len = len(http_read_credential_list)
                 if cred_len > 5:
                     cred_len = 5
@@ -655,10 +655,10 @@ class Discovery(DnacBase):
                     if http_cred.get('description') and http_cred.get('username'):
                         for http in response.get("httpsRead"):
                             if http.get("description") == http.get('description') and http.get("username") == http.get('username'):
-                                global_cred_dict["httpsRead"].append(http.get("id"))
-                        global_cred_dict["httpsRead"] = global_cred_dict["httpsRead"][:cred_len]
+                                global_credentails_all["httpsRead"].append(http.get("id"))
+                        global_credentails_all["httpsRead"] = global_credentails_all["httpsRead"][:cred_len]
                     else:
-                        msg = "Please provide description and username of the Global HTTP read credential to be used"
+                        msg = "Kindly ensure you include both the description and the username for the Global HTTP Read credential to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
 
         if http_write_credential_list:
@@ -666,7 +666,7 @@ class Discovery(DnacBase):
                 msg = "Global HTTP write credentials must be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(http_write_credential_list) > 0:
-                global_cred_dict["httpsWrite"] = []
+                global_credentails_all["httpsWrite"] = []
                 cred_len = len(http_write_credential_list)
                 if cred_len > 5:
                     cred_len = 5
@@ -674,10 +674,10 @@ class Discovery(DnacBase):
                     if http_cred.get('description') and http_cred.get('username'):
                         for http in response.get("httpsWrite"):
                             if http.get("description") == http.get('description') and http.get("username") == http.get('username'):
-                                global_cred_dict["httpsWrite"].append(http.get("id"))
-                        global_cred_dict["httpsWrite"] = global_cred_dict["httpsWrite"][:cred_len]
+                                global_credentails_all["httpsWrite"].append(http.get("id"))
+                        global_credentails_all["httpsWrite"] = global_credentails_all["httpsWrite"][:cred_len]
                     else:
-                        msg = "Please provide description and username of the Global HTTP write credential to be used"
+                        msg = "Kindly ensure you include both the description and the username for the Global HTTP Write credential to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
 
         if snmp_v2_read_credential_list:
@@ -685,7 +685,7 @@ class Discovery(DnacBase):
                 msg = "Global SNMPV2 read credentials must be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(snmp_v2_read_credential_list) > 0:
-                global_cred_dict["snmpV2cRead"] = []
+                global_credentails_all["snmpV2cRead"] = []
                 cred_len = len(snmp_v2_read_credential_list)
                 if cred_len > 5:
                     cred_len = 5
@@ -693,10 +693,11 @@ class Discovery(DnacBase):
                     if snmp_cred.get('description'):
                         for snmp in response.get("snmpV2cRead"):
                             if snmp.get("description") == snmp_cred.get('description'):
-                                global_cred_dict["snmpV2cRead"].append(snmp.get("id"))
-                        global_cred_dict["snmpV2cRead"] = global_cred_dict["snmpV2cRead"][:cred_len]
+                                global_credentails_all["snmpV2cRead"].append(snmp.get("id"))
+                        global_credentails_all["snmpV2cRead"] = global_credentails_all["snmpV2cRead"][:cred_len]
                     else:
-                        msg = "Please provide description of the Global SNMPV2 read credential to be used"
+                        msg = "Kindly ensure you include both the description and the username for the Global SNMPV2 Read \
+                                credential to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
 
         if snmp_v3_credential_list:
@@ -704,7 +705,7 @@ class Discovery(DnacBase):
                 msg = "Global SNMPV3 write credentials must be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(snmp_v3_credential_list) > 0:
-                global_cred_dict["snmpV3"] = []
+                global_credentails_all["snmpV3"] = []
                 cred_len = len(snmp_v3_credential_list)
                 if cred_len > 5:
                     cred_len = 5
@@ -712,10 +713,11 @@ class Discovery(DnacBase):
                     if snmp_cred.get('description') and snmp_cred.get('username'):
                         for snmp in response.get("snmpV3"):
                             if snmp.get("description") == snmp_cred.get('description') and snmp.get("username") == snmp_cred.get('username'):
-                                global_cred_dict["snmpV3"].append(snmp.get("id"))
-                        global_cred_dict["snmpV3"] = global_cred_dict["snmpV3"][:cred_len]
+                                global_credentails_all["snmpV3"].append(snmp.get("id"))
+                        global_credentails_all["snmpV3"] = global_credentails_all["snmpV3"][:cred_len]
                     else:
-                        msg = "Please provide description and username of the Global SNMPV3 credential to be used"
+                        msg = "Kindly ensure you include both the description and the username for the Global SNMPV3 \
+                                to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
 
         if snmp_v2_write_credential_list:
@@ -723,7 +725,7 @@ class Discovery(DnacBase):
                 msg = "Global SNMPV2 write credentials must be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(snmp_v2_write_credential_list) > 0:
-                global_cred_dict["snmpV2cWrite"] = []
+                global_credentails_all["snmpV2cWrite"] = []
                 cred_len = len(snmp_v2_write_credential_list)
                 if cred_len > 5:
                     cred_len = 5
@@ -731,10 +733,10 @@ class Discovery(DnacBase):
                     if snmp_cred.get('description'):
                         for snmp in response.get("snmpV2cWrite"):
                             if snmp.get("description") == snmp_cred.get('description'):
-                                global_cred_dict["snmpV2cWrite"].append(snmp.get("id"))
-                        global_cred_dict["snmpV2cWrite"] = global_cred_dict["snmpV2cWrite"][:cred_len]
+                                global_credentails_all["snmpV2cWrite"].append(snmp.get("id"))
+                        global_credentails_all["snmpV2cWrite"] = global_credentails_all["snmpV2cWrite"][:cred_len]
                     else:
-                        msg = "Please provide description of the Global SNMPV2 write credential to be used"
+                        msg = "Kindly ensure you include both the description and the username for the Global SNMPV2 credential to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
 
         if net_conf_port_list:
@@ -742,7 +744,7 @@ class Discovery(DnacBase):
                 msg = "Global net Conf Ports be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(net_conf_port_list) > 0:
-                global_cred_dict["netconfCredential"] = []
+                global_credentails_all["netconfCredential"] = []
                 cred_len = len(net_conf_port_list)
                 if cred_len > 5:
                     cred_len = 5
@@ -750,14 +752,14 @@ class Discovery(DnacBase):
                     if port.get("description"):
                         for netconf in response.get("netconfCredential"):
                             if port.get('description') == netconf.get('description'):
-                                global_cred_dict["netconfCredential"].append(netconf.get("id"))
-                        global_cred_dict["netconfCredential"] = global_cred_dict["netconfCredential"][:cred_len]
+                                global_credentails_all["netconfCredential"].append(netconf.get("id"))
+                        global_credentails_all["netconfCredential"] = global_credentails_all["netconfCredential"][:cred_len]
                     else:
                         msg = "Please provide description of the Global Netconf port to be used"
                         self.discovery_specific_cred_failure(msg=msg)
 
-        self.log("Fetched Global credentials IDs are {0}".format(global_cred_dict), "INFO")
-        return global_cred_dict
+        self.log("Fetched Global credentials IDs are {0}".format(global_credentails_all), "INFO")
+        return global_credentails_all
 
     def get_ccc_global_credentials_v2_info(self):
         """
@@ -780,31 +782,31 @@ class Discovery(DnacBase):
         )
         response = response.get('response')
         self.log("The Global credentials response from 'get all global credentials v2' API is {0}".format(str(response)), "DEBUG")
-        global_cred_dict = {}
+        global_credentails_all = {}
         global_credentials = self.validated_config[0].get("global_credentials")
         if global_credentials:
-            global_cred_dict = self.handle_global_credentials(response=response)
+            global_credentails_all = self.handle_global_credentials(response=response)
 
-        global_cred_set = set(global_cred_dict.keys())
+        global_cred_set = set(global_credentails_all.keys())
         response_cred_set = set(response.keys())
         diff_keys = response_cred_set.difference(global_cred_set)
 
         for key in diff_keys:
-            global_cred_dict[key] = []
+            global_credentails_all[key] = []
             if response[key] is None:
                 response[key] = []
             total_len = len(response[key])
             if total_len > 5:
                 total_len = 5
             for element in response.get(key):
-                global_cred_dict[key].append(element.get('id'))
-            global_cred_dict[key] = global_cred_dict[key][:total_len]
+                global_credentails_all[key].append(element.get('id'))
+            global_credentails_all[key] = global_credentails_all[key][:total_len]
 
-        if global_cred_dict == {}:
+        if global_credentails_all == {}:
             msg = 'Not found any global credentials to perform discovery'
             self.log(msg, "WARNING")
 
-        return global_cred_dict
+        return global_credentails_all
 
     def get_devices_list_info(self):
         """
@@ -1056,19 +1058,19 @@ class Discovery(DnacBase):
         if self.validated_config[0].get('discovery_specific_credentials'):
             self.handle_discovery_specific_credentials(new_object_params=new_object_params)
 
-        global_cred_dict = self.get_ccc_global_credentials_v2_info()
+        global_credentails_all = self.get_ccc_global_credentials_v2_info()
 
-        self.log(global_cred_dict, "DEBUG")
+        self.log(global_credentails_all, "DEBUG")
         if not (new_object_params.get('snmpUserName') or new_object_params.get('snmpROCommunityDesc') or new_object_params.get('snmpRWCommunityDesc')
-                or global_cred_dict.get('snmpV2cRead') or global_cred_dict.get('snmpV2cWrite') or global_cred_dict.get('snmpV3')):
+                or global_credentails_all.get('snmpV2cRead') or global_credentails_all.get('snmpV2cWrite') or global_credentails_all.get('snmpV3')):
             msg = "Please provide atleast one valid SNMP credential to perform Discovery"
             self.discovery_specific_cred_failure(msg=msg)
 
-        if not (new_object_params.get('userNameList') or global_cred_dict.get('cliCredential')):
+        if not (new_object_params.get('userNameList') or global_credentails_all.get('cliCredential')):
             msg = "Please provide atleast one valid CLI credential to perform Discovery"
             self.discovery_specific_cred_failure(msg=msg)
 
-        for global_cred_list in global_cred_dict.values():
+        for global_cred_list in global_credentails_all.values():
             credential_ids.extend(global_cred_list)
 
         new_object_params['globalCredentialIdList'] = credential_ids

--- a/plugins/modules/discovery_intent.py
+++ b/plugins/modules/discovery_intent.py
@@ -200,6 +200,101 @@ options:
                     - Requires valid SSH credentials to work.
                     - Avoid standard ports like 22, 80, and 8080.
                 type: str
+      global_credentials:
+        description:
+            - Credentials that are already created by the user under Device Credentials in Cisco Catalyst Center.
+            - If user doesn't pass any global credentials in the playbook.
+            - By default we will use all the global credentials present in the Cisco Catalyst Center of each type for performing discovery. (Max 5 allowed)
+        type: dict
+        suboptions:
+            cli_credentials_list:
+                description:
+                    - List of Global CLI credentials to be used during device discovery.
+                    - Generally it is advised to create device credentials with unique username or description.
+                type: list
+                elements: dict
+                suboptions:
+                    username:
+                        description: Username for CLI authentication, mandatory when using global CLI credentials.
+                        type: str
+                    description:
+                        description: Name of the CLI credential, mandatory when using global CLI credentials.
+                        type: str
+            http_read_credential_list:
+                description:
+                    - List of Global HTTP Read credentials to be used during device discovery.
+                    - Generally it is advised to create device credentials with unique username or description.
+                type: list
+                elements: dict
+                suboptions:
+                    username:
+                        description: Username for HTTP Read authentication, mandatory when using global HTTP credentials.
+                        type: str
+                    description:
+                        description: Name of the HTTP Read credential, mandatory when using  global HTTP credentials.
+                        type: str
+            http_write_credential_list:
+                description:
+                    - List of Global HTTP Write credentials to be used during device discovery.
+                    - Generally it is advised to create device credentials with unique username or description.
+                type: list
+                elements: dict
+                suboptions:
+                    username:
+                        description: Username for HTTP Write authentication, mandatory when using global HTTP credentials.
+                        type: str
+                    description:
+                        description: Name of the HTTP Write credential, mandatory when using  global HTTP credentials.
+                        type: str
+            snmp_v2_read_credential_list:
+                description:
+                    - List of Global SNMP V2 Read credentials to be used during device discovery.
+                    - Generally it is advised to create device credentials with unique username or description.
+                type: list
+                elements: dict
+                suboptions:
+                    username:
+                        description: Username for SNMP Read authentication, mandatory when using global SNMP credentials.
+                        type: str
+                    description:
+                        description: Name of the SNMP Read credential, mandatory when using  global SNMP credentials.
+                        type: str
+            snmp_v2_write_credential_list:
+                description:
+                    - List of Global SNMP V2 Write credentials to be used during device discovery.
+                    - Generally it is advised to create device credentials with unique username or description.
+                type: list
+                elements: dict
+                suboptions:
+                    username:
+                        description: Username for SNMP Write authentication, mandatory when using global SNMP credentials.
+                        type: str
+                    description:
+                        description: Name of the SNMP Write credential, mandatory when using global SNMP credentials.
+                        type: str
+            snmp_v3_credential_list:
+                description:
+                    - List of Global SNMP V3 credentials to be used during device discovery, giving read and write mode.
+                    - Generally it is advised to create device credentials with unique username or description.
+                type: list
+                elements: dict
+                suboptions:
+                    username:
+                        description: Username for SNMP V3 authentication, mandatory when using global SNMP credentials.
+                        type: str
+                    description:
+                        description: Name of the SNMP V3 credential, mandatory when using global SNMP credentials.
+                        type: str
+            net_conf_port_list:
+                description:
+                    - List of Global Net conf ports to be used during device discovery.
+                    - Generally it is advised to create device credentials with unique description.
+                type: list
+                elements: dict
+                suboptions:
+                    description:
+                        description: Name of the Net Conf Port credential, mandatory when using global Net conf port.
+                        type: str
       ip_filter_list:
         description: List of IP adddrsess that needs to get filtered out from the IP addresses passed.
         type: list
@@ -224,10 +319,6 @@ options:
       timeout:
         description: Time to wait for device response in seconds
         type: int
-      global_cli_len:
-       description: Specifies the total number of CLI credentials to be used, ranging from 1 to 5.
-       type: int
-       default: 1
       delete_all:
         description: Parameter to delete all the discoveries at one go
         type: bool
@@ -286,7 +377,6 @@ EXAMPLES = r"""
           protocol_order: string
           retry: integer
           timeout: integer
-          global_cli_len: integer
           discovery_specific_credentials:
             cli_credentials_list:
                 - username: string
@@ -315,6 +405,28 @@ EXAMPLES = r"""
                 auth_type: string
                 privacy_type: string
                 privacy_password: string
+            net_conf_port: string
+          global_credentials:
+            cli_credentials_list:
+                - description: string
+                  username: string
+            http_read_credential_list:
+                - description: string
+                  username: string
+            http_write_credential_list:
+                - description: string
+                  username: string
+            snmp_v3_credential_list:
+                - description: string
+                  username: string
+            snmp_v2_read_credential_list:
+                - description: string
+                  username: string
+            snmp_v2_write_credential_list:
+                - description: string
+                  username: string
+            net_conf_port_list:
+                - description: string
 
 - name: Delete disovery by name
   cisco.dnac.discovery_intent:
@@ -443,8 +555,7 @@ class Discovery(DnacBase):
                                          'default': 'None'},
             'retry': {'type': 'int', 'required': False},
             'timeout': {'type': 'str', 'required': False},
-            'global_cli_len': {'type': 'int', 'required': False,
-                               'default': 1}
+            'global_credentials': {'type': 'dict', 'required': False}
         }
 
         if state == "merged":
@@ -490,6 +601,164 @@ class Discovery(DnacBase):
         self.log("Credential Ids list passed is {0}".format(str(self.creds_ids_list)), "INFO")
         return self.creds_ids_list
 
+    def handle_global_credentials(self, response=None):
+        """
+        Method to convert values for create_params API when global paramters
+        are passed as input.
+
+        Parameters:
+            - response: The response collected from the get_all_global_credentials_v2 API
+
+        Returns:
+            - global_cred_dict  : The dictionary containing list of IDs of various types of
+                                    Global credentials.
+        """
+
+        global_credentials = self.validated_config[0].get("global_credentials")
+        cli_credentials_list = global_credentials.get('cli_credentials_list')
+        http_read_credential_list = global_credentials.get('http_read_credential_list')
+        http_write_credential_list = global_credentials.get('http_write_credential_list')
+        snmp_v2_read_credential_list = global_credentials.get('snmp_v2_read_credential_list')
+        snmp_v2_write_credential_list = global_credentials.get('snmp_v2_write_credential_list')
+        snmp_v3_credential_list = global_credentials.get('snmp_v3_credential_list')
+        net_conf_port_list = global_credentials.get('net_conf_port_list')
+        global_cred_dict = {}
+        if cli_credentials_list:
+            if not isinstance(cli_credentials_list, list):
+                msg = "Global ClI credentials must be passed as a list"
+                self.discovery_specific_cred_failure(msg=msg)
+            if len(cli_credentials_list) > 0:
+                global_cred_dict["cliCredential"] = []
+                cred_len = len(cli_credentials_list)
+                if cred_len > 5:
+                    cred_len = 5
+                for cli_cred in cli_credentials_list:
+                    if cli_cred.get('description') and cli_cred.get('username'):
+                        for cli in response.get("cliCredential"):
+                            if cli.get("description") == cli_cred.get('description') and cli.get("username") == cli_cred.get('username'):
+                                global_cred_dict["cliCredential"].append(cli.get("id"))
+                        global_cred_dict["cliCredential"] = global_cred_dict["cliCredential"][:cred_len]
+                    else:
+                        msg = "Please provide description and username of the Global CLI credential to be used"
+                        self.discovery_specific_cred_failure(msg=msg)
+
+        if http_read_credential_list:
+            if not isinstance(http_read_credential_list, list):
+                msg = "Global HTTP read credentials must be passed as a list"
+                self.discovery_specific_cred_failure(msg=msg)
+            if len(http_read_credential_list) > 0:
+                global_cred_dict["httpsRead"] = []
+                cred_len = len(http_read_credential_list)
+                if cred_len > 5:
+                    cred_len = 5
+                for http_cred in http_read_credential_list:
+                    if http_cred.get('description') and http_cred.get('username'):
+                        for http in response.get("httpsRead"):
+                            if http.get("description") == http.get('description') and http.get("username") == http.get('username'):
+                                global_cred_dict["httpsRead"].append(http.get("id"))
+                        global_cred_dict["httpsRead"] = global_cred_dict["httpsRead"][:cred_len]
+                    else:
+                        msg = "Please provide description and username of the Global HTTP read credential to be used"
+                        self.discovery_specific_cred_failure(msg=msg)
+
+        if http_write_credential_list:
+            if not isinstance(http_write_credential_list, list):
+                msg = "Global HTTP write credentials must be passed as a list"
+                self.discovery_specific_cred_failure(msg=msg)
+            if len(http_write_credential_list) > 0:
+                global_cred_dict["httpsWrite"] = []
+                cred_len = len(http_write_credential_list)
+                if cred_len > 5:
+                    cred_len = 5
+                for http_cred in http_write_credential_list:
+                    if http_cred.get('description') and http_cred.get('username'):
+                        for http in response.get("httpsWrite"):
+                            if http.get("description") == http.get('description') and http.get("username") == http.get('username'):
+                                global_cred_dict["httpsWrite"].append(http.get("id"))
+                        global_cred_dict["httpsWrite"] = global_cred_dict["httpsWrite"][:cred_len]
+                    else:
+                        msg = "Please provide description and username of the Global HTTP write credential to be used"
+                        self.discovery_specific_cred_failure(msg=msg)
+
+        if snmp_v2_read_credential_list:
+            if not isinstance(snmp_v2_read_credential_list, list):
+                msg = "Global SNMPV2 read credentials must be passed as a list"
+                self.discovery_specific_cred_failure(msg=msg)
+            if len(snmp_v2_read_credential_list) > 0:
+                global_cred_dict["snmpV2cRead"] = []
+                cred_len = len(snmp_v2_read_credential_list)
+                if cred_len > 5:
+                    cred_len = 5
+                for snmp_cred in snmp_v2_read_credential_list:
+                    if snmp_cred.get('description'):
+                        for snmp in response.get("snmpV2cRead"):
+                            if snmp.get("description") == snmp_cred.get('description'):
+                                global_cred_dict["snmpV2cRead"].append(snmp.get("id"))
+                        global_cred_dict["snmpV2cRead"] = global_cred_dict["snmpV2cRead"][:cred_len]
+                    else:
+                        msg = "Please provide description of the Global SNMPV2 read credential to be used"
+                        self.discovery_specific_cred_failure(msg=msg)
+
+        if snmp_v3_credential_list:
+            if not isinstance(snmp_v3_credential_list, list):
+                msg = "Global SNMPV3 write credentials must be passed as a list"
+                self.discovery_specific_cred_failure(msg=msg)
+            if len(snmp_v3_credential_list) > 0:
+                global_cred_dict["snmpV3"] = []
+                cred_len = len(snmp_v3_credential_list)
+                if cred_len > 5:
+                    cred_len = 5
+                for snmp_cred in snmp_v3_credential_list:
+                    if snmp_cred.get('description') and snmp_cred.get('username'):
+                        for snmp in response.get("snmpV3"):
+                            if snmp.get("description") == snmp_cred.get('description') and snmp.get("username") == snmp_cred.get('username'):
+                                global_cred_dict["snmpV3"].append(snmp.get("id"))
+                        global_cred_dict["snmpV3"] = global_cred_dict["snmpV3"][:cred_len]
+                    else:
+                        msg = "Please provide description and username of the Global SNMPV3 credential to be used"
+                        self.discovery_specific_cred_failure(msg=msg)
+
+        if snmp_v2_write_credential_list:
+            if not isinstance(snmp_v2_write_credential_list, list):
+                msg = "Global SNMPV2 write credentials must be passed as a list"
+                self.discovery_specific_cred_failure(msg=msg)
+            if len(snmp_v2_write_credential_list) > 0:
+                global_cred_dict["snmpV2cWrite"] = []
+                cred_len = len(snmp_v2_write_credential_list)
+                if cred_len > 5:
+                    cred_len = 5
+                for snmp_cred in snmp_v2_write_credential_list:
+                    if snmp_cred.get('description'):
+                        for snmp in response.get("snmpV2cWrite"):
+                            if snmp.get("description") == snmp_cred.get('description'):
+                                global_cred_dict["snmpV2cWrite"].append(snmp.get("id"))
+                        global_cred_dict["snmpV2cWrite"] = global_cred_dict["snmpV2cWrite"][:cred_len]
+                    else:
+                        msg = "Please provide description of the Global SNMPV2 write credential to be used"
+                        self.discovery_specific_cred_failure(msg=msg)
+
+        if net_conf_port_list:
+            if not isinstance(net_conf_port_list, list):
+                msg = "Global net Conf Ports be passed as a list"
+                self.discovery_specific_cred_failure(msg=msg)
+            if len(net_conf_port_list) > 0:
+                global_cred_dict["netconfCredential"] = []
+                cred_len = len(net_conf_port_list)
+                if cred_len > 5:
+                    cred_len = 5
+                for port in net_conf_port_list:
+                    if port.get("description"):
+                        for netconf in response.get("netconfCredential"):
+                            if port.get('description') == netconf.get('description'):
+                                global_cred_dict["netconfCredential"].append(netconf.get("id"))
+                        global_cred_dict["netconfCredential"] = global_cred_dict["netconfCredential"][:cred_len]
+                    else:
+                        msg = "Please provide description of the Global Netconf port to be used"
+                        self.discovery_specific_cred_failure(msg=msg)
+
+        self.log("Fetched Global credentials IDs are {0}".format(global_cred_dict), "INFO")
+        return global_cred_dict
+
     def get_ccc_global_credentials_v2_info(self):
         """
         Retrieve the global credentials information (version 2).
@@ -511,44 +780,31 @@ class Discovery(DnacBase):
         )
         response = response.get('response')
         self.log("The Global credentials response from 'get all global credentials v2' API is {0}".format(str(response)), "DEBUG")
+        global_cred_dict = {}
+        global_credentials = self.validated_config[0].get("global_credentials")
+        if global_credentials:
+            global_cred_dict = self.handle_global_credentials(response=response)
 
-        cli_len_inp = self.validated_config[0].get("global_cli_len")
-        if response.get("cliCredential") is None:
-            msg = 'Not found any CLI credentials to perform discovery'
-            self.log(msg, "CRITICAL")
-            self.module.fail_json(msg=msg)
+        global_cred_set = set(global_cred_dict.keys())
+        response_cred_set = set(response.keys())
+        diff_keys = response_cred_set.difference(global_cred_set)
 
-        if response.get("snmpV2cRead") is None and response.get("snmpV2cWrite") is None and response.get("snmpV3"):
-            msg = 'Not found any SNMP credentials to perform discovery'
-            self.log(msg, "CRITICAL")
-            self.module.fail_json(msg=msg)
-
-        total_cli = len(response.get("cliCredential"))
-        if total_cli > 5:
-            if cli_len_inp > 5:
-                cli_len_inp = 5
-
-        elif total_cli < 6 and cli_len_inp > total_cli:
-            cli_len_inp = total_cli
-
-        cli_len = 0
-
-        for key in response.keys():
+        for key in diff_keys:
+            global_cred_dict[key] = []
             if response[key] is None:
                 response[key] = []
-            if key == "cliCredential":
-                for element in response.get(key):
-                    while cli_len < cli_len_inp:
-                        self.creds_ids_list.append(element.get('id'))
-                        cli_len += 1
-            else:
-                self.creds_ids_list.extend(element.get('id') for element in response.get(key))
-        if not self.creds_ids_list:
-            msg = 'Not found any credentials to perform discovery'
-            self.log(msg, "CRITICAL")
-            self.module.fail_json(msg=msg)
+            total_len = len(response[key])
+            if total_len > 5:
+                total_len = 5
+            for element in response.get(key):
+                global_cred_dict[key].append(element.get('id'))
+            global_cred_dict[key] = global_cred_dict[key][:total_len]
 
-        self.result.update(dict(credential_ids=self.creds_ids_list))
+        if global_cred_dict == {}:
+            msg = 'Not found any global credentials to perform discovery'
+            self.log(msg, "WARNING")
+
+        return global_cred_dict
 
     def get_devices_list_info(self):
         """
@@ -631,7 +887,7 @@ class Discovery(DnacBase):
 
     def discovery_specific_cred_failure(self, msg=None):
         """
-        Method for failing discovery if there is any discrepancy in the http credentials
+        Method for failing discovery if there is any discrepancy in the credentials
         passed by the user
         """
 
@@ -767,7 +1023,7 @@ class Discovery(DnacBase):
 
         return new_object_params
 
-    def create_params(self, credential_ids=None, ip_address_list=None):
+    def create_params(self, ip_address_list=None):
         """
         Create a new parameter object based on the validated configuration,
         credential IDs, and IP address list.
@@ -783,13 +1039,11 @@ class Discovery(DnacBase):
                                parameters.
         """
 
-        if credential_ids is None:
-            credential_ids = []
+        credential_ids = []
 
         new_object_params = {}
         new_object_params['cdpLevel'] = self.validated_config[0].get('cdp_level')
         new_object_params['discoveryType'] = self.validated_config[0].get('discovery_type')
-        new_object_params['globalCredentialIdList'] = credential_ids
         new_object_params['ipAddressList'] = ip_address_list
         new_object_params['ipFilterList'] = self.validated_config[0].get('ip_filter_list')
         new_object_params['lldpLevel'] = self.validated_config[0].get('lldp_level')
@@ -802,11 +1056,27 @@ class Discovery(DnacBase):
         if self.validated_config[0].get('discovery_specific_credentials'):
             self.handle_discovery_specific_credentials(new_object_params=new_object_params)
 
+        global_cred_dict = self.get_ccc_global_credentials_v2_info()
+
+        self.log(global_cred_dict, "DEBUG")
+        if not (new_object_params.get('snmpUserName') or new_object_params.get('snmpROCommunityDesc') or new_object_params.get('snmpRWCommunityDesc')
+                or global_cred_dict.get('snmpV2cRead') or global_cred_dict.get('snmpV2cWrite') or global_cred_dict.get('snmpV3')):
+            msg = "Please provide atleast one valid SNMP credential to perform Discovery"
+            self.discovery_specific_cred_failure(msg=msg)
+
+        if not (new_object_params.get('userNameList') or global_cred_dict.get('cliCredential')):
+            msg = "Please provide atleast one valid CLI credential to perform Discovery"
+            self.discovery_specific_cred_failure(msg=msg)
+
+        for global_cred_list in global_cred_dict.values():
+            credential_ids.extend(global_cred_list)
+
+        new_object_params['globalCredentialIdList'] = credential_ids
         self.log("The payload/object created for calling the start discovery API is {0}".format(str(new_object_params)), "INFO")
 
         return new_object_params
 
-    def create_discovery(self, credential_ids=None, ip_address_list=None):
+    def create_discovery(self, ip_address_list=None):
         """
         Start a new discovery process in the Cisco Catalyst Center. It creates the
         parameters required for the discovery and then calls the
@@ -823,14 +1093,10 @@ class Discovery(DnacBase):
           - task_id: The ID of the task created for the discovery process.
         """
 
-        if credential_ids is None:
-            credential_ids = []
-
         result = self.dnac_apply['exec'](
             family="discovery",
             function="start_discovery",
-            params=self.create_params(
-                credential_ids=credential_ids, ip_address_list=ip_address_list),
+            params=self.create_params(ip_address_list=ip_address_list),
             op_modifies=True,
         )
 
@@ -873,7 +1139,7 @@ class Discovery(DnacBase):
                 self.module.fail_json(msg=msg)
                 return False
 
-            if response.get('progress') != 'In Progress':
+            if response.get('progress') != 'In Progress' or response.get('progress') != 'Inventory service initiating discovery':
                 result = True
                 self.log("The Process is completed", "INFO")
                 break
@@ -1079,7 +1345,6 @@ class Discovery(DnacBase):
           - self: The instance of the class with updated attributes.
         """
 
-        self.get_ccc_global_credentials_v2_info()
         devices_list_info = self.get_devices_list_info()
         ip_address_list = self.preprocess_device_discovery(devices_list_info)
         exist_discovery = self.get_exist_discovery()
@@ -1089,7 +1354,6 @@ class Discovery(DnacBase):
             complete_discovery = self.get_task_status(task_id=discovery_task_id)
 
         discovery_task_id = self.create_discovery(
-            credential_ids=self.get_creds_ids_list(),
             ip_address_list=ip_address_list)
         complete_discovery = self.get_task_status(task_id=discovery_task_id)
         discovery_task_info = self.get_discoveries_by_range_until_success()

--- a/plugins/modules/discovery_intent.py
+++ b/plugins/modules/discovery_intent.py
@@ -229,6 +229,7 @@ options:
                 description:
                     - List of global HTTP Read credentials that will be used in the process of discovering devices.
                     - It's recommended to create device credentials with both a unique username and a clear description for easy identification.
+                type: list
                 elements: dict
                 suboptions:
                     username:

--- a/plugins/modules/discovery_workflow_manager.py
+++ b/plugins/modules/discovery_workflow_manager.py
@@ -39,14 +39,9 @@ options:
     elements: dict
     required: true
     suboptions:
-      ip_address_list:
-        description: List of IP addresses to be discovered. For CDP/LLDP/SINGLE based discovery, we should
-            pass a list with single element like - 10.197.156.22. For CIDR based discovery, we should pass a list with
-            single element like - 10.197.156.22/22. For RANGE based discovery, we should pass a list with single element
-            and range like - 10.197.156.1-10.197.156.100. For MULTI RANGE based discovery, we should pass a list with multiple
-            elementd like - 10.197.156.1-10.197.156.100 and in next line - 10.197.157.1-10.197.157.100.
-        type: list
-        elements: str
+      discovery_name:
+        description: Name of the discovery task
+        type: str
         required: true
       discovery_type:
         description: Determines the method of device discovery. Here are the available options.
@@ -59,6 +54,19 @@ options:
         type: str
         required: true
         choices: [ 'SINGLE', 'RANGE', 'MULTI RANGE', 'CDP', 'LLDP', 'CIDR']
+      ip_address_list:
+        description: List of IP addresses to be discovered. For CDP/LLDP/SINGLE based discovery, we should
+            pass a list with single element like - 10.197.156.22. For CIDR based discovery, we should pass a list with
+            single element like - 10.197.156.22/22. For RANGE based discovery, we should pass a list with single element
+            and range like - 10.197.156.1-10.197.156.100. For MULTI RANGE based discovery, we should pass a list with multiple
+            elementd like - 10.197.156.1-10.197.156.100 and in next line - 10.197.157.1-10.197.157.100.
+        type: list
+        elements: str
+        required: true
+      ip_filter_list:
+        description: List of IP adddrsess that needs to get filtered out from the IP addresses passed.
+        type: list
+        elements: str
       cdp_level:
         description: Total number of levels that are there in cdp's method of discovery
         type: int
@@ -67,14 +75,10 @@ options:
         description: Total number of levels that are there in lldp's method of discovery
         type: int
         default: 16
-      start_index:
-        description: Start index for the header in fetching SNMP v2 credentials
-        type: int
-        default: 1
-      records_to_return:
-        description: Number of records to return for the header in fetching global v2 credentials
-        type: int
-        default: 100
+      preferred_mgmt_ip_method:
+        description: Preferred method for the management of the IP (None/UseLoopBack)
+        type: str
+        default: None
       discovery_specific_credentials:
         description: Credentials specifically created by the user for performing device discovery.
         type: dict
@@ -203,8 +207,8 @@ options:
       global_credentials:
         description:
             - Credentials that are already created by the user under Device Credentials in Cisco Catalyst Center.
-            - If user doesn't pass any global credentials in the playbook.
-            - By default we will use all the global credentials present in the Cisco Catalyst Center of each type for performing discovery. (Max 5 allowed)
+            - If user doesn't pass any global credentials in the playbook, then by default, we will use all the global
+                credentials present in the Cisco Catalyst Center of each type for performing discovery. (Max 5 allowed)
         type: dict
         suboptions:
             cli_credentials_list:
@@ -295,24 +299,20 @@ options:
                     description:
                         description: Name of the Net Conf Port credential, mandatory when using global Net conf port.
                         type: str
-      ip_filter_list:
-        description: List of IP adddrsess that needs to get filtered out from the IP addresses passed.
-        type: list
-        elements: str
-      discovery_name:
-        description: Name of the discovery task
-        type: str
-        required: true
-      preferred_mgmt_ip_method:
-        description: Preferred method for the management of the IP (None/UseLoopBack)
-        type: str
-        default: None
+      start_index:
+        description: Start index for the header in fetching SNMP v2 credentials
+        type: int
+        default: 1
+      records_to_return:
+        description: Number of records to return for the header in fetching global v2 credentials
+        type: int
+        default: 100
       protocol_order:
         description: Determines the order in which device connections will be attempted. Here are the options
             - "telnet" Only telnet connections will be tried.
             - "ssh, telnet" SSH (Secure Shell) will be attempted first, followed by telnet if SSH fails.
         type: str
-        required: true
+        default: ssh
       retry:
         description: Number of times to try establishing connection to device
         type: int
@@ -364,19 +364,13 @@ EXAMPLES = r"""
     state: merged
     config_verify: True
     config:
-        - ip_address_list: list
+        - discovery_name: string
           discovery_type: string
+          ip_address_list: list
+          ip_filter_list: list
           cdp_level: string
           lldp_level: string
-          start_index: integer
-          records_to_return: integer
-          ip_filter_list: list
-          discovery_name: string
-          password_list: list
           prefered_mgmt_ip_method: string
-          protocol_order: string
-          retry: integer
-          timeout: integer
           discovery_specific_credentials:
             cli_credentials_list:
                 - username: string
@@ -427,6 +421,11 @@ EXAMPLES = r"""
                   username: string
             net_conf_port_list:
                 - description: string
+          start_index: integer
+          records_to_return: integer
+          protocol_order: string
+          retry: integer
+          timeout: integer
 
 - name: Delete disovery by name
   cisco.dnac.discovery_workflow_manager:
@@ -555,14 +554,15 @@ class Discovery(DnacBase):
                                          'default': 'None'},
             'retry': {'type': 'int', 'required': False},
             'timeout': {'type': 'str', 'required': False},
-            'global_credentials': {'type': 'dict', 'required': False}
+            'global_credentials': {'type': 'dict', 'required': False},
+            'protocol_order': {'type': 'str', 'required': False,
+                                'default': 'ssh'}
         }
 
         if state == "merged":
             discovery_spec["ip_address_list"] = {'type': 'list', 'required': True,
                                                  'elements': 'str'}
             discovery_spec["discovery_type"] = {'type': 'str', 'required': True}
-            discovery_spec["protocol_order"] = {'type': 'str', 'required': True}
 
         elif state == "deleted":
             if self.config[0].get("delete_all") is True:
@@ -610,7 +610,7 @@ class Discovery(DnacBase):
             - response: The response collected from the get_all_global_credentials_v2 API
 
         Returns:
-            - global_cred_dict  : The dictionary containing list of IDs of various types of
+            - global_credentails_all  : The dictionary containing list of IDs of various types of
                                     Global credentials.
         """
 
@@ -622,13 +622,13 @@ class Discovery(DnacBase):
         snmp_v2_write_credential_list = global_credentials.get('snmp_v2_write_credential_list')
         snmp_v3_credential_list = global_credentials.get('snmp_v3_credential_list')
         net_conf_port_list = global_credentials.get('net_conf_port_list')
-        global_cred_dict = {}
+        global_credentails_all = {}
         if cli_credentials_list:
             if not isinstance(cli_credentials_list, list):
                 msg = "Global ClI credentials must be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(cli_credentials_list) > 0:
-                global_cred_dict["cliCredential"] = []
+                global_credentails_all["cliCredential"] = []
                 cred_len = len(cli_credentials_list)
                 if cred_len > 5:
                     cred_len = 5
@@ -636,10 +636,10 @@ class Discovery(DnacBase):
                     if cli_cred.get('description') and cli_cred.get('username'):
                         for cli in response.get("cliCredential"):
                             if cli.get("description") == cli_cred.get('description') and cli.get("username") == cli_cred.get('username'):
-                                global_cred_dict["cliCredential"].append(cli.get("id"))
-                        global_cred_dict["cliCredential"] = global_cred_dict["cliCredential"][:cred_len]
+                                global_credentails_all["cliCredential"].append(cli.get("id"))
+                        global_credentails_all["cliCredential"] = global_credentails_all["cliCredential"][:cred_len]
                     else:
-                        msg = "Please provide description and username of the Global CLI credential to be used"
+                        msg = "Kindly ensure you include both the description and the username for the Global CLI credential to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
 
         if http_read_credential_list:
@@ -647,7 +647,7 @@ class Discovery(DnacBase):
                 msg = "Global HTTP read credentials must be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(http_read_credential_list) > 0:
-                global_cred_dict["httpsRead"] = []
+                global_credentails_all["httpsRead"] = []
                 cred_len = len(http_read_credential_list)
                 if cred_len > 5:
                     cred_len = 5
@@ -655,10 +655,10 @@ class Discovery(DnacBase):
                     if http_cred.get('description') and http_cred.get('username'):
                         for http in response.get("httpsRead"):
                             if http.get("description") == http.get('description') and http.get("username") == http.get('username'):
-                                global_cred_dict["httpsRead"].append(http.get("id"))
-                        global_cred_dict["httpsRead"] = global_cred_dict["httpsRead"][:cred_len]
+                                global_credentails_all["httpsRead"].append(http.get("id"))
+                        global_credentails_all["httpsRead"] = global_credentails_all["httpsRead"][:cred_len]
                     else:
-                        msg = "Please provide description and username of the Global HTTP read credential to be used"
+                        msg = "Kindly ensure you include both the description and the username for the Global HTTP Read credential to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
 
         if http_write_credential_list:
@@ -666,7 +666,7 @@ class Discovery(DnacBase):
                 msg = "Global HTTP write credentials must be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(http_write_credential_list) > 0:
-                global_cred_dict["httpsWrite"] = []
+                global_credentails_all["httpsWrite"] = []
                 cred_len = len(http_write_credential_list)
                 if cred_len > 5:
                     cred_len = 5
@@ -674,10 +674,10 @@ class Discovery(DnacBase):
                     if http_cred.get('description') and http_cred.get('username'):
                         for http in response.get("httpsWrite"):
                             if http.get("description") == http.get('description') and http.get("username") == http.get('username'):
-                                global_cred_dict["httpsWrite"].append(http.get("id"))
-                        global_cred_dict["httpsWrite"] = global_cred_dict["httpsWrite"][:cred_len]
+                                global_credentails_all["httpsWrite"].append(http.get("id"))
+                        global_credentails_all["httpsWrite"] = global_credentails_all["httpsWrite"][:cred_len]
                     else:
-                        msg = "Please provide description and username of the Global HTTP write credential to be used"
+                        msg = "Kindly ensure you include both the description and the username for the Global HTTP Write credential to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
 
         if snmp_v2_read_credential_list:
@@ -685,7 +685,7 @@ class Discovery(DnacBase):
                 msg = "Global SNMPV2 read credentials must be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(snmp_v2_read_credential_list) > 0:
-                global_cred_dict["snmpV2cRead"] = []
+                global_credentails_all["snmpV2cRead"] = []
                 cred_len = len(snmp_v2_read_credential_list)
                 if cred_len > 5:
                     cred_len = 5
@@ -693,10 +693,11 @@ class Discovery(DnacBase):
                     if snmp_cred.get('description'):
                         for snmp in response.get("snmpV2cRead"):
                             if snmp.get("description") == snmp_cred.get('description'):
-                                global_cred_dict["snmpV2cRead"].append(snmp.get("id"))
-                        global_cred_dict["snmpV2cRead"] = global_cred_dict["snmpV2cRead"][:cred_len]
+                                global_credentails_all["snmpV2cRead"].append(snmp.get("id"))
+                        global_credentails_all["snmpV2cRead"] = global_credentails_all["snmpV2cRead"][:cred_len]
                     else:
-                        msg = "Please provide description of the Global SNMPV2 read credential to be used"
+                        msg = "Kindly ensure you include both the description and the username for the Global SNMPV2 Read \
+                                credential to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
 
         if snmp_v3_credential_list:
@@ -704,7 +705,7 @@ class Discovery(DnacBase):
                 msg = "Global SNMPV3 write credentials must be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(snmp_v3_credential_list) > 0:
-                global_cred_dict["snmpV3"] = []
+                global_credentails_all["snmpV3"] = []
                 cred_len = len(snmp_v3_credential_list)
                 if cred_len > 5:
                     cred_len = 5
@@ -712,10 +713,11 @@ class Discovery(DnacBase):
                     if snmp_cred.get('description') and snmp_cred.get('username'):
                         for snmp in response.get("snmpV3"):
                             if snmp.get("description") == snmp_cred.get('description') and snmp.get("username") == snmp_cred.get('username'):
-                                global_cred_dict["snmpV3"].append(snmp.get("id"))
-                        global_cred_dict["snmpV3"] = global_cred_dict["snmpV3"][:cred_len]
+                                global_credentails_all["snmpV3"].append(snmp.get("id"))
+                        global_credentails_all["snmpV3"] = global_credentails_all["snmpV3"][:cred_len]
                     else:
-                        msg = "Please provide description and username of the Global SNMPV3 credential to be used"
+                        msg = "Kindly ensure you include both the description and the username for the Global SNMPV3 \
+                                to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
 
         if snmp_v2_write_credential_list:
@@ -723,7 +725,7 @@ class Discovery(DnacBase):
                 msg = "Global SNMPV2 write credentials must be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(snmp_v2_write_credential_list) > 0:
-                global_cred_dict["snmpV2cWrite"] = []
+                global_credentails_all["snmpV2cWrite"] = []
                 cred_len = len(snmp_v2_write_credential_list)
                 if cred_len > 5:
                     cred_len = 5
@@ -731,10 +733,10 @@ class Discovery(DnacBase):
                     if snmp_cred.get('description'):
                         for snmp in response.get("snmpV2cWrite"):
                             if snmp.get("description") == snmp_cred.get('description'):
-                                global_cred_dict["snmpV2cWrite"].append(snmp.get("id"))
-                        global_cred_dict["snmpV2cWrite"] = global_cred_dict["snmpV2cWrite"][:cred_len]
+                                global_credentails_all["snmpV2cWrite"].append(snmp.get("id"))
+                        global_credentails_all["snmpV2cWrite"] = global_credentails_all["snmpV2cWrite"][:cred_len]
                     else:
-                        msg = "Please provide description of the Global SNMPV2 write credential to be used"
+                        msg = "Kindly ensure you include both the description and the username for the Global SNMPV2 credential to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
 
         if net_conf_port_list:
@@ -742,7 +744,7 @@ class Discovery(DnacBase):
                 msg = "Global net Conf Ports be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(net_conf_port_list) > 0:
-                global_cred_dict["netconfCredential"] = []
+                global_credentails_all["netconfCredential"] = []
                 cred_len = len(net_conf_port_list)
                 if cred_len > 5:
                     cred_len = 5
@@ -750,14 +752,14 @@ class Discovery(DnacBase):
                     if port.get("description"):
                         for netconf in response.get("netconfCredential"):
                             if port.get('description') == netconf.get('description'):
-                                global_cred_dict["netconfCredential"].append(netconf.get("id"))
-                        global_cred_dict["netconfCredential"] = global_cred_dict["netconfCredential"][:cred_len]
+                                global_credentails_all["netconfCredential"].append(netconf.get("id"))
+                        global_credentails_all["netconfCredential"] = global_credentails_all["netconfCredential"][:cred_len]
                     else:
                         msg = "Please provide description of the Global Netconf port to be used"
                         self.discovery_specific_cred_failure(msg=msg)
 
-        self.log("Fetched Global credentials IDs are {0}".format(global_cred_dict), "INFO")
-        return global_cred_dict
+        self.log("Fetched Global credentials IDs are {0}".format(global_credentails_all), "INFO")
+        return global_credentails_all
 
     def get_ccc_global_credentials_v2_info(self):
         """
@@ -780,31 +782,31 @@ class Discovery(DnacBase):
         )
         response = response.get('response')
         self.log("The Global credentials response from 'get all global credentials v2' API is {0}".format(str(response)), "DEBUG")
-        global_cred_dict = {}
+        global_credentails_all = {}
         global_credentials = self.validated_config[0].get("global_credentials")
         if global_credentials:
-            global_cred_dict = self.handle_global_credentials(response=response)
+            global_credentails_all = self.handle_global_credentials(response=response)
 
-        global_cred_set = set(global_cred_dict.keys())
+        global_cred_set = set(global_credentails_all.keys())
         response_cred_set = set(response.keys())
         diff_keys = response_cred_set.difference(global_cred_set)
 
         for key in diff_keys:
-            global_cred_dict[key] = []
+            global_credentails_all[key] = []
             if response[key] is None:
                 response[key] = []
             total_len = len(response[key])
             if total_len > 5:
                 total_len = 5
             for element in response.get(key):
-                global_cred_dict[key].append(element.get('id'))
-            global_cred_dict[key] = global_cred_dict[key][:total_len]
+                global_credentails_all[key].append(element.get('id'))
+            global_credentails_all[key] = global_credentails_all[key][:total_len]
 
-        if global_cred_dict == {}:
+        if global_credentails_all == {}:
             msg = 'Not found any global credentials to perform discovery'
             self.log(msg, "WARNING")
 
-        return global_cred_dict
+        return global_credentails_all
 
     def get_devices_list_info(self):
         """
@@ -1056,19 +1058,19 @@ class Discovery(DnacBase):
         if self.validated_config[0].get('discovery_specific_credentials'):
             self.handle_discovery_specific_credentials(new_object_params=new_object_params)
 
-        global_cred_dict = self.get_ccc_global_credentials_v2_info()
+        global_credentails_all = self.get_ccc_global_credentials_v2_info()
 
-        self.log(global_cred_dict, "DEBUG")
+        self.log(global_credentails_all, "DEBUG")
         if not (new_object_params.get('snmpUserName') or new_object_params.get('snmpROCommunityDesc') or new_object_params.get('snmpRWCommunityDesc')
-                or global_cred_dict.get('snmpV2cRead') or global_cred_dict.get('snmpV2cWrite') or global_cred_dict.get('snmpV3')):
+                or global_credentails_all.get('snmpV2cRead') or global_credentails_all.get('snmpV2cWrite') or global_credentails_all.get('snmpV3')):
             msg = "Please provide atleast one valid SNMP credential to perform Discovery"
             self.discovery_specific_cred_failure(msg=msg)
 
-        if not (new_object_params.get('userNameList') or global_cred_dict.get('cliCredential')):
+        if not (new_object_params.get('userNameList') or global_credentails_all.get('cliCredential')):
             msg = "Please provide atleast one valid CLI credential to perform Discovery"
             self.discovery_specific_cred_failure(msg=msg)
 
-        for global_cred_list in global_cred_dict.values():
+        for global_cred_list in global_credentails_all.values():
             credential_ids.extend(global_cred_list)
 
         new_object_params['globalCredentialIdList'] = credential_ids

--- a/plugins/modules/discovery_workflow_manager.py
+++ b/plugins/modules/discovery_workflow_manager.py
@@ -206,28 +206,29 @@ options:
                 type: str
       global_credentials:
         description:
-            - Credentials that are already created by the user under Device Credentials in Cisco Catalyst Center.
+            - Set of various credential types, including CLI, SNMP, HTTP, and NETCONF, that a user has pre-configured in
+                the Device Credentials section of the Cisco Catalyst Center.
             - If user doesn't pass any global credentials in the playbook, then by default, we will use all the global
                 credentials present in the Cisco Catalyst Center of each type for performing discovery. (Max 5 allowed)
         type: dict
         suboptions:
             cli_credentials_list:
                 description:
-                    - List of Global CLI credentials to be used during device discovery.
-                    - Generally it is advised to create device credentials with unique username or description.
+                   - Accepts a list of global CLI credentials for use in device discovery.
+                   - It's recommended to create device credentials with both a unique username and a clear description.
                 type: list
                 elements: dict
                 suboptions:
                     username:
-                        description: Username for CLI authentication, mandatory when using global CLI credentials.
+                        description: Username required for CLI authentication and is mandatory when using global CLI credentials.
                         type: str
                     description:
                         description: Name of the CLI credential, mandatory when using global CLI credentials.
                         type: str
             http_read_credential_list:
                 description:
-                    - List of Global HTTP Read credentials to be used during device discovery.
-                    - Generally it is advised to create device credentials with unique username or description.
+                    - List of global HTTP Read credentials that will be used in the process of discovering devices.
+                    - It's recommended to create device credentials with both a unique username and a clear description for easy identification.
                 type: list
                 elements: dict
                 suboptions:
@@ -239,8 +240,8 @@ options:
                         type: str
             http_write_credential_list:
                 description:
-                    - List of Global HTTP Write credentials to be used during device discovery.
-                    - Generally it is advised to create device credentials with unique username or description.
+                    - List of global HTTP Write credentials that will be used in the process of discovering devices.
+                    - It's recommended to create device credentials with both a unique username and a clear description for easy identification.
                 type: list
                 elements: dict
                 suboptions:
@@ -253,7 +254,7 @@ options:
             snmp_v2_read_credential_list:
                 description:
                     - List of Global SNMP V2 Read credentials to be used during device discovery.
-                    - Generally it is advised to create device credentials with unique username or description.
+                    - It's recommended to create device credentials with both a unique username and a clear description for easy identification.
                 type: list
                 elements: dict
                 suboptions:
@@ -266,7 +267,7 @@ options:
             snmp_v2_write_credential_list:
                 description:
                     - List of Global SNMP V2 Write credentials to be used during device discovery.
-                    - Generally it is advised to create device credentials with unique username or description.
+                    - It's recommended to create device credentials with both a unique username and a clear description for easy identification.
                 type: list
                 elements: dict
                 suboptions:
@@ -279,7 +280,7 @@ options:
             snmp_v3_credential_list:
                 description:
                     - List of Global SNMP V3 credentials to be used during device discovery, giving read and write mode.
-                    - Generally it is advised to create device credentials with unique username or description.
+                    - It's recommended to create device credentials with both a unique username and a clear description for easy identification.
                 type: list
                 elements: dict
                 suboptions:
@@ -292,7 +293,7 @@ options:
             net_conf_port_list:
                 description:
                     - List of Global Net conf ports to be used during device discovery.
-                    - Generally it is advised to create device credentials with unique description.
+                    - It's recommended to create device credentials with unique description.
                 type: list
                 elements: dict
                 suboptions:
@@ -555,8 +556,7 @@ class Discovery(DnacBase):
             'retry': {'type': 'int', 'required': False},
             'timeout': {'type': 'str', 'required': False},
             'global_credentials': {'type': 'dict', 'required': False},
-            'protocol_order': {'type': 'str', 'required': False,
-                                'default': 'ssh'}
+            'protocol_order': {'type': 'str', 'required': False, 'default': 'ssh'}
         }
 
         if state == "merged":
@@ -615,17 +615,12 @@ class Discovery(DnacBase):
         """
 
         global_credentials = self.validated_config[0].get("global_credentials")
-        cli_credentials_list = global_credentials.get('cli_credentials_list')
-        http_read_credential_list = global_credentials.get('http_read_credential_list')
-        http_write_credential_list = global_credentials.get('http_write_credential_list')
-        snmp_v2_read_credential_list = global_credentials.get('snmp_v2_read_credential_list')
-        snmp_v2_write_credential_list = global_credentials.get('snmp_v2_write_credential_list')
-        snmp_v3_credential_list = global_credentials.get('snmp_v3_credential_list')
-        net_conf_port_list = global_credentials.get('net_conf_port_list')
         global_credentails_all = {}
+
+        cli_credentials_list = global_credentials.get('cli_credentials_list')
         if cli_credentials_list:
             if not isinstance(cli_credentials_list, list):
-                msg = "Global ClI credentials must be passed as a list"
+                msg = "Global CLI credentials must be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(cli_credentials_list) > 0:
                 global_credentails_all["cliCredential"] = []
@@ -642,6 +637,7 @@ class Discovery(DnacBase):
                         msg = "Kindly ensure you include both the description and the username for the Global CLI credential to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
 
+        http_read_credential_list = global_credentials.get('http_read_credential_list')
         if http_read_credential_list:
             if not isinstance(http_read_credential_list, list):
                 msg = "Global HTTP read credentials must be passed as a list"
@@ -661,6 +657,7 @@ class Discovery(DnacBase):
                         msg = "Kindly ensure you include both the description and the username for the Global HTTP Read credential to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
 
+        http_write_credential_list = global_credentials.get('http_write_credential_list')
         if http_write_credential_list:
             if not isinstance(http_write_credential_list, list):
                 msg = "Global HTTP write credentials must be passed as a list"
@@ -680,6 +677,7 @@ class Discovery(DnacBase):
                         msg = "Kindly ensure you include both the description and the username for the Global HTTP Write credential to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
 
+        snmp_v2_read_credential_list = global_credentials.get('snmp_v2_read_credential_list')
         if snmp_v2_read_credential_list:
             if not isinstance(snmp_v2_read_credential_list, list):
                 msg = "Global SNMPV2 read credentials must be passed as a list"
@@ -700,6 +698,27 @@ class Discovery(DnacBase):
                                 credential to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
 
+        snmp_v2_write_credential_list = global_credentials.get('snmp_v2_write_credential_list')
+        if snmp_v2_write_credential_list:
+            if not isinstance(snmp_v2_write_credential_list, list):
+                msg = "Global SNMPV2 write credentials must be passed as a list"
+                self.discovery_specific_cred_failure(msg=msg)
+            if len(snmp_v2_write_credential_list) > 0:
+                global_credentails_all["snmpV2cWrite"] = []
+                cred_len = len(snmp_v2_write_credential_list)
+                if cred_len > 5:
+                    cred_len = 5
+                for snmp_cred in snmp_v2_write_credential_list:
+                    if snmp_cred.get('description'):
+                        for snmp in response.get("snmpV2cWrite"):
+                            if snmp.get("description") == snmp_cred.get('description'):
+                                global_credentails_all["snmpV2cWrite"].append(snmp.get("id"))
+                        global_credentails_all["snmpV2cWrite"] = global_credentails_all["snmpV2cWrite"][:cred_len]
+                    else:
+                        msg = "Kindly ensure you include both the description and the username for the Global SNMPV2 credential to discover the devices"
+                        self.discovery_specific_cred_failure(msg=msg)
+
+        snmp_v3_credential_list = global_credentials.get('snmp_v3_credential_list')
         if snmp_v3_credential_list:
             if not isinstance(snmp_v3_credential_list, list):
                 msg = "Global SNMPV3 write credentials must be passed as a list"
@@ -720,25 +739,7 @@ class Discovery(DnacBase):
                                 to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
 
-        if snmp_v2_write_credential_list:
-            if not isinstance(snmp_v2_write_credential_list, list):
-                msg = "Global SNMPV2 write credentials must be passed as a list"
-                self.discovery_specific_cred_failure(msg=msg)
-            if len(snmp_v2_write_credential_list) > 0:
-                global_credentails_all["snmpV2cWrite"] = []
-                cred_len = len(snmp_v2_write_credential_list)
-                if cred_len > 5:
-                    cred_len = 5
-                for snmp_cred in snmp_v2_write_credential_list:
-                    if snmp_cred.get('description'):
-                        for snmp in response.get("snmpV2cWrite"):
-                            if snmp.get("description") == snmp_cred.get('description'):
-                                global_credentails_all["snmpV2cWrite"].append(snmp.get("id"))
-                        global_credentails_all["snmpV2cWrite"] = global_credentails_all["snmpV2cWrite"][:cred_len]
-                    else:
-                        msg = "Kindly ensure you include both the description and the username for the Global SNMPV2 credential to discover the devices"
-                        self.discovery_specific_cred_failure(msg=msg)
-
+        net_conf_port_list = global_credentials.get('net_conf_port_list')
         if net_conf_port_list:
             if not isinstance(net_conf_port_list, list):
                 msg = "Global net Conf Ports be passed as a list"


### PR DESCRIPTION
Problem: 1. Option to perform Discovery with any of the Snmp credentials.
                2.  Option to perform Discovery with global credentials of user's choice.
                3. Intermittent failure of discovery in Starting State.
Fix: 1. Have removed the and condition for SNMP Read and write and SNV3 to be present together.
       2. Have added option to remove Discovery with multiple global credentials as list.
       3. Have added an extra condition which checks the failure when the discovery undergoes Inventory Service.
Test Cases: 1. Execute discovery devices using MULTI RANGE with various global credentials
                     2. Execute discovery of single device using various discovery specific credentials
                     3. Execute discovery devices using MULTI RANGE with various discovery specific credentials
                     4. Execute discovery devices using CDP/LLDP/CIDR
                     5. Execute deletion of all the discoveries from the dashboard
