### PR TITLE
Adding the feature of non-mandatory global credentials

### DIFF
--- a/playbooks/discovery_intent.yml
+++ b/playbooks/discovery_intent.yml
@@ -53,7 +53,7 @@
                   username: snmpV3
             protocol_order: ssh
 
-    - name: Execute discovery of single device using various discovery specific credentials
+    - name: Execute discovery of single device using various discovery specific credentials and all the global credentials
       cisco.dnac.discovery_intent:
         <<: *dnac_login
         state: merged
@@ -87,6 +87,43 @@
                 privacy_type: AES256
                 privacy_password: Lablab#1234
                 global_cli_len: 3
+            protocol_order: ssh
+
+    - name: Execute discovery of single device using various discovery specific credentials only
+      cisco.dnac.discovery_intent:
+        <<: *dnac_login
+        state: merged
+        config_verify: True
+        config:
+          - discovery_name: Single without Global Credentials
+            discovery_type: "SINGLE"
+            ip_address_list:
+              - 204.1.2.5
+            discovery_specific_credentials:
+              cli_credentials_list:
+              - username: cisco
+                password: Cisco#123
+                enable_password: Cisco#123
+              http_read_credential:
+                username: string
+                password: Lablab#123
+                port: 443
+                secure: True
+              snmp_v2_read_credential:
+                desc: string
+                community: string
+              snmp_v2_write_credential:
+                desc: string
+                community: string
+              snmp_v3_credential:
+                username: v3Public2
+                snmp_mode: AUTHPRIV
+                auth_type: SHA
+                auth_password: Lablab#1234
+                privacy_type: AES256
+                privacy_password: Lablab#1234
+                global_cli_len: 3
+            use_global_cred: False
             protocol_order: ssh
 
     - name: Execute discovery devices using MULTI RANGE with various discovery specific credentials

--- a/playbooks/discovery_workflow_manager.yml
+++ b/playbooks/discovery_workflow_manager.yml
@@ -53,7 +53,7 @@
                   username: snmpV3
             protocol_order: ssh
 
-    - name: Execute discovery of single device using various discovery specific credentials
+    - name: Execute discovery of single device using various discovery specific credentials and all the global credentials
       cisco.dnac.discovery_workflow_manager:
         <<: *dnac_login
         state: merged
@@ -87,6 +87,43 @@
                 privacy_type: AES256
                 privacy_password: Lablab#1234
                 global_cli_len: 3
+            protocol_order: ssh
+
+    - name: Execute discovery of single device using various discovery specific credentials only
+      cisco.dnac.discovery_workflow_manager:
+        <<: *dnac_login
+        state: merged
+        config_verify: True
+        config:
+          - discovery_name: Single without Global Credentials
+            discovery_type: "SINGLE"
+            ip_address_list:
+              - 204.1.2.5
+            discovery_specific_credentials:
+              cli_credentials_list:
+              - username: cisco
+                password: Cisco#123
+                enable_password: Cisco#123
+              http_read_credential:
+                username: string
+                password: Lablab#123
+                port: 443
+                secure: True
+              snmp_v2_read_credential:
+                desc: string
+                community: string
+              snmp_v2_write_credential:
+                desc: string
+                community: string
+              snmp_v3_credential:
+                username: v3Public2
+                snmp_mode: AUTHPRIV
+                auth_type: SHA
+                auth_password: Lablab#1234
+                privacy_type: AES256
+                privacy_password: Lablab#1234
+                global_cli_len: 3
+            use_global_cred: False
             protocol_order: ssh
 
     - name: Execute discovery devices using MULTI RANGE with various discovery specific credentials

--- a/plugins/modules/discovery_intent.py
+++ b/plugins/modules/discovery_intent.py
@@ -79,6 +79,13 @@ options:
         description: Preferred method for the management of the IP (None/UseLoopBack)
         type: str
         default: None
+      use_global_credentials:
+        description:
+            - Determines if device discovery should utilize pre-configured global credentials.
+            - Setting to True employs the predefined global credentials for discovery tasks. This is the default setting.
+            - Setting to False requires manually provided, device-specific credentials for discovery, as global credentials will be bypassed.
+        type: bool
+        default: True
       discovery_specific_credentials:
         description: Credentials specifically created by the user for performing device discovery.
         type: dict
@@ -204,13 +211,6 @@ options:
                     - Requires valid SSH credentials to work.
                     - Avoid standard ports like 22, 80, and 8080.
                 type: str
-      use_global_cred:
-        description:
-            - Boolean value to determine whether the user wants to use the global credentials by default while performing discovery.
-            - If set to False, global credentials will not be used to discover the devices, and at least one discovery-specific SNMP
-                and CLI credential is required.
-        type: bool
-        default: True
       global_credentials:
         description:
             - Set of various credential types, including CLI, SNMP, HTTP, and NETCONF, that a user has pre-configured in
@@ -485,7 +485,7 @@ EXAMPLES = r"""
                 privacy_type: string
                 privacy_password: string
             net_conf_port: string
-          use_global_cred: False
+          use_global_credentials: False
           start_index: integer
           records_to_return: integer
           protocol_order: string
@@ -621,7 +621,7 @@ class Discovery(DnacBase):
             'timeout': {'type': 'str', 'required': False},
             'global_credentials': {'type': 'dict', 'required': False},
             'protocol_order': {'type': 'str', 'required': False, 'default': 'ssh'},
-            'use_global_cred': {'type': 'bool', 'required': False,
+            'use_global_credentials': {'type': 'bool', 'required': False,
                                 'default': True}
         }
 
@@ -1125,7 +1125,7 @@ class Discovery(DnacBase):
         if self.validated_config[0].get('discovery_specific_credentials'):
             self.handle_discovery_specific_credentials(new_object_params=new_object_params)
 
-        global_cred_flag = self.validated_config[0].get('use_global_cred')
+        global_cred_flag = self.validated_config[0].get('use_global_credentials')
         global_credentials_all = {}
 
         if global_cred_flag is True:

--- a/plugins/modules/discovery_intent.py
+++ b/plugins/modules/discovery_intent.py
@@ -204,6 +204,12 @@ options:
                     - Requires valid SSH credentials to work.
                     - Avoid standard ports like 22, 80, and 8080.
                 type: str
+      use_global_cred:
+        description:
+            - Boolean value to determine whether the user wants to use the global credentials by default while performing discovery.
+            - If set False, global credentials will not be used to discover the devices.
+        type: bool
+        default: True
       global_credentials:
         description:
             - Set of various credential types, including CLI, SNMP, HTTP, and NETCONF, that a user has pre-configured in
@@ -351,7 +357,7 @@ notes:
 """
 
 EXAMPLES = r"""
-- name: Execute discovery devices
+- name: Execute discovery devices with both global credentials and discovery specific credentials
   cisco.dnac.discovery_intent:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
@@ -422,6 +428,63 @@ EXAMPLES = r"""
                   username: string
             net_conf_port_list:
                 - description: string
+          start_index: integer
+          records_to_return: integer
+          protocol_order: string
+          retry: integer
+          timeout: integer
+
+- name: Execute discovery devices with discovery specific credentials only
+  cisco.dnac.discovery_intent:
+    dnac_host: "{{dnac_host}}"
+    dnac_username: "{{dnac_username}}"
+    dnac_password: "{{dnac_password}}"
+    dnac_verify: "{{dnac_verify}}"
+    dnac_port: "{{dnac_port}}"
+    dnac_version: "{{dnac_version}}"
+    dnac_debug: "{{dnac_debug}}"
+    dnac_log: True
+    dnac_log_level: "{{dnac_log_level}}"
+    state: merged
+    config_verify: True
+    config:
+        - discovery_name: string
+          discovery_type: string
+          ip_address_list: list
+          ip_filter_list: list
+          cdp_level: string
+          lldp_level: string
+          prefered_mgmt_ip_method: string
+          discovery_specific_credentials:
+            cli_credentials_list:
+                - username: string
+                  password: string
+                  enable_password: string
+            http_read_credential:
+                username: string
+                password: string
+                port: integer
+                secure: boolean
+            http_write_credential:
+                username: string
+                password: string
+                port: integer
+                secure: boolean
+            snmp_v2_read_credential:
+                desc: string
+                community: string
+            snmp_v2_write_credential:
+                desc: string
+                community: string
+            snmp_v3_credential:
+                username: string
+                snmp_mode: string
+                auth_password: string
+                auth_type: string
+                privacy_type: string
+                privacy_password: string
+            net_conf_port: string
+          use_global_cred: False
           start_index: integer
           records_to_return: integer
           protocol_order: string
@@ -556,7 +619,9 @@ class Discovery(DnacBase):
             'retry': {'type': 'int', 'required': False},
             'timeout': {'type': 'str', 'required': False},
             'global_credentials': {'type': 'dict', 'required': False},
-            'protocol_order': {'type': 'str', 'required': False, 'default': 'ssh'}
+            'protocol_order': {'type': 'str', 'required': False, 'default': 'ssh'},
+            'use_global_cred': {'type': 'bool', 'required': False,
+                                'default': True}
         }
 
         if state == "merged":
@@ -610,12 +675,12 @@ class Discovery(DnacBase):
             - response: The response collected from the get_all_global_credentials_v2 API
 
         Returns:
-            - global_credentails_all  : The dictionary containing list of IDs of various types of
+            - global_credentials_all  : The dictionary containing list of IDs of various types of
                                     Global credentials.
         """
 
         global_credentials = self.validated_config[0].get("global_credentials")
-        global_credentails_all = {}
+        global_credentials_all = {}
 
         cli_credentials_list = global_credentials.get('cli_credentials_list')
         if cli_credentials_list:
@@ -623,7 +688,7 @@ class Discovery(DnacBase):
                 msg = "Global CLI credentials must be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(cli_credentials_list) > 0:
-                global_credentails_all["cliCredential"] = []
+                global_credentials_all["cliCredential"] = []
                 cred_len = len(cli_credentials_list)
                 if cred_len > 5:
                     cred_len = 5
@@ -631,8 +696,8 @@ class Discovery(DnacBase):
                     if cli_cred.get('description') and cli_cred.get('username'):
                         for cli in response.get("cliCredential"):
                             if cli.get("description") == cli_cred.get('description') and cli.get("username") == cli_cred.get('username'):
-                                global_credentails_all["cliCredential"].append(cli.get("id"))
-                        global_credentails_all["cliCredential"] = global_credentails_all["cliCredential"][:cred_len]
+                                global_credentials_all["cliCredential"].append(cli.get("id"))
+                        global_credentials_all["cliCredential"] = global_credentials_all["cliCredential"][:cred_len]
                     else:
                         msg = "Kindly ensure you include both the description and the username for the Global CLI credential to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
@@ -643,7 +708,7 @@ class Discovery(DnacBase):
                 msg = "Global HTTP read credentials must be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(http_read_credential_list) > 0:
-                global_credentails_all["httpsRead"] = []
+                global_credentials_all["httpsRead"] = []
                 cred_len = len(http_read_credential_list)
                 if cred_len > 5:
                     cred_len = 5
@@ -651,8 +716,8 @@ class Discovery(DnacBase):
                     if http_cred.get('description') and http_cred.get('username'):
                         for http in response.get("httpsRead"):
                             if http.get("description") == http.get('description') and http.get("username") == http.get('username'):
-                                global_credentails_all["httpsRead"].append(http.get("id"))
-                        global_credentails_all["httpsRead"] = global_credentails_all["httpsRead"][:cred_len]
+                                global_credentials_all["httpsRead"].append(http.get("id"))
+                        global_credentials_all["httpsRead"] = global_credentials_all["httpsRead"][:cred_len]
                     else:
                         msg = "Kindly ensure you include both the description and the username for the Global HTTP Read credential to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
@@ -663,7 +728,7 @@ class Discovery(DnacBase):
                 msg = "Global HTTP write credentials must be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(http_write_credential_list) > 0:
-                global_credentails_all["httpsWrite"] = []
+                global_credentials_all["httpsWrite"] = []
                 cred_len = len(http_write_credential_list)
                 if cred_len > 5:
                     cred_len = 5
@@ -671,8 +736,8 @@ class Discovery(DnacBase):
                     if http_cred.get('description') and http_cred.get('username'):
                         for http in response.get("httpsWrite"):
                             if http.get("description") == http.get('description') and http.get("username") == http.get('username'):
-                                global_credentails_all["httpsWrite"].append(http.get("id"))
-                        global_credentails_all["httpsWrite"] = global_credentails_all["httpsWrite"][:cred_len]
+                                global_credentials_all["httpsWrite"].append(http.get("id"))
+                        global_credentials_all["httpsWrite"] = global_credentials_all["httpsWrite"][:cred_len]
                     else:
                         msg = "Kindly ensure you include both the description and the username for the Global HTTP Write credential to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
@@ -683,7 +748,7 @@ class Discovery(DnacBase):
                 msg = "Global SNMPV2 read credentials must be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(snmp_v2_read_credential_list) > 0:
-                global_credentails_all["snmpV2cRead"] = []
+                global_credentials_all["snmpV2cRead"] = []
                 cred_len = len(snmp_v2_read_credential_list)
                 if cred_len > 5:
                     cred_len = 5
@@ -691,8 +756,8 @@ class Discovery(DnacBase):
                     if snmp_cred.get('description'):
                         for snmp in response.get("snmpV2cRead"):
                             if snmp.get("description") == snmp_cred.get('description'):
-                                global_credentails_all["snmpV2cRead"].append(snmp.get("id"))
-                        global_credentails_all["snmpV2cRead"] = global_credentails_all["snmpV2cRead"][:cred_len]
+                                global_credentials_all["snmpV2cRead"].append(snmp.get("id"))
+                        global_credentials_all["snmpV2cRead"] = global_credentials_all["snmpV2cRead"][:cred_len]
                     else:
                         msg = "Kindly ensure you include both the description and the username for the Global SNMPV2 Read \
                                 credential to discover the devices"
@@ -704,7 +769,7 @@ class Discovery(DnacBase):
                 msg = "Global SNMPV2 write credentials must be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(snmp_v2_write_credential_list) > 0:
-                global_credentails_all["snmpV2cWrite"] = []
+                global_credentials_all["snmpV2cWrite"] = []
                 cred_len = len(snmp_v2_write_credential_list)
                 if cred_len > 5:
                     cred_len = 5
@@ -712,8 +777,8 @@ class Discovery(DnacBase):
                     if snmp_cred.get('description'):
                         for snmp in response.get("snmpV2cWrite"):
                             if snmp.get("description") == snmp_cred.get('description'):
-                                global_credentails_all["snmpV2cWrite"].append(snmp.get("id"))
-                        global_credentails_all["snmpV2cWrite"] = global_credentails_all["snmpV2cWrite"][:cred_len]
+                                global_credentials_all["snmpV2cWrite"].append(snmp.get("id"))
+                        global_credentials_all["snmpV2cWrite"] = global_credentials_all["snmpV2cWrite"][:cred_len]
                     else:
                         msg = "Kindly ensure you include both the description and the username for the Global SNMPV2 credential to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
@@ -724,7 +789,7 @@ class Discovery(DnacBase):
                 msg = "Global SNMPV3 write credentials must be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(snmp_v3_credential_list) > 0:
-                global_credentails_all["snmpV3"] = []
+                global_credentials_all["snmpV3"] = []
                 cred_len = len(snmp_v3_credential_list)
                 if cred_len > 5:
                     cred_len = 5
@@ -732,8 +797,8 @@ class Discovery(DnacBase):
                     if snmp_cred.get('description') and snmp_cred.get('username'):
                         for snmp in response.get("snmpV3"):
                             if snmp.get("description") == snmp_cred.get('description') and snmp.get("username") == snmp_cred.get('username'):
-                                global_credentails_all["snmpV3"].append(snmp.get("id"))
-                        global_credentails_all["snmpV3"] = global_credentails_all["snmpV3"][:cred_len]
+                                global_credentials_all["snmpV3"].append(snmp.get("id"))
+                        global_credentials_all["snmpV3"] = global_credentials_all["snmpV3"][:cred_len]
                     else:
                         msg = "Kindly ensure you include both the description and the username for the Global SNMPV3 \
                                 to discover the devices"
@@ -745,7 +810,7 @@ class Discovery(DnacBase):
                 msg = "Global net Conf Ports be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(net_conf_port_list) > 0:
-                global_credentails_all["netconfCredential"] = []
+                global_credentials_all["netconfCredential"] = []
                 cred_len = len(net_conf_port_list)
                 if cred_len > 5:
                     cred_len = 5
@@ -753,14 +818,14 @@ class Discovery(DnacBase):
                     if port.get("description"):
                         for netconf in response.get("netconfCredential"):
                             if port.get('description') == netconf.get('description'):
-                                global_credentails_all["netconfCredential"].append(netconf.get("id"))
-                        global_credentails_all["netconfCredential"] = global_credentails_all["netconfCredential"][:cred_len]
+                                global_credentials_all["netconfCredential"].append(netconf.get("id"))
+                        global_credentials_all["netconfCredential"] = global_credentials_all["netconfCredential"][:cred_len]
                     else:
                         msg = "Please provide description of the Global Netconf port to be used"
                         self.discovery_specific_cred_failure(msg=msg)
 
-        self.log("Fetched Global credentials IDs are {0}".format(global_credentails_all), "INFO")
-        return global_credentails_all
+        self.log("Fetched Global credentials IDs are {0}".format(global_credentials_all), "INFO")
+        return global_credentials_all
 
     def get_ccc_global_credentials_v2_info(self):
         """
@@ -783,31 +848,31 @@ class Discovery(DnacBase):
         )
         response = response.get('response')
         self.log("The Global credentials response from 'get all global credentials v2' API is {0}".format(str(response)), "DEBUG")
-        global_credentails_all = {}
+        global_credentials_all = {}
         global_credentials = self.validated_config[0].get("global_credentials")
         if global_credentials:
-            global_credentails_all = self.handle_global_credentials(response=response)
+            global_credentials_all = self.handle_global_credentials(response=response)
 
-        global_cred_set = set(global_credentails_all.keys())
+        global_cred_set = set(global_credentials_all.keys())
         response_cred_set = set(response.keys())
         diff_keys = response_cred_set.difference(global_cred_set)
 
         for key in diff_keys:
-            global_credentails_all[key] = []
+            global_credentials_all[key] = []
             if response[key] is None:
                 response[key] = []
             total_len = len(response[key])
             if total_len > 5:
                 total_len = 5
             for element in response.get(key):
-                global_credentails_all[key].append(element.get('id'))
-            global_credentails_all[key] = global_credentails_all[key][:total_len]
+                global_credentials_all[key].append(element.get('id'))
+            global_credentials_all[key] = global_credentials_all[key][:total_len]
 
-        if global_credentails_all == {}:
+        if global_credentials_all == {}:
             msg = 'Not found any global credentials to perform discovery'
             self.log(msg, "WARNING")
 
-        return global_credentails_all
+        return global_credentials_all
 
     def get_devices_list_info(self):
         """
@@ -1059,22 +1124,26 @@ class Discovery(DnacBase):
         if self.validated_config[0].get('discovery_specific_credentials'):
             self.handle_discovery_specific_credentials(new_object_params=new_object_params)
 
-        global_credentails_all = self.get_ccc_global_credentials_v2_info()
+        global_cred_flag = self.validated_config[0].get('use_global_cred')
+        global_credentials_all = {}
 
-        self.log(global_credentails_all, "DEBUG")
+        if global_cred_flag is True:
+            global_credentials_all = self.get_ccc_global_credentials_v2_info()
+            for global_cred_list in global_credentials_all.values():
+                credential_ids.extend(global_cred_list)
+            new_object_params['globalCredentialIdList'] = credential_ids
+
+        self.log("All the global credentials used for the discovery task are {0}".format(str(global_credentials_all)), "DEBUG")
+
         if not (new_object_params.get('snmpUserName') or new_object_params.get('snmpROCommunityDesc') or new_object_params.get('snmpRWCommunityDesc')
-                or global_credentails_all.get('snmpV2cRead') or global_credentails_all.get('snmpV2cWrite') or global_credentails_all.get('snmpV3')):
+                or global_credentials_all.get('snmpV2cRead') or global_credentials_all.get('snmpV2cWrite') or global_credentials_all.get('snmpV3')):
             msg = "Please provide atleast one valid SNMP credential to perform Discovery"
             self.discovery_specific_cred_failure(msg=msg)
 
-        if not (new_object_params.get('userNameList') or global_credentails_all.get('cliCredential')):
+        if not (new_object_params.get('userNameList') or global_credentials_all.get('cliCredential')):
             msg = "Please provide atleast one valid CLI credential to perform Discovery"
             self.discovery_specific_cred_failure(msg=msg)
 
-        for global_cred_list in global_credentails_all.values():
-            credential_ids.extend(global_cred_list)
-
-        new_object_params['globalCredentialIdList'] = credential_ids
         self.log("The payload/object created for calling the start discovery API is {0}".format(str(new_object_params)), "INFO")
 
         return new_object_params
@@ -1277,6 +1346,11 @@ class Discovery(DnacBase):
             elif any(res.get('reachabilityStatus') == 'Success' for res in devices):
                 result = True
                 self.log("Some devices in the range are reachable", "INFO")
+                break
+
+            elif all(res.get('reachabilityStatus') != 'Success' and res.get('inventoryReachabilityStatus') == 'Reachable' for res in devices):
+                result = True
+                self.log("Devices are not reachable, but discovery is completed", "WARNING")
                 break
 
             count += 1

--- a/plugins/modules/discovery_intent.py
+++ b/plugins/modules/discovery_intent.py
@@ -207,7 +207,8 @@ options:
       use_global_cred:
         description:
             - Boolean value to determine whether the user wants to use the global credentials by default while performing discovery.
-            - If set False, global credentials will not be used to discover the devices.
+            - If set to False, global credentials will not be used to discover the devices, and at least one discovery-specific SNMP
+                and CLI credential is required.
         type: bool
         default: True
       global_credentials:

--- a/plugins/modules/discovery_intent.py
+++ b/plugins/modules/discovery_intent.py
@@ -621,8 +621,7 @@ class Discovery(DnacBase):
             'timeout': {'type': 'str', 'required': False},
             'global_credentials': {'type': 'dict', 'required': False},
             'protocol_order': {'type': 'str', 'required': False, 'default': 'ssh'},
-            'use_global_credentials': {'type': 'bool', 'required': False,
-                                'default': True}
+            'use_global_credentials': {'type': 'bool', 'required': False, 'default': True}
         }
 
         if state == "merged":

--- a/plugins/modules/discovery_workflow_manager.py
+++ b/plugins/modules/discovery_workflow_manager.py
@@ -79,6 +79,13 @@ options:
         description: Preferred method for the management of the IP (None/UseLoopBack)
         type: str
         default: None
+      use_global_credentials:
+        description:
+            - Determines if device discovery should utilize pre-configured global credentials.
+            - Setting to True employs the predefined global credentials for discovery tasks. This is the default setting.
+            - Setting to False requires manually provided, device-specific credentials for discovery, as global credentials will be bypassed.
+        type: bool
+        default: True
       discovery_specific_credentials:
         description: Credentials specifically created by the user for performing device discovery.
         type: dict
@@ -204,13 +211,6 @@ options:
                     - Requires valid SSH credentials to work.
                     - Avoid standard ports like 22, 80, and 8080.
                 type: str
-      use_global_cred:
-        description:
-            - Boolean value to determine whether the user wants to use the global credentials by default while performing discovery.
-            - If set to False, global credentials will not be used to discover the devices, and at least one discovery-specific
-                SNMP and CLI credential is required.
-        type: bool
-        default: True
       global_credentials:
         description:
             - Set of various credential types, including CLI, SNMP, HTTP, and NETCONF, that a user has pre-configured in
@@ -359,7 +359,7 @@ notes:
 
 EXAMPLES = r"""
 - name: Execute discovery devices with both global credentials and discovery specific credentials
-  cisco.dnac.discovery_workflow_manager:
+  cisco.dnac.discovery_intent:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
     dnac_password: "{{dnac_password}}"
@@ -485,7 +485,7 @@ EXAMPLES = r"""
                 privacy_type: string
                 privacy_password: string
             net_conf_port: string
-          use_global_cred: False
+          use_global_credentials: False
           start_index: integer
           records_to_return: integer
           protocol_order: string
@@ -621,7 +621,7 @@ class Discovery(DnacBase):
             'timeout': {'type': 'str', 'required': False},
             'global_credentials': {'type': 'dict', 'required': False},
             'protocol_order': {'type': 'str', 'required': False, 'default': 'ssh'},
-            'use_global_cred': {'type': 'bool', 'required': False,
+            'use_global_credentials': {'type': 'bool', 'required': False,
                                 'default': True}
         }
 
@@ -1125,7 +1125,7 @@ class Discovery(DnacBase):
         if self.validated_config[0].get('discovery_specific_credentials'):
             self.handle_discovery_specific_credentials(new_object_params=new_object_params)
 
-        global_cred_flag = self.validated_config[0].get('use_global_cred')
+        global_cred_flag = self.validated_config[0].get('use_global_credentials')
         global_credentials_all = {}
 
         if global_cred_flag is True:

--- a/plugins/modules/discovery_workflow_manager.py
+++ b/plugins/modules/discovery_workflow_manager.py
@@ -204,6 +204,12 @@ options:
                     - Requires valid SSH credentials to work.
                     - Avoid standard ports like 22, 80, and 8080.
                 type: str
+      use_global_cred:
+        description:
+            - Boolean value to determine whether the user wants to use the global credentials by default while performing discovery.
+            - If set False, global credentials will not be used to discover the devices.
+        type: bool
+        default: True
       global_credentials:
         description:
             - Set of various credential types, including CLI, SNMP, HTTP, and NETCONF, that a user has pre-configured in
@@ -351,7 +357,7 @@ notes:
 """
 
 EXAMPLES = r"""
-- name: Execute discovery devices
+- name: Execute discovery devices with both global credentials and discovery specific credentials
   cisco.dnac.discovery_workflow_manager:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
@@ -422,6 +428,63 @@ EXAMPLES = r"""
                   username: string
             net_conf_port_list:
                 - description: string
+          start_index: integer
+          records_to_return: integer
+          protocol_order: string
+          retry: integer
+          timeout: integer
+
+- name: Execute discovery devices with discovery specific credentials only
+  cisco.dnac.discovery_workflow_manager:
+    dnac_host: "{{dnac_host}}"
+    dnac_username: "{{dnac_username}}"
+    dnac_password: "{{dnac_password}}"
+    dnac_verify: "{{dnac_verify}}"
+    dnac_port: "{{dnac_port}}"
+    dnac_version: "{{dnac_version}}"
+    dnac_debug: "{{dnac_debug}}"
+    dnac_log: True
+    dnac_log_level: "{{dnac_log_level}}"
+    state: merged
+    config_verify: True
+    config:
+        - discovery_name: string
+          discovery_type: string
+          ip_address_list: list
+          ip_filter_list: list
+          cdp_level: string
+          lldp_level: string
+          prefered_mgmt_ip_method: string
+          discovery_specific_credentials:
+            cli_credentials_list:
+                - username: string
+                  password: string
+                  enable_password: string
+            http_read_credential:
+                username: string
+                password: string
+                port: integer
+                secure: boolean
+            http_write_credential:
+                username: string
+                password: string
+                port: integer
+                secure: boolean
+            snmp_v2_read_credential:
+                desc: string
+                community: string
+            snmp_v2_write_credential:
+                desc: string
+                community: string
+            snmp_v3_credential:
+                username: string
+                snmp_mode: string
+                auth_password: string
+                auth_type: string
+                privacy_type: string
+                privacy_password: string
+            net_conf_port: string
+          use_global_cred: False
           start_index: integer
           records_to_return: integer
           protocol_order: string
@@ -556,7 +619,9 @@ class Discovery(DnacBase):
             'retry': {'type': 'int', 'required': False},
             'timeout': {'type': 'str', 'required': False},
             'global_credentials': {'type': 'dict', 'required': False},
-            'protocol_order': {'type': 'str', 'required': False, 'default': 'ssh'}
+            'protocol_order': {'type': 'str', 'required': False, 'default': 'ssh'},
+            'use_global_cred': {'type': 'bool', 'required': False,
+                                'default': True}
         }
 
         if state == "merged":
@@ -610,12 +675,12 @@ class Discovery(DnacBase):
             - response: The response collected from the get_all_global_credentials_v2 API
 
         Returns:
-            - global_credentails_all  : The dictionary containing list of IDs of various types of
+            - global_credentials_all  : The dictionary containing list of IDs of various types of
                                     Global credentials.
         """
 
         global_credentials = self.validated_config[0].get("global_credentials")
-        global_credentails_all = {}
+        global_credentials_all = {}
 
         cli_credentials_list = global_credentials.get('cli_credentials_list')
         if cli_credentials_list:
@@ -623,7 +688,7 @@ class Discovery(DnacBase):
                 msg = "Global CLI credentials must be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(cli_credentials_list) > 0:
-                global_credentails_all["cliCredential"] = []
+                global_credentials_all["cliCredential"] = []
                 cred_len = len(cli_credentials_list)
                 if cred_len > 5:
                     cred_len = 5
@@ -631,8 +696,8 @@ class Discovery(DnacBase):
                     if cli_cred.get('description') and cli_cred.get('username'):
                         for cli in response.get("cliCredential"):
                             if cli.get("description") == cli_cred.get('description') and cli.get("username") == cli_cred.get('username'):
-                                global_credentails_all["cliCredential"].append(cli.get("id"))
-                        global_credentails_all["cliCredential"] = global_credentails_all["cliCredential"][:cred_len]
+                                global_credentials_all["cliCredential"].append(cli.get("id"))
+                        global_credentials_all["cliCredential"] = global_credentials_all["cliCredential"][:cred_len]
                     else:
                         msg = "Kindly ensure you include both the description and the username for the Global CLI credential to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
@@ -643,7 +708,7 @@ class Discovery(DnacBase):
                 msg = "Global HTTP read credentials must be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(http_read_credential_list) > 0:
-                global_credentails_all["httpsRead"] = []
+                global_credentials_all["httpsRead"] = []
                 cred_len = len(http_read_credential_list)
                 if cred_len > 5:
                     cred_len = 5
@@ -651,8 +716,8 @@ class Discovery(DnacBase):
                     if http_cred.get('description') and http_cred.get('username'):
                         for http in response.get("httpsRead"):
                             if http.get("description") == http.get('description') and http.get("username") == http.get('username'):
-                                global_credentails_all["httpsRead"].append(http.get("id"))
-                        global_credentails_all["httpsRead"] = global_credentails_all["httpsRead"][:cred_len]
+                                global_credentials_all["httpsRead"].append(http.get("id"))
+                        global_credentials_all["httpsRead"] = global_credentials_all["httpsRead"][:cred_len]
                     else:
                         msg = "Kindly ensure you include both the description and the username for the Global HTTP Read credential to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
@@ -663,7 +728,7 @@ class Discovery(DnacBase):
                 msg = "Global HTTP write credentials must be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(http_write_credential_list) > 0:
-                global_credentails_all["httpsWrite"] = []
+                global_credentials_all["httpsWrite"] = []
                 cred_len = len(http_write_credential_list)
                 if cred_len > 5:
                     cred_len = 5
@@ -671,8 +736,8 @@ class Discovery(DnacBase):
                     if http_cred.get('description') and http_cred.get('username'):
                         for http in response.get("httpsWrite"):
                             if http.get("description") == http.get('description') and http.get("username") == http.get('username'):
-                                global_credentails_all["httpsWrite"].append(http.get("id"))
-                        global_credentails_all["httpsWrite"] = global_credentails_all["httpsWrite"][:cred_len]
+                                global_credentials_all["httpsWrite"].append(http.get("id"))
+                        global_credentials_all["httpsWrite"] = global_credentials_all["httpsWrite"][:cred_len]
                     else:
                         msg = "Kindly ensure you include both the description and the username for the Global HTTP Write credential to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
@@ -683,7 +748,7 @@ class Discovery(DnacBase):
                 msg = "Global SNMPV2 read credentials must be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(snmp_v2_read_credential_list) > 0:
-                global_credentails_all["snmpV2cRead"] = []
+                global_credentials_all["snmpV2cRead"] = []
                 cred_len = len(snmp_v2_read_credential_list)
                 if cred_len > 5:
                     cred_len = 5
@@ -691,8 +756,8 @@ class Discovery(DnacBase):
                     if snmp_cred.get('description'):
                         for snmp in response.get("snmpV2cRead"):
                             if snmp.get("description") == snmp_cred.get('description'):
-                                global_credentails_all["snmpV2cRead"].append(snmp.get("id"))
-                        global_credentails_all["snmpV2cRead"] = global_credentails_all["snmpV2cRead"][:cred_len]
+                                global_credentials_all["snmpV2cRead"].append(snmp.get("id"))
+                        global_credentials_all["snmpV2cRead"] = global_credentials_all["snmpV2cRead"][:cred_len]
                     else:
                         msg = "Kindly ensure you include both the description and the username for the Global SNMPV2 Read \
                                 credential to discover the devices"
@@ -704,7 +769,7 @@ class Discovery(DnacBase):
                 msg = "Global SNMPV2 write credentials must be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(snmp_v2_write_credential_list) > 0:
-                global_credentails_all["snmpV2cWrite"] = []
+                global_credentials_all["snmpV2cWrite"] = []
                 cred_len = len(snmp_v2_write_credential_list)
                 if cred_len > 5:
                     cred_len = 5
@@ -712,8 +777,8 @@ class Discovery(DnacBase):
                     if snmp_cred.get('description'):
                         for snmp in response.get("snmpV2cWrite"):
                             if snmp.get("description") == snmp_cred.get('description'):
-                                global_credentails_all["snmpV2cWrite"].append(snmp.get("id"))
-                        global_credentails_all["snmpV2cWrite"] = global_credentails_all["snmpV2cWrite"][:cred_len]
+                                global_credentials_all["snmpV2cWrite"].append(snmp.get("id"))
+                        global_credentials_all["snmpV2cWrite"] = global_credentials_all["snmpV2cWrite"][:cred_len]
                     else:
                         msg = "Kindly ensure you include both the description and the username for the Global SNMPV2 credential to discover the devices"
                         self.discovery_specific_cred_failure(msg=msg)
@@ -724,7 +789,7 @@ class Discovery(DnacBase):
                 msg = "Global SNMPV3 write credentials must be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(snmp_v3_credential_list) > 0:
-                global_credentails_all["snmpV3"] = []
+                global_credentials_all["snmpV3"] = []
                 cred_len = len(snmp_v3_credential_list)
                 if cred_len > 5:
                     cred_len = 5
@@ -732,8 +797,8 @@ class Discovery(DnacBase):
                     if snmp_cred.get('description') and snmp_cred.get('username'):
                         for snmp in response.get("snmpV3"):
                             if snmp.get("description") == snmp_cred.get('description') and snmp.get("username") == snmp_cred.get('username'):
-                                global_credentails_all["snmpV3"].append(snmp.get("id"))
-                        global_credentails_all["snmpV3"] = global_credentails_all["snmpV3"][:cred_len]
+                                global_credentials_all["snmpV3"].append(snmp.get("id"))
+                        global_credentials_all["snmpV3"] = global_credentials_all["snmpV3"][:cred_len]
                     else:
                         msg = "Kindly ensure you include both the description and the username for the Global SNMPV3 \
                                 to discover the devices"
@@ -745,7 +810,7 @@ class Discovery(DnacBase):
                 msg = "Global net Conf Ports be passed as a list"
                 self.discovery_specific_cred_failure(msg=msg)
             if len(net_conf_port_list) > 0:
-                global_credentails_all["netconfCredential"] = []
+                global_credentials_all["netconfCredential"] = []
                 cred_len = len(net_conf_port_list)
                 if cred_len > 5:
                     cred_len = 5
@@ -753,14 +818,14 @@ class Discovery(DnacBase):
                     if port.get("description"):
                         for netconf in response.get("netconfCredential"):
                             if port.get('description') == netconf.get('description'):
-                                global_credentails_all["netconfCredential"].append(netconf.get("id"))
-                        global_credentails_all["netconfCredential"] = global_credentails_all["netconfCredential"][:cred_len]
+                                global_credentials_all["netconfCredential"].append(netconf.get("id"))
+                        global_credentials_all["netconfCredential"] = global_credentials_all["netconfCredential"][:cred_len]
                     else:
                         msg = "Please provide description of the Global Netconf port to be used"
                         self.discovery_specific_cred_failure(msg=msg)
 
-        self.log("Fetched Global credentials IDs are {0}".format(global_credentails_all), "INFO")
-        return global_credentails_all
+        self.log("Fetched Global credentials IDs are {0}".format(global_credentials_all), "INFO")
+        return global_credentials_all
 
     def get_ccc_global_credentials_v2_info(self):
         """
@@ -783,31 +848,31 @@ class Discovery(DnacBase):
         )
         response = response.get('response')
         self.log("The Global credentials response from 'get all global credentials v2' API is {0}".format(str(response)), "DEBUG")
-        global_credentails_all = {}
+        global_credentials_all = {}
         global_credentials = self.validated_config[0].get("global_credentials")
         if global_credentials:
-            global_credentails_all = self.handle_global_credentials(response=response)
+            global_credentials_all = self.handle_global_credentials(response=response)
 
-        global_cred_set = set(global_credentails_all.keys())
+        global_cred_set = set(global_credentials_all.keys())
         response_cred_set = set(response.keys())
         diff_keys = response_cred_set.difference(global_cred_set)
 
         for key in diff_keys:
-            global_credentails_all[key] = []
+            global_credentials_all[key] = []
             if response[key] is None:
                 response[key] = []
             total_len = len(response[key])
             if total_len > 5:
                 total_len = 5
             for element in response.get(key):
-                global_credentails_all[key].append(element.get('id'))
-            global_credentails_all[key] = global_credentails_all[key][:total_len]
+                global_credentials_all[key].append(element.get('id'))
+            global_credentials_all[key] = global_credentials_all[key][:total_len]
 
-        if global_credentails_all == {}:
+        if global_credentials_all == {}:
             msg = 'Not found any global credentials to perform discovery'
             self.log(msg, "WARNING")
 
-        return global_credentails_all
+        return global_credentials_all
 
     def get_devices_list_info(self):
         """
@@ -1059,22 +1124,26 @@ class Discovery(DnacBase):
         if self.validated_config[0].get('discovery_specific_credentials'):
             self.handle_discovery_specific_credentials(new_object_params=new_object_params)
 
-        global_credentails_all = self.get_ccc_global_credentials_v2_info()
+        global_cred_flag = self.validated_config[0].get('use_global_cred')
+        global_credentials_all = {}
 
-        self.log(global_credentails_all, "DEBUG")
+        if global_cred_flag is True:
+            global_credentials_all = self.get_ccc_global_credentials_v2_info()
+            for global_cred_list in global_credentials_all.values():
+                credential_ids.extend(global_cred_list)
+            new_object_params['globalCredentialIdList'] = credential_ids
+
+        self.log("All the global credentials used for the discovery task are {0}".format(str(global_credentials_all)), "DEBUG")
+
         if not (new_object_params.get('snmpUserName') or new_object_params.get('snmpROCommunityDesc') or new_object_params.get('snmpRWCommunityDesc')
-                or global_credentails_all.get('snmpV2cRead') or global_credentails_all.get('snmpV2cWrite') or global_credentails_all.get('snmpV3')):
+                or global_credentials_all.get('snmpV2cRead') or global_credentials_all.get('snmpV2cWrite') or global_credentials_all.get('snmpV3')):
             msg = "Please provide atleast one valid SNMP credential to perform Discovery"
             self.discovery_specific_cred_failure(msg=msg)
 
-        if not (new_object_params.get('userNameList') or global_credentails_all.get('cliCredential')):
+        if not (new_object_params.get('userNameList') or global_credentials_all.get('cliCredential')):
             msg = "Please provide atleast one valid CLI credential to perform Discovery"
             self.discovery_specific_cred_failure(msg=msg)
 
-        for global_cred_list in global_credentails_all.values():
-            credential_ids.extend(global_cred_list)
-
-        new_object_params['globalCredentialIdList'] = credential_ids
         self.log("The payload/object created for calling the start discovery API is {0}".format(str(new_object_params)), "INFO")
 
         return new_object_params
@@ -1277,6 +1346,11 @@ class Discovery(DnacBase):
             elif any(res.get('reachabilityStatus') == 'Success' for res in devices):
                 result = True
                 self.log("Some devices in the range are reachable", "INFO")
+                break
+
+            elif all(res.get('reachabilityStatus') != 'Success' and res.get('inventoryReachabilityStatus') == 'Reachable' for res in devices):
+                result = True
+                self.log("Devices are not reachable, but discovery is completed", "WARNING")
                 break
 
             count += 1

--- a/plugins/modules/discovery_workflow_manager.py
+++ b/plugins/modules/discovery_workflow_manager.py
@@ -207,7 +207,8 @@ options:
       use_global_cred:
         description:
             - Boolean value to determine whether the user wants to use the global credentials by default while performing discovery.
-            - If set False, global credentials will not be used to discover the devices.
+            - If set to False, global credentials will not be used to discover the devices, and at least one discovery-specific
+                SNMP and CLI credential is required.
         type: bool
         default: True
       global_credentials:

--- a/plugins/modules/discovery_workflow_manager.py
+++ b/plugins/modules/discovery_workflow_manager.py
@@ -621,8 +621,7 @@ class Discovery(DnacBase):
             'timeout': {'type': 'str', 'required': False},
             'global_credentials': {'type': 'dict', 'required': False},
             'protocol_order': {'type': 'str', 'required': False, 'default': 'ssh'},
-            'use_global_credentials': {'type': 'bool', 'required': False,
-                                'default': True}
+            'use_global_credentials': {'type': 'bool', 'required': False, 'default': True}
         }
 
         if state == "merged":


### PR DESCRIPTION
Problem: The user should have the choice of using/not using global credentials while performing discovery.
Fix: Have added a new parameter called use_global_cred which if False, doesn't use any global credentials to perform discovery.
Test cases:
1. Execute discovery devices using MULTI RANGE with various global credentials
2. Execute discovery of single device using various discovery specific credentials and all the global credentials
3. Execute discovery of single device using various discovery specific credentials only
4. Execute discovery devices using MULTI RANGE with various discovery specific credentials
5. Execute discovery devices using CDP/LLDP/CIDR
6. Execute deletion of single discovery from the dashboard
7. Execute deletion of all the discoveries from the dashboard