### PR TITLE
Fixing Invalid SWIM issue while claiming

### DIFF
--- a/plugins/modules/pnp_intent.py
+++ b/plugins/modules/pnp_intent.py
@@ -474,6 +474,7 @@ class PnP(DnacBase):
         imageinfo = {
             'imageId': self.have.get('image_id')
         }
+        template_params = self.validated_config[0].get("template_params")
         configinfo = {
             'configId': self.have.get('template_id'),
             'configParameters': [
@@ -484,11 +485,11 @@ class PnP(DnacBase):
             ]
         }
 
-        if configinfo.get("configId") and self.validated_config[0].get("template_params"):
-            if isinstance(self.validated_config[0]["template_params"], dict):
-                if len(self.validated_config[0]["template_params"]) > 0:
+        if configinfo.get("configId") and template_params:
+            if isinstance(template_params, dict):
+                if len(template_params) > 0:
                     configinfo["configParameters"] = []
-                    for key, value in self.validated_config[0]["template_params"].items():
+                    for key, value in template_params.items():
                         config_dict = {
                             'key': key,
                             'value': value

--- a/plugins/modules/pnp_intent.py
+++ b/plugins/modules/pnp_intent.py
@@ -474,7 +474,7 @@ class PnP(DnacBase):
         imageinfo = {
             'imageId': self.have.get('image_id')
         }
-
+        
         configinfo = {
             'configId': self.have.get('template_id'),
             'configParameters': [
@@ -485,7 +485,7 @@ class PnP(DnacBase):
             ]
         }
 
-        if configinfo["configId"] and self.validated_config[0]["template_params"]:
+        if configinfo.get("configId") and self.validated_config[0].get("template_params"):
             if isinstance(self.validated_config[0]["template_params"], dict):
                 if len(self.validated_config[0]["template_params"]) > 0:
                     configinfo["configParameters"] = []
@@ -609,7 +609,7 @@ class PnP(DnacBase):
                 number '{0}': {1}".format(self.want.get("serial_number"), str(device_response)), "DEBUG")
 
             if not (device_response and (len(device_response) == 1)):
-                self.log("Device with with serial number {0} is not found in the inventory".format(self.want.get("serial_number")), "WARNING")
+                self.log("Device with serial number {0} is not found in the inventory".format(self.want.get("serial_number")), "WARNING")
                 self.msg = "Adding the device to database"
                 self.status = "success"
                 self.have = have
@@ -893,6 +893,7 @@ class PnP(DnacBase):
                     params=self.want.get("pnp_params")[0],
                     op_modifies=True,
                 )
+                self.get_have().check_return_status()
                 self.have["deviceInfo"] = dev_add_response.get("deviceInfo")
                 self.log("Response from API 'add device' for single device addition: {0}".format(str(dev_add_response)), "DEBUG")
                 claim_params = self.get_claim_params()
@@ -905,8 +906,7 @@ class PnP(DnacBase):
                 )
 
                 self.log("Response from API 'claim a device to a site' for a single claiming: {0}".format(str(dev_add_response)), "DEBUG")
-                if claim_response.get("response") == "Device Claimed" \
-                        and self.have["deviceInfo"]:
+                if claim_response.get("response") == "Device Claimed" and self.have["deviceInfo"]:
                     self.result['msg'] = "Device Added and Claimed Successfully"
                     self.log(self.result['msg'], "INFO")
                     self.result['response'] = claim_response

--- a/plugins/modules/pnp_intent.py
+++ b/plugins/modules/pnp_intent.py
@@ -474,7 +474,6 @@ class PnP(DnacBase):
         imageinfo = {
             'imageId': self.have.get('image_id')
         }
-        
         configinfo = {
             'configId': self.have.get('template_id'),
             'configParameters': [

--- a/plugins/modules/pnp_workflow_manager.py
+++ b/plugins/modules/pnp_workflow_manager.py
@@ -474,6 +474,7 @@ class PnP(DnacBase):
         imageinfo = {
             'imageId': self.have.get('image_id')
         }
+        template_params = self.validated_config[0].get("template_params")
         configinfo = {
             'configId': self.have.get('template_id'),
             'configParameters': [
@@ -484,11 +485,11 @@ class PnP(DnacBase):
             ]
         }
 
-        if configinfo.get("configId") and self.validated_config[0].get("template_params"):
-            if isinstance(self.validated_config[0]["template_params"], dict):
-                if len(self.validated_config[0]["template_params"]) > 0:
+        if configinfo.get("configId") and template_params:
+            if isinstance(template_params, dict):
+                if len(template_params) > 0:
                     configinfo["configParameters"] = []
-                    for key, value in self.validated_config[0]["template_params"].items():
+                    for key, value in template_params.items():
                         config_dict = {
                             'key': key,
                             'value': value

--- a/plugins/modules/pnp_workflow_manager.py
+++ b/plugins/modules/pnp_workflow_manager.py
@@ -485,7 +485,7 @@ class PnP(DnacBase):
             ]
         }
 
-        if configinfo["configId"] and self.validated_config[0]["template_params"]:
+        if configinfo.get("configId") and self.validated_config[0].get("template_params"):
             if isinstance(self.validated_config[0]["template_params"], dict):
                 if len(self.validated_config[0]["template_params"]) > 0:
                     configinfo["configParameters"] = []
@@ -609,7 +609,7 @@ class PnP(DnacBase):
                 number '{0}': {1}".format(self.want.get("serial_number"), str(device_response)), "DEBUG")
 
             if not (device_response and (len(device_response) == 1)):
-                self.log("Device with with serial number {0} is not found in the inventory".format(self.want.get("serial_number")), "WARNING")
+                self.log("Device with serial number {0} is not found in the inventory".format(self.want.get("serial_number")), "WARNING")
                 self.msg = "Adding the device to database"
                 self.status = "success"
                 self.have = have
@@ -893,6 +893,7 @@ class PnP(DnacBase):
                     params=self.want.get("pnp_params")[0],
                     op_modifies=True,
                 )
+                self.get_have().check_return_status()
                 self.have["deviceInfo"] = dev_add_response.get("deviceInfo")
                 self.log("Response from API 'add device' for single device addition: {0}".format(str(dev_add_response)), "DEBUG")
                 claim_params = self.get_claim_params()
@@ -905,8 +906,7 @@ class PnP(DnacBase):
                 )
 
                 self.log("Response from API 'claim a device to a site' for a single claiming: {0}".format(str(dev_add_response)), "DEBUG")
-                if claim_response.get("response") == "Device Claimed" \
-                        and self.have["deviceInfo"]:
+                if claim_response.get("response") == "Device Claimed" and self.have["deviceInfo"]:
                     self.result['msg'] = "Device Added and Claimed Successfully"
                     self.log(self.result['msg'], "INFO")
                     self.result['response'] = claim_response

--- a/plugins/modules/pnp_workflow_manager.py
+++ b/plugins/modules/pnp_workflow_manager.py
@@ -474,7 +474,6 @@ class PnP(DnacBase):
         imageinfo = {
             'imageId': self.have.get('image_id')
         }
-
         configinfo = {
             'configId': self.have.get('template_id'),
             'configParameters': [


### PR DESCRIPTION
1.  **Git PR Link**: https://github.com/madhansansel/dnacenter-ansible/pull/181
2.  **Problem Description**: When we provide an invalid image name/site details, we see an error coming on the GUI, without proper error handling.
3.  **Root Cause:** We tried to perform PnP of a EWLC using an invalid image. The device was not added in the PnP database. We tried to claim it just after adding it to the PnP database.
4.  **Code Changes:** Called get_have method in get_diff_merged to fetch the site/image values post adding it to the PnP database.
5.  **Testing and Automation:**
    _PnP.yml_


TASK [Claim an existing Wireless Controller, apply a template, and upgrade its image for a specified site] *********************************************************************************************
task path: /home/admin/madhan_ansible/collections/ansible_collections/cisco/dnac/playbooks/PnP.yml:113
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: admin
<127.0.0.1> EXEC /bin/sh -c 'echo ~admin && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/admin/.ansible/tmp `"&& mkdir "` echo /home/admin/.ansible/tmp/ansible-tmp-1709548933.2167194-2686148-97777508565436 `" && echo ansible-tmp-1709548933.2167194-2686148-97777508565436="` echo /home/admin/.ansible/tmp/ansible-tmp-1709548933.2167194-2686148-97777508565436 `" ) && sleep 0'
Using module file /home/admin/madhan_ansible/collections/ansible_collections/cisco/dnac/plugins/modules/pnp_intent.py
<127.0.0.1> PUT /home/admin/.ansible/tmp/ansible-local-2685602yxwbgwqq/tmpiucimk8h TO /home/admin/.ansible/tmp/ansible-tmp-1709548933.2167194-2686148-97777508565436/AnsiballZ_pnp_intent.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/admin/.ansible/tmp/ansible-tmp-1709548933.2167194-2686148-97777508565436/ /home/admin/.ansible/tmp/ansible-tmp-1709548933.2167194-2686148-97777508565436/AnsiballZ_pnp_intent.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/home/admin/pyats_env/bin/python3 /home/admin/.ansible/tmp/ansible-tmp-1709548933.2167194-2686148-97777508565436/AnsiballZ_pnp_intent.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/admin/.ansible/tmp/ansible-tmp-1709548933.2167194-2686148-97777508565436/ > /dev/null 2>&1 && sleep 0'
fatal: [localhost]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "config": [
                {
                    "device_info": [
                        {
                            "hostname": "New_WLC",
                            "pid": "C9800-CL-K9",
                            "serial_number": "abinash123",
                            "state": "Unclaimed"
                        }
                    ],
                    "gateway": "204.192.101.1",
                    "image_name": "aaa",
                    "ip_interface_name": "TenGigabitEthernet0/0/0",
                    "pnp_type": "CatalystWLC",
                    "site_name": "Global/USA/San Francisco/BGL_18",
                    "static_ip": "204.192.101.10",
                    "subnet_mask": "255.255.255.0",
                    "template_name": "Ansible_PNP_WLC",
                    "template_params": {
                        "hostname": "IAC-EWLC-Claimed"
                    },
                    "vlan_id": 1101
                }
            ],
            "config_verify": false,
            "dnac_debug": true,
            "dnac_host": "172.23.241.186",
            "dnac_log": true,
            "dnac_log_append": true,
            "dnac_log_file_path": "dnac.log",
            "dnac_log_level": "DEBUG",
            "dnac_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "dnac_port": "443",
            "dnac_username": "admin",
            "dnac_verify": false,
            "dnac_version": "2.3.5.3",
            "state": "merged",
            "validate_response_schema": true
        }
    },
    "msg": "The image 'aaa' is either not present or not tagged as 'Golden' in the Cisco Catalyst Center. Please verify its existence and its tag status.",
    "response": []
}

PLAY RECAP *********************************************************************************************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
                       
