### PR TITLE
Adding fix for Stackswitch getting changed to normal switch post editing the device's info

### DIFF
--- a/plugins/modules/pnp_intent.py
+++ b/plugins/modules/pnp_intent.py
@@ -956,8 +956,7 @@ class PnP(DnacBase):
             return self
 
         update_payload = {"deviceInfo": self.want.get('pnp_params')[0].get("deviceInfo")}
-        if is_stack is True:
-            update_payload["deviceInfo"]["stack"] = True
+        update_payload["deviceInfo"]["stack"] = is_stack
 
         self.log("The request sent for 'update_device' API for device's config update: {0}".format(update_payload), "DEBUG")
         update_response = self.dnac_apply['exec'](

--- a/plugins/modules/pnp_intent.py
+++ b/plugins/modules/pnp_intent.py
@@ -943,6 +943,9 @@ class PnP(DnacBase):
         )
         self.log("Response from 'get_device_by_id' API for device details: {0}".format(str(dev_details_response)), "DEBUG")
 
+        is_stack = False
+        if dev_details_response.get("deviceInfo").get("stack"):
+            is_stack = dev_details_response.get("deviceInfo").get("stack")
         pnp_state = dev_details_response.get("deviceInfo").get("state")
         self.log("PnP state of the device: {0}".format(pnp_state), "INFO")
 
@@ -953,6 +956,10 @@ class PnP(DnacBase):
             return self
 
         update_payload = {"deviceInfo": self.want.get('pnp_params')[0].get("deviceInfo")}
+        if is_stack is True:
+            update_payload["deviceInfo"]["stack"] = True
+
+        self.log("The request sent for 'update_device' API for device's config update: {0}".format(update_payload), "DEBUG")
         update_response = self.dnac_apply['exec'](
             family="device_onboarding_pnp",
             function="update_device",

--- a/plugins/modules/pnp_workflow_manager.py
+++ b/plugins/modules/pnp_workflow_manager.py
@@ -956,8 +956,7 @@ class PnP(DnacBase):
             return self
 
         update_payload = {"deviceInfo": self.want.get('pnp_params')[0].get("deviceInfo")}
-        if is_stack is True:
-            update_payload["deviceInfo"]["stack"] = True
+        update_payload["deviceInfo"]["stack"] = is_stack
 
         self.log("The request sent for 'update_device' API for device's config update: {0}".format(update_payload), "DEBUG")
         update_response = self.dnac_apply['exec'](

--- a/plugins/modules/pnp_workflow_manager.py
+++ b/plugins/modules/pnp_workflow_manager.py
@@ -943,6 +943,9 @@ class PnP(DnacBase):
         )
         self.log("Response from 'get_device_by_id' API for device details: {0}".format(str(dev_details_response)), "DEBUG")
 
+        is_stack = False
+        if dev_details_response.get("deviceInfo").get("stack"):
+            is_stack = dev_details_response.get("deviceInfo").get("stack")
         pnp_state = dev_details_response.get("deviceInfo").get("state")
         self.log("PnP state of the device: {0}".format(pnp_state), "INFO")
 
@@ -953,6 +956,10 @@ class PnP(DnacBase):
             return self
 
         update_payload = {"deviceInfo": self.want.get('pnp_params')[0].get("deviceInfo")}
+        if is_stack is True:
+            update_payload["deviceInfo"]["stack"] = True
+
+        self.log("The request sent for 'update_device' API for device's config update: {0}".format(update_payload), "DEBUG")
         update_response = self.dnac_apply['exec'](
             family="device_onboarding_pnp",
             function="update_device",


### PR DESCRIPTION
1.  **Git PR Link:** https://github.com/madhansansel/dnacenter-ansible/pull/187
2.  **Problem Description**: Whenever the user tries to claim a Stack Switch using the playbook and tries to edit the device info like hostname/serial_number/pid, then it automatically gets converted to a normal switch.
3.  **Root Cause:** This conversion happens due to a bug in the update_device API under PnP, which automatically makes stack as False if not passed in the payload.
4.  **Code Changes**: Have added a check for the stack. If the device is a stack, it automatically takes stack as True for passing the payload to the API, bypassing the bug.
5. **Testing and Automation**: For testing I added a test case for claiming a stack switch by passing PnP type as "StackSwitch" in the playbook. It passed without any failure. 
PLAY [Manage operations - Add, claim, and delete devices of Onboarding Configuration (PnP)] ************************************************************************************************************
Read vars_file '{{ CLUSTERFILE }}'
META: ran handlers
Read vars_file '{{ CLUSTERFILE }}'

TASK [Claim a pre-added stack switch, apply a template, and perform an image upgrade for a specific site] **********************************************************************************************
task path: /home/admin/madhan_ansible/collections/ansible_collections/cisco/dnac/playbooks/PnP.yml:154
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: admin
<127.0.0.1> EXEC /bin/sh -c 'echo ~admin && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/admin/.ansible/tmp `"&& mkdir "` echo /home/admin/.ansible/tmp/ansible-tmp-1709792619.8986197-805288-269125788707987 `" && echo ansible-tmp-1709792619.8986197-805288-269125788707987="` echo /home/admin/.ansible/tmp/ansible-tmp-1709792619.8986197-805288-269125788707987 `" ) && sleep 0'
Using module file /home/admin/madhan_ansible/collections/ansible_collections/cisco/dnac/plugins/modules/pnp_intent.py
<127.0.0.1> PUT /home/admin/.ansible/tmp/ansible-local-804761alwxsjdt/tmpdz4l0o99 TO /home/admin/.ansible/tmp/ansible-tmp-1709792619.8986197-805288-269125788707987/AnsiballZ_pnp_intent.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/admin/.ansible/tmp/ansible-tmp-1709792619.8986197-805288-269125788707987/ /home/admin/.ansible/tmp/ansible-tmp-1709792619.8986197-805288-269125788707987/AnsiballZ_pnp_intent.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/home/admin/pyats_env/bin/python3 /home/admin/.ansible/tmp/ansible-tmp-1709792619.8986197-805288-269125788707987/AnsiballZ_pnp_intent.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/admin/.ansible/tmp/ansible-tmp-1709792619.8986197-805288-269125788707987/ > /dev/null 2>&1 && sleep 0'
changed: [localhost] => {
    "changed": true,
    "diff": [
        {
            "device_info": [
                {
                    "hostname": "Only_Stack",
                    "pid": "C9300-48UXM",
                    "serialNumber": "FJC271924EQ",
                    "stack": true,
                    "state": "Unclaimed"
                }
            ],
            "gateway": null,
            "golden_image": null,
            "image_name": null,
            "ip_interface_name": null,
            "pnp_type": "StackSwitch",
            "project_name": "Onboarding Configuration",
            "rf_profile": null,
            "sensorProfile": null,
            "site_name": "Global/USA/San Francisco/BGL_18",
            "static_ip": null,
            "subnet_mask": null,
            "template_name": null,
            "template_params": null,
            "vlan_id": null
        }
    ],
    "invocation": {
        "module_args": {
            "config": [
                {
                    "device_info": [
                        {
                            "hostname": "Only_Stack",
                            "pid": "C9300-48UXM",
                            "serial_number": "FJC271924EQ",
                            "state": "Unclaimed"
                        }
                    ],
                    "pnp_type": "StackSwitch",
                    "project_name": "Onboarding Configuration",
                    "site_name": "Global/USA/San Francisco/BGL_18"
                }
            ],
            "config_verify": false,
            "dnac_debug": true,
            "dnac_host": "172.23.241.186",
            "dnac_log": true,
            "dnac_log_append": true,
            "dnac_log_file_path": "dnac.log",
            "dnac_log_level": "DEBUG",
            "dnac_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "dnac_port": "443",
            "dnac_username": "admin",
            "dnac_verify": false,
            "dnac_version": "2.3.5.3",
            "state": "merged",
            "validate_response_schema": true
        }
    },
    "msg": "Only Device Claimed Successfully",
    "response": {
        "response": "Device Claimed",
        "version": "1.0"
    }
}
Read vars_file '{{ CLUSTERFILE }}'
META: ran handlers
Read vars_file '{{ CLUSTERFILE }}'
META: ran handlers

PLAY RECAP *********************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
7.  **Follow-up Tasks:** Will raise a bug to the API team to fix the issue with the bug and also there is a DEBUG statement added for the user to check the payload getting sent for the API.
      