### PR TITLE
Fixed the language enum check for the name instead of language

### DIFF
--- a/plugins/modules/template_intent.py
+++ b/plugins/modules/template_intent.py
@@ -1784,12 +1784,12 @@ class DnacTemplate(DnacBase):
             containingTemplates[i].update({"name": name})
 
             language = item.get("language")
-            language_list = ["JINJA", "VELOCITY"]
             if language is None:
                 self.msg = "language is mandatory under containing templates"
                 self.status = "failed"
                 return self.check_return_status()
 
+            language_list = ["JINJA", "VELOCITY"]
             if language not in language_list:
                 self.msg = "language under containing templates should be in " + str(language_list)
                 self.status = "failed"

--- a/plugins/modules/template_intent.py
+++ b/plugins/modules/template_intent.py
@@ -1776,25 +1776,26 @@ class DnacTemplate(DnacBase):
                 containingTemplates[i].update({"id": id})
 
             name = item.get("name")
-            if name is not None:
-                containingTemplates[i].update({"name": name})
-            else:
+            if name is None:
                 self.msg = "name is mandatory under containing templates"
                 self.status = "failed"
                 return self.check_return_status()
 
+            containingTemplates[i].update({"name": name})
+
             language = item.get("language")
             language_list = ["JINJA", "VELOCITY"]
-            if language is not None:
-                containingTemplates[i].update({"language": language})
-            else:
+            if language is None:
                 self.msg = "language is mandatory under containing templates"
                 self.status = "failed"
                 return self.check_return_status()
+
             if language not in language_list:
                 self.msg = "language under containing templates should be in " + str(language_list)
                 self.status = "failed"
                 return self.check_return_status()
+
+            containingTemplates[i].update({"language": language})
 
             project_name = item.get("project_name")
             if project_name is not None:

--- a/plugins/modules/template_intent.py
+++ b/plugins/modules/template_intent.py
@@ -1775,24 +1775,24 @@ class DnacTemplate(DnacBase):
             if id is not None:
                 containingTemplates[i].update({"id": id})
 
-            language = item.get("language")
-            if language is not None:
-                containingTemplates[i].update({"language": language})
-            else:
-                self.msg = "language is mandatory under containing templates"
-                self.status = "failed"
-                return self.check_return_status()
-
             name = item.get("name")
-            name_list = ["JINJA", "VELOCITY"]
             if name is not None:
                 containingTemplates[i].update({"name": name})
             else:
                 self.msg = "name is mandatory under containing templates"
                 self.status = "failed"
                 return self.check_return_status()
-            if name not in name_list:
-                self.msg = "name under containing templates should be in " + str(name_list)
+
+            language = item.get("language")
+            language_list = ["JINJA", "VELOCITY"]
+            if language is not None:
+                containingTemplates[i].update({"language": language})
+            else:
+                self.msg = "language is mandatory under containing templates"
+                self.status = "failed"
+                return self.check_return_status()
+            if language not in language_list:
+                self.msg = "language under containing templates should be in " + str(language_list)
                 self.status = "failed"
                 return self.check_return_status()
 

--- a/plugins/modules/template_workflow_manager.py
+++ b/plugins/modules/template_workflow_manager.py
@@ -1775,24 +1775,24 @@ class Template(DnacBase):
             if id is not None:
                 containingTemplates[i].update({"id": id})
 
-            language = item.get("language")
-            if language is not None:
-                containingTemplates[i].update({"language": language})
-            else:
-                self.msg = "language is mandatory under containing templates"
-                self.status = "failed"
-                return self.check_return_status()
-
             name = item.get("name")
-            name_list = ["JINJA", "VELOCITY"]
             if name is not None:
                 containingTemplates[i].update({"name": name})
             else:
                 self.msg = "name is mandatory under containing templates"
                 self.status = "failed"
                 return self.check_return_status()
-            if name not in name_list:
-                self.msg = "name under containing templates should be in " + str(name_list)
+
+            language = item.get("language")
+            language_list = ["JINJA", "VELOCITY"]
+            if language is not None:
+                containingTemplates[i].update({"language": language})
+            else:
+                self.msg = "language is mandatory under containing templates"
+                self.status = "failed"
+                return self.check_return_status()
+            if language not in language_list:
+                self.msg = "language under containing templates should be in " + str(language_list)
                 self.status = "failed"
                 return self.check_return_status()
 

--- a/plugins/modules/template_workflow_manager.py
+++ b/plugins/modules/template_workflow_manager.py
@@ -1776,25 +1776,26 @@ class Template(DnacBase):
                 containingTemplates[i].update({"id": id})
 
             name = item.get("name")
-            if name is not None:
-                containingTemplates[i].update({"name": name})
-            else:
+            if name is None:
                 self.msg = "name is mandatory under containing templates"
                 self.status = "failed"
                 return self.check_return_status()
 
+            containingTemplates[i].update({"name": name})
+
             language = item.get("language")
             language_list = ["JINJA", "VELOCITY"]
-            if language is not None:
-                containingTemplates[i].update({"language": language})
-            else:
+            if language is None:
                 self.msg = "language is mandatory under containing templates"
                 self.status = "failed"
                 return self.check_return_status()
+
             if language not in language_list:
                 self.msg = "language under containing templates should be in " + str(language_list)
                 self.status = "failed"
                 return self.check_return_status()
+
+            containingTemplates[i].update({"language": language})
 
             project_name = item.get("project_name")
             if project_name is not None:

--- a/plugins/modules/template_workflow_manager.py
+++ b/plugins/modules/template_workflow_manager.py
@@ -1784,12 +1784,12 @@ class Template(DnacBase):
             containingTemplates[i].update({"name": name})
 
             language = item.get("language")
-            language_list = ["JINJA", "VELOCITY"]
             if language is None:
                 self.msg = "language is mandatory under containing templates"
                 self.status = "failed"
                 return self.check_return_status()
 
+            language_list = ["JINJA", "VELOCITY"]
             if language not in language_list:
                 self.msg = "language under containing templates should be in " + str(language_list)
                 self.status = "failed"


### PR DESCRIPTION
Review - 1 [04-03-2024 (DD/MM/YYYY]
## 1. Problem Description
              The language enum - ["JINJA", "VELOCITY"] is checking the name not the language.

## 2. Root Cause
               While passing language other than 'JINJA' and 'VELOCITY', no error is getting triggered.

## 3. Code changes
            Changed the name_list = ["JINJA", "VELOCITY"] to language and corrected the mismatched name and language by interchanging the 'name' and 'language'.

## 4. Testing and automation changes
          Passed the language input other than 'JINJA' and 'VELOCITY' and the error is getting triggered.