### PR TITLE
Handle the case if site name is not given then will site name as “Glo…

### DIFF
--- a/plugins/modules/swim_intent.py
+++ b/plugins/modules/swim_intent.py
@@ -497,7 +497,6 @@ from ansible_collections.cisco.dnac.plugins.module_utils.dnac import (
 )
 from ansible.module_utils.basic import AnsibleModule
 import os
-import json
 
 
 class DnacSwims(DnacBase):

--- a/plugins/modules/swim_intent.py
+++ b/plugins/modules/swim_intent.py
@@ -792,27 +792,27 @@ class DnacSwims(DnacBase):
 
         device_response = device_list_response.get('response')
         if not response or not device_response:
-            self.log("Failed to retrieve devices associated with the site due to empty API response.")
+            self.log("Failed to retrieve devices associated with the site '{0}' due to empty API response.".format(site_name), "INFO")
             return device_uuid_list
 
         site_memberships_ids, device_response_ids = [], []
 
         for item in site_response_list:
             if item["reachabilityStatus"] != "Reachable":
-                self.log("""Reachability status of device '{0}' is '{1}', so cannot add it for distribution/activation
-                            task of swim image""".format(item["managementIpAddress"], item["reachabilityStatus"]), "INFO")
+                self.log("""Device '{0}' is currently '{1}' and cannot be included in the SWIM distribution/activation
+                            process.""".format(item["managementIpAddress"], item["reachabilityStatus"]), "INFO")
                 continue
-            self.log("""Successfully fetched the device '{0}' associated with the given site '{1}' for SWIM distribution/activation
-                        task.""".format(item["managementIpAddress"], site_name))
+            self.log("""Device '{0}' from site '{1}' is ready for the SWIM distribution/activation
+                        process.""".format(item["managementIpAddress"], site_name), "INFO")
             site_memberships_ids.append(item["instanceUuid"])
 
         for item in device_response:
             if item["reachabilityStatus"] != "Reachable":
-                self.log("""Reachability status of device '{0}' is '{1}', so cannot add it for distribution/activation
-                            task of swim image""".format(item["managementIpAddress"], item["reachabilityStatus"]), "INFO")
+                self.log("""Unable to proceed with the device '{0}' for SWIM distribution/activation as its status is
+                            '{1}'.""".format(item["managementIpAddress"], item["reachabilityStatus"]), "INFO")
                 continue
-            self.log("""Successfully fetched the device '{0}' with given device filter for SWIM distribution/activation
-                        task.""".format(item["managementIpAddress"]))
+            self.log("""Device '{0}' matches to the specified filter requirements and is set for SWIM
+                      distribution/activation.""".format(item["managementIpAddress"]), "INFO")
             device_response_ids.append(item["instanceUuid"])
 
         # Find the intersection of device IDs with the response get from get_membership api and get_device_list api with provided filters

--- a/plugins/modules/swim_intent.py
+++ b/plugins/modules/swim_intent.py
@@ -497,6 +497,7 @@ from ansible_collections.cisco.dnac.plugins.module_utils.dnac import (
 )
 from ansible.module_utils.basic import AnsibleModule
 import os
+import json
 
 
 class DnacSwims(DnacBase):
@@ -741,8 +742,8 @@ class DnacSwims(DnacBase):
 
         device_uuid_list = []
         if not site_name:
-            self.log("Failed to retrieve devices associated with the site due to missing site name", "INFO")
-            return device_uuid_list
+            site_name = "Global"
+            self.log("Since site name is not given so it will be fetch all the devices under Global and mark site name as 'Global'", "INFO")
 
         (site_exists, site_id) = self.site_exists(site_name)
         if not site_exists:
@@ -758,8 +759,7 @@ class DnacSwims(DnacBase):
 
         site_params = {
             "site_id": site_id,
-            "device_family": device_family,
-            "device_series_name": device_series_name
+            "device_family": device_family
         }
         response = self.dnac._exec(
             family="sites",
@@ -768,18 +768,56 @@ class DnacSwims(DnacBase):
             params=site_params,
         )
         self.log("Received API response from 'get_membership': {0}".format(str(response)), "DEBUG")
-        response = response['device'][0]['response']
+        response = response['device']
 
-        if len(response) > 0:
-            for item in response:
-                if item["reachabilityStatus"] != "Reachable":
-                    self.log("""Reachability status of device '{0}' is '{1}', so cannot add it for distribution/activation
-                              task of swim image""".format(item["managementIpAddress"], item["reachabilityStatus"]), "INFO")
-                    continue
-                if "role" in item and (device_role is None or item["role"] == device_role.upper() or device_role.upper() == "ALL"):
-                    self.log("""Successfully fetched the device '{0}' associated with the given site '{1}' for SWIM distribution/activation
-                              task.""".format(item["managementIpAddress"], site_name))
-                    device_uuid_list.append(item["instanceUuid"])
+        site_response_list = []
+        for item in response:
+            if item['response']:
+                for item_dict in item['response']:
+                    site_response_list.append(item_dict)
+
+        if device_role.upper() == 'ALL':
+            device_role = None
+
+        device_params = {
+            'series': device_series_name,
+            'family': device_family,
+            'role': device_role
+        }
+        device_list_response = self.dnac._exec(
+            family="devices",
+            function='get_device_list',
+            op_modifies=True,
+            params=device_params,
+        )
+
+        device_response = device_list_response.get('response')
+        if not response or not device_response:
+            self.log("Failed to retrieve devices associated with the site due to empty API response.")
+            return device_uuid_list
+
+        site_memberships_ids, device_response_ids = [], []
+
+        for item in site_response_list:
+            if item["reachabilityStatus"] != "Reachable":
+                self.log("""Reachability status of device '{0}' is '{1}', so cannot add it for distribution/activation
+                            task of swim image""".format(item["managementIpAddress"], item["reachabilityStatus"]), "INFO")
+                continue
+            self.log("""Successfully fetched the device '{0}' associated with the given site '{1}' for SWIM distribution/activation
+                        task.""".format(item["managementIpAddress"], site_name))
+            site_memberships_ids.append(item["instanceUuid"])
+
+        for item in device_response:
+            if item["reachabilityStatus"] != "Reachable":
+                self.log("""Reachability status of device '{0}' is '{1}', so cannot add it for distribution/activation
+                            task of swim image""".format(item["managementIpAddress"], item["reachabilityStatus"]), "INFO")
+                continue
+            self.log("""Successfully fetched the device '{0}' with given device filter for SWIM distribution/activation
+                        task.""".format(item["managementIpAddress"]))
+            device_response_ids.append(item["instanceUuid"])
+
+        # Find the intersection of device IDs with the response get from get_membership api and get_device_list api with provided filters
+        device_uuid_list = set(site_memberships_ids).intersection(set(device_response_ids))
 
         return device_uuid_list
 

--- a/plugins/modules/swim_workflow_manager.py
+++ b/plugins/modules/swim_workflow_manager.py
@@ -728,7 +728,7 @@ class Swim(DnacBase):
         device_uuid_list = []
         if not site_name:
             site_name = "Global"
-            self.log("Since site name is not given so it will be fetch all the devices under Global and mark site name as 'Global'", "INFO")
+            self.log("Site name not specified; defaulting to 'Global' to fetch all devices under this category", "INFO")
 
         (site_exists, site_id) = self.site_exists(site_name)
         if not site_exists:
@@ -778,27 +778,27 @@ class Swim(DnacBase):
 
         device_response = device_list_response.get('response')
         if not response or not device_response:
-            self.log("Failed to retrieve devices associated with the site due to empty API response.")
+            self.log("Failed to retrieve devices associated with the site '{0}' due to empty API response.".format(site_name), "INFO")
             return device_uuid_list
 
         site_memberships_ids, device_response_ids = [], []
 
         for item in site_response_list:
             if item["reachabilityStatus"] != "Reachable":
-                self.log("""Reachability status of device '{0}' is '{1}' with site membership api, so cannot add it for distribution/activation
-                            task of swim image""".format(item["managementIpAddress"], item["reachabilityStatus"]), "INFO")
+                self.log("""Device '{0}' is currently '{1}' and cannot be included in the SWIM distribution/activation
+                            process.""".format(item["managementIpAddress"], item["reachabilityStatus"]), "INFO")
                 continue
-            self.log("""Successfully fetched the device '{0}' associated with the given site '{1}' for SWIM distribution/activation
-                        task.""".format(item["managementIpAddress"], site_name))
+            self.log("""Device '{0}' from site '{1}' is ready for the SWIM distribution/activation
+                        process.""".format(item["managementIpAddress"], site_name), "INFO")
             site_memberships_ids.append(item["instanceUuid"])
 
         for item in device_response:
             if item["reachabilityStatus"] != "Reachable":
-                self.log("""Reachability status of device '{0}' is '{1}' with device list api, so cannot add it for distribution/activation
-                            task of swim image""".format(item["managementIpAddress"], item["reachabilityStatus"]), "INFO")
+                self.log("""Unable to proceed with the device '{0}' for SWIM distribution/activation as its status is
+                            '{1}'.""".format(item["managementIpAddress"], item["reachabilityStatus"]), "INFO")
                 continue
-            self.log("""Successfully fetched the device '{0}' with given device filter for SWIM distribution/activation
-                        task.""".format(item["managementIpAddress"]))
+            self.log("""Device '{0}' matches to the specified filter requirements and is set for SWIM
+                      distribution/activation.""".format(item["managementIpAddress"]), "INFO")
             device_response_ids.append(item["instanceUuid"])
 
         # Find the intersection of device IDs with the response get from get_membership api and get_device_list api with provided filters

--- a/plugins/modules/swim_workflow_manager.py
+++ b/plugins/modules/swim_workflow_manager.py
@@ -484,6 +484,7 @@ from ansible_collections.cisco.dnac.plugins.module_utils.dnac import (
 )
 from ansible.module_utils.basic import AnsibleModule
 import os
+import json
 
 
 class Swim(DnacBase):
@@ -727,8 +728,8 @@ class Swim(DnacBase):
 
         device_uuid_list = []
         if not site_name:
-            self.log("Failed to retrieve devices associated with the site due to missing site name", "INFO")
-            return device_uuid_list
+            site_name = "Global"
+            self.log("Since site name is not given so it will be fetch all the devices under Global and mark site name as 'Global'", "INFO")
 
         (site_exists, site_id) = self.site_exists(site_name)
         if not site_exists:
@@ -744,8 +745,7 @@ class Swim(DnacBase):
 
         site_params = {
             "site_id": site_id,
-            "device_family": device_family,
-            "device_series_name": device_series_name
+            "device_family": device_family
         }
         response = self.dnac._exec(
             family="sites",
@@ -754,18 +754,58 @@ class Swim(DnacBase):
             params=site_params,
         )
         self.log("Received API response from 'get_membership': {0}".format(str(response)), "DEBUG")
-        response = response['device'][0]['response']
+        response = response['device']
 
-        if len(response) > 0:
-            for item in response:
-                if item["reachabilityStatus"] != "Reachable":
-                    self.log("""Reachability status of device '{0}' is '{1}', so cannot add it for distribution/activation
-                              task of swim image""".format(item["managementIpAddress"], item["reachabilityStatus"]), "INFO")
-                    continue
-                if "role" in item and (device_role is None or item["role"] == device_role.upper() or device_role.upper() == "ALL"):
-                    self.log("""Successfully fetched the device '{0}' associated with the given site '{1}' for SWIM distribution/activation
-                              task.""".format(item["managementIpAddress"], site_name))
-                    device_uuid_list.append(item["instanceUuid"])
+        site_response_list = []
+        for item in response:
+            if item['response']:
+                for item_dict in item['response']:
+                    site_response_list.append(item_dict)
+
+        if device_role.upper() == 'ALL':
+            device_role = None
+
+        device_params = {
+            'series': device_series_name,
+            'family': device_family,
+            'role': device_role
+        }
+        device_list_response = self.dnac._exec(
+            family="devices",
+            function='get_device_list',
+            op_modifies=True,
+            params=device_params,
+        )
+
+        device_response = device_list_response.get('response')
+        if not response or not device_response:
+            self.log("Failed to retrieve devices associated with the site due to empty API response.")
+            return device_uuid_list
+
+        site_memberships_ids, device_response_ids = [], []
+
+        for item in site_response_list:
+            # import epdb;
+            # epdb.serve(port=8888)
+            if item["reachabilityStatus"] != "Reachable":
+                self.log("""Reachability status of device '{0}' is '{1}' with site membership api, so cannot add it for distribution/activation
+                            task of swim image""".format(item["managementIpAddress"], item["reachabilityStatus"]), "INFO")
+                continue
+            self.log("""Successfully fetched the device '{0}' associated with the given site '{1}' for SWIM distribution/activation
+                        task.""".format(item["managementIpAddress"], site_name))
+            site_memberships_ids.append(item["instanceUuid"])
+
+        for item in device_response:
+            if item["reachabilityStatus"] != "Reachable":
+                self.log("""Reachability status of device '{0}' is '{1}' with device list api, so cannot add it for distribution/activation
+                            task of swim image""".format(item["managementIpAddress"], item["reachabilityStatus"]), "INFO")
+                continue
+            self.log("""Successfully fetched the device '{0}' with given device filter for SWIM distribution/activation
+                        task.""".format(item["managementIpAddress"]))
+            device_response_ids.append(item["instanceUuid"])
+
+        # Find the intersection of device IDs with the response get from get_membership api and get_device_list api with provided filters
+        device_uuid_list = set(site_memberships_ids).intersection(set(device_response_ids))
 
         return device_uuid_list
 

--- a/plugins/modules/swim_workflow_manager.py
+++ b/plugins/modules/swim_workflow_manager.py
@@ -484,7 +484,6 @@ from ansible_collections.cisco.dnac.plugins.module_utils.dnac import (
 )
 from ansible.module_utils.basic import AnsibleModule
 import os
-import json
 
 
 class Swim(DnacBase):
@@ -785,8 +784,6 @@ class Swim(DnacBase):
         site_memberships_ids, device_response_ids = [], []
 
         for item in site_response_list:
-            # import epdb;
-            # epdb.serve(port=8888)
             if item["reachabilityStatus"] != "Reachable":
                 self.log("""Reachability status of device '{0}' is '{1}' with site membership api, so cannot add it for distribution/activation
                             task of swim image""".format(item["managementIpAddress"], item["reachabilityStatus"]), "INFO")


### PR DESCRIPTION
…bal” and fetch all devices under Global for getting device_uuid_list for swim distribute/activate operation.

In this commit -

— Handle the case if site name is not given then will site name as “Global” and fetch all devices under Global for getting device_uuid_list for swim distribute/activate operation.

— And then take the  intersection of device list API with given rules like - device role, device family and device series name.