### PR TITLE
Adding documentation for the EWLC template issue in CCC 235x

### DIFF
--- a/plugins/modules/pnp_intent.py
+++ b/plugins/modules/pnp_intent.py
@@ -13,53 +13,61 @@ DOCUMENTATION = r"""
 module: pnp_intent
 short_description: Resource module for Site and PnP related functions
 description:
-- Manage operations add device, claim device and unclaim device of Onboarding Configuration(PnP) resource
-- API to add device to pnp inventory and claim it to a site.
-- API to delete device from the pnp inventory.
-- API to reset the device from errored state.
-version_added: '6.6.0'
+  - Manage operations add device, claim device and unclaim device of Onboarding
+    Configuration(PnP) resource
+  - API to add device to pnp inventory and claim it to a site.
+  - API to delete device from the pnp inventory.
+  - API to reset the device from errored state.
+version_added: 6.6.0
 extends_documentation_fragment:
   - cisco.dnac.intent_params
-author: Abinash Mishra (@abimishr)
-        Madhan Sankaranarayanan (@madhansansel)
-        Rishita Chowdhary (@rishitachowdhary)
+author: Abinash Mishra (@abimishr) Madhan Sankaranarayanan (@madhansansel)
+  Rishita Chowdhary (@rishitachowdhary)
 options:
   config_verify:
-    description: Set to True to verify the Cisco Catalyst Center config after applying the playbook config.
+    description: Set to True to verify the Cisco Catalyst Center config after
+      applying the playbook config.
     type: bool
-    default: False
+    default: false
   state:
     description: The state of Cisco Catalyst Center after module completion.
     type: str
-    choices: [ merged, deleted ]
+    choices:
+      - merged
+      - deleted
     default: merged
   config:
     description:
-    - List of details of device being managed.
+      - List of details of device being managed.
     type: list
     elements: dict
     required: true
     suboptions:
       device_info:
         description:
-            - Provides the device-specific information required for adding devices to the PnP database that are not already present.
-            - For adding a single device, the list should contain exactly one set of device information. If a site name is also provided,
-              the device can be claimed immediately after being added.
-            - For bulk import, the list must contain information for more than one device. Bulk import is intended solely for adding devices;
-              claiming must be performed with separate tasks or configurations.
+          - Provides the device-specific information required for adding devices
+            to the PnP database that are not already present.
+          - For adding a single device, the list should contain exactly one set
+            of device information. If a site name is also provided, the device
+            can be claimed immediately after being added.
+          - For bulk import, the list must contain information for more than one
+            device. Bulk import is intended solely for adding devices; claiming
+            must be performed with separate tasks or configurations.
         type: list
         required: true
         elements: dict
         suboptions:
           hostname:
             description:
-            - Defines the desired hostname for the PnP device after it has been claimed.
-            - The hostname can only be assigned or changed during the claim process, not during bulk or single device additions.
+              - Defines the desired hostname for the PnP device after it has
+                been claimed.
+              - The hostname can only be assigned or changed during the claim
+                process, not during bulk or single device additions.
             type: str
           state:
             description:
-                - Represents the onboarding state of the PnP device.
-                - Possible values are 'Unclaimed', 'Claimed', or 'Provisioned'.
+              - Represents the onboarding state of the PnP device.
+              - Possible values are 'Unclaimed', 'Claimed', or 'Provisioned'.
             type: str
           pid:
             description: Pnp Device's pid.
@@ -79,15 +87,18 @@ options:
         default: Onboarding Configuration
       template_name:
         description:
-            - Name of template to be configured on the device.
-            - Supported for EWLC from Cisco Catalyst Center release version 2.3.7.x onwards.
+          - Name of template to be configured on the device.
+          - Supported for EWLC from Cisco Catalyst Center release version
+            2.3.7.x onwards.
         type: str
       template_params:
         description:
-            - Parameter values for the parameterised templates.
-            - Each varibale has a value that needs to be passed as key-value pair
-              in the dictionary. We can pass values as variable_name:variable_value.
-            - Supported for EWLC from Cisco Catalyst Center release version 2.3.7.x onwards.
+          - Parameter values for the parameterised templates.
+          - Each varibale has a value that needs to be passed as key-value pair
+            in the dictionary. We can pass values as
+            variable_name:variable_value.
+          - Supported for EWLC from Cisco Catalyst Center release version
+            2.3.7.x onwards.
         type: dict
       image_name:
         description: Name of image to be configured on the device
@@ -96,15 +107,20 @@ options:
         description: Is the image to be condifgured tagged as golden image
         type: bool
       pnp_type:
-        description: Specifies the device type for the Plug and Play (PnP) device.
-            - Options include 'Default', 'CatalystWLC', 'AccessPoint', or 'StackSwitch'.
-            - 'Default' is applicable to switches and routers.
-            - 'CatalystWLC' should be selected for 9800 series wireless controllers.
-            - 'AccessPoint' is used when claiming an access point.
-            - 'StackSwitch' should be chosen for a group of switches that operate as a single switch, typically used in the access layer.
+        description: Specifies the device type for the Plug and Play (PnP) device. -
+          Options include 'Default', 'CatalystWLC', 'AccessPoint', or
+          'StackSwitch'. - 'Default' is applicable to switches and routers. -
+          'CatalystWLC' should be selected for 9800 series wireless controllers.
+          - 'AccessPoint' is used when claiming an access point. - 'StackSwitch'
+          should be chosen for a group of switches that operate as a single
+          switch, typically used in the access layer.
         type: str
-        choices: [ 'Default', 'CatalystWLC', 'AccessPoint', 'StackSwitch' ]
-        default: 'Default'
+        choices:
+          - Default
+          - CatalystWLC
+          - AccessPoint
+          - StackSwitch
+        default: Default
       static_ip:
         description: Management IP address of the Wireless Controller
         type: str
@@ -118,26 +134,33 @@ options:
         description: Vlan Id allocated for claimimg of Wireless Controller
         type: str
       ip_interface_name:
-        description: Specifies the interface name utilized for Plug and Play (PnP) by the Wireless Controller.
-            Ensure this interface is pre-configured on the Controller prior to device claiming.
+        description: Specifies the interface name utilized for Plug and Play (PnP) by
+          the Wireless Controller. Ensure this interface is pre-configured on
+          the Controller prior to device claiming.
         type: str
       rf_profile:
         description:
-            - Radio Frequecy (RF) profile of the AP being claimed.
-            - RF Profiles allow you to tune groups of APs that share a common coverage zone together.
-            - They selectively change how Radio Resource Management will operate the APs within that coverage zone.
-            - HIGH RF profile allows you to use more power and allows to join AP with the client in an easier fashion.
-            - TYPICAL RF profile is a blend of moderate power and moderate visibility to the client.
-            - LOW RF profile allows you to consume lesser power and has least visibility to the client.
+          - Radio Frequecy (RF) profile of the AP being claimed.
+          - RF Profiles allow you to tune groups of APs that share a common
+            coverage zone together.
+          - They selectively change how Radio Resource Management will operate
+            the APs within that coverage zone.
+          - HIGH RF profile allows you to use more power and allows to join AP
+            with the client in an easier fashion.
+          - TYPICAL RF profile is a blend of moderate power and moderate
+            visibility to the client.
+          - LOW RF profile allows you to consume lesser power and has least
+            visibility to the client.
         type: str
-        choices: [ 'HIGH', 'LOW', 'TYPICAL' ]
-
+        choices:
+          - HIGH
+          - LOW
+          - TYPICAL
 requirements:
-- dnacentersdk == 2.6.10
-- python >= 3.5
+  - dnacentersdk == 2.6.10
+  - python >= 3.5
 notes:
-  - SDK Method used are
-    device_onboarding_pnp.DeviceOnboardingPnp.add_device,
+  - SDK Method used are device_onboarding_pnp.DeviceOnboardingPnp.add_device,
     device_onboarding_pnp.DeviceOnboardingPnp.get_device_list,
     device_onboarding_pnp.DeviceOnboardingPnp.claim_a_device_to_a_site,
     device_onboarding_pnp.DeviceOnboardingPnp.delete_device_by_id_from_pnp,
@@ -147,17 +170,13 @@ notes:
     sites.Sites.get_site,
     software_image_management_swim.SoftwareImageManagementSwim.get_software_image_details,
     configuration_templates.ConfigurationTemplates.gets_the_templates_available
-
-  - Paths used are
-    post /dna/intent/api/v1/onboarding/pnp-device
-    post /dna/intent/api/v1/onboarding/pnp-device/site-claim
-    post /dna/intent/api/v1/onboarding/pnp-device/{id}
-    get /dna/intent/api/v1/onboarding/pnp-device/count
-    get /dna/intent/api/v1/onboarding/pnp-device
-    put /onboarding/pnp-device/${id}
-    get /dna/intent/api/v1/site
-    get /dna/intent/api/v1/image/importation
-    get /dna/intent/api/v1/template-programmer/template
+  - Paths used are post /dna/intent/api/v1/onboarding/pnp-device post
+    /dna/intent/api/v1/onboarding/pnp-device/site-claim post
+    /dna/intent/api/v1/onboarding/pnp-device/{id} get
+    /dna/intent/api/v1/onboarding/pnp-device/count get
+    /dna/intent/api/v1/onboarding/pnp-device put /onboarding/pnp-device/${id}
+    get /dna/intent/api/v1/site get /dna/intent/api/v1/image/importation get
+    /dna/intent/api/v1/template-programmer/template
 
 """
 
@@ -235,7 +254,6 @@ EXAMPLES = r"""
     dnac_log: True
     state: merged
     config_verify: True
-    state: merged
     config:
         - device_info:
             - serial_number: FJC271924EQ
@@ -263,7 +281,6 @@ EXAMPLES = r"""
     dnac_log: True
     state: deleted
     config_verify: True
-    state: merged
     config:
         - device_info:
             - serial_number: QD2425L8M7

--- a/plugins/modules/pnp_intent.py
+++ b/plugins/modules/pnp_intent.py
@@ -239,9 +239,9 @@ EXAMPLES = r"""
     config:
         - device_info:
             - serial_number: FJC271924EQ
-            hostname: Switch
-            state: Unclaimed
-            pid: C9300-48UXM
+              hostname: Switch
+              state: Unclaimed
+              pid: C9300-48UXM
           site_name: Global/USA/San Francisco/BGL_18
           template_name: "Ansible_PNP_Switch"
           image_name: cat9k_iosxe_npe.17.03.07.SPA.bin
@@ -268,7 +268,7 @@ EXAMPLES = r"""
         - device_info:
             - serial_number: QD2425L8M7
             - serial_number: FTC2320E0HA
-            - serial_number: FKC2310E0HB  
+            - serial_number: FKC2310E0HB
 """
 
 RETURN = r"""

--- a/plugins/modules/pnp_workflow_manager.py
+++ b/plugins/modules/pnp_workflow_manager.py
@@ -13,53 +13,61 @@ DOCUMENTATION = r"""
 module: pnp_workflow_manager
 short_description: Resource module for Site and PnP related functions
 description:
-- Manage operations add device, claim device and unclaim device of Onboarding Configuration(PnP) resource
-- API to add device to pnp inventory and claim it to a site.
-- API to delete device from the pnp inventory.
-- API to reset the device from errored state.
-version_added: '6.6.0'
+  - Manage operations add device, claim device and unclaim device of Onboarding
+    Configuration(PnP) resource
+  - API to add device to pnp inventory and claim it to a site.
+  - API to delete device from the pnp inventory.
+  - API to reset the device from errored state.
+version_added: 6.6.0
 extends_documentation_fragment:
   - cisco.dnac.workflow_manager_params
-author: Abinash Mishra (@abimishr)
-        Madhan Sankaranarayanan (@madhansansel)
-        Rishita Chowdhary (@rishitachowdhary)
+author: Abinash Mishra (@abimishr) Madhan Sankaranarayanan (@madhansansel)
+  Rishita Chowdhary (@rishitachowdhary)
 options:
   config_verify:
-    description: Set to True to verify the Cisco Catalyst Center config after applying the playbook config.
+    description: Set to True to verify the Cisco Catalyst Center config after
+      applying the playbook config.
     type: bool
-    default: False
+    default: false
   state:
     description: The state of Cisco Catalyst Center after module completion.
     type: str
-    choices: [ merged, deleted ]
+    choices:
+      - merged
+      - deleted
     default: merged
   config:
     description:
-    - List of details of device being managed.
+      - List of details of device being managed.
     type: list
     elements: dict
     required: true
     suboptions:
       device_info:
         description:
-            - Provides the device-specific information required for adding devices to the PnP database that are not already present.
-            - For adding a single device, the list should contain exactly one set of device information. If a site name is also provided,
-              the device can be claimed immediately after being added.
-            - For bulk import, the list must contain information for more than one device. Bulk import is intended solely for adding devices;
-              claiming must be performed with separate tasks or configurations.
+          - Provides the device-specific information required for adding devices
+            to the PnP database that are not already present.
+          - For adding a single device, the list should contain exactly one set
+            of device information. If a site name is also provided, the device
+            can be claimed immediately after being added.
+          - For bulk import, the list must contain information for more than one
+            device. Bulk import is intended solely for adding devices; claiming
+            must be performed with separate tasks or configurations.
         type: list
         required: true
         elements: dict
         suboptions:
           hostname:
             description:
-            - Defines the desired hostname for the PnP device after it has been claimed.
-            - The hostname can only be assigned or changed during the claim process, not during bulk or single device additions.
+              - Defines the desired hostname for the PnP device after it has
+                been claimed.
+              - The hostname can only be assigned or changed during the claim
+                process, not during bulk or single device additions.
             type: str
           state:
             description:
-                - Represents the onboarding state of the PnP device.
-                - Possible values are 'Unclaimed', 'Claimed', or 'Provisioned'.
+              - Represents the onboarding state of the PnP device.
+              - Possible values are 'Unclaimed', 'Claimed', or 'Provisioned'.
             type: str
           pid:
             description: Pnp Device's pid.
@@ -79,15 +87,18 @@ options:
         default: Onboarding Configuration
       template_name:
         description:
-            - Name of template to be configured on the device.
-            - Supported for EWLC from Cisco Catalyst Center release version 2.3.7.x onwards.
+          - Name of template to be configured on the device.
+          - Supported for EWLC from Cisco Catalyst Center release version
+            2.3.7.x onwards.
         type: str
       template_params:
         description:
-            - Parameter values for the parameterised templates.
-            - Each varibale has a value that needs to be passed as key-value pair
-              in the dictionary. We can pass values as variable_name:variable_value.
-            - Supported for EWLC from Cisco Catalyst Center release version 2.3.7.x onwards.
+          - Parameter values for the parameterised templates.
+          - Each varibale has a value that needs to be passed as key-value pair
+            in the dictionary. We can pass values as
+            variable_name:variable_value.
+          - Supported for EWLC from Cisco Catalyst Center release version
+            2.3.7.x onwards.
         type: dict
       image_name:
         description: Name of image to be configured on the device
@@ -96,15 +107,20 @@ options:
         description: Is the image to be condifgured tagged as golden image
         type: bool
       pnp_type:
-        description: Specifies the device type for the Plug and Play (PnP) device.
-            - Options include 'Default', 'CatalystWLC', 'AccessPoint', or 'StackSwitch'.
-            - 'Default' is applicable to switches and routers.
-            - 'CatalystWLC' should be selected for 9800 series wireless controllers.
-            - 'AccessPoint' is used when claiming an access point.
-            - 'StackSwitch' should be chosen for a group of switches that operate as a single switch, typically used in the access layer.
+        description: Specifies the device type for the Plug and Play (PnP) device. -
+          Options include 'Default', 'CatalystWLC', 'AccessPoint', or
+          'StackSwitch'. - 'Default' is applicable to switches and routers. -
+          'CatalystWLC' should be selected for 9800 series wireless controllers.
+          - 'AccessPoint' is used when claiming an access point. - 'StackSwitch'
+          should be chosen for a group of switches that operate as a single
+          switch, typically used in the access layer.
         type: str
-        choices: [ 'Default', 'CatalystWLC', 'AccessPoint', 'StackSwitch' ]
-        default: 'Default'
+        choices:
+          - Default
+          - CatalystWLC
+          - AccessPoint
+          - StackSwitch
+        default: Default
       static_ip:
         description: Management IP address of the Wireless Controller
         type: str
@@ -118,26 +134,33 @@ options:
         description: Vlan Id allocated for claimimg of Wireless Controller
         type: str
       ip_interface_name:
-        description: Specifies the interface name utilized for Plug and Play (PnP) by the Wireless Controller.
-            Ensure this interface is pre-configured on the Controller prior to device claiming.
+        description: Specifies the interface name utilized for Plug and Play (PnP) by
+          the Wireless Controller. Ensure this interface is pre-configured on
+          the Controller prior to device claiming.
         type: str
       rf_profile:
         description:
-            - Radio Frequecy (RF) profile of the AP being claimed.
-            - RF Profiles allow you to tune groups of APs that share a common coverage zone together.
-            - They selectively change how Radio Resource Management will operate the APs within that coverage zone.
-            - HIGH RF profile allows you to use more power and allows to join AP with the client in an easier fashion.
-            - TYPICAL RF profile is a blend of moderate power and moderate visibility to the client.
-            - LOW RF profile allows you to consume lesser power and has least visibility to the client.
+          - Radio Frequecy (RF) profile of the AP being claimed.
+          - RF Profiles allow you to tune groups of APs that share a common
+            coverage zone together.
+          - They selectively change how Radio Resource Management will operate
+            the APs within that coverage zone.
+          - HIGH RF profile allows you to use more power and allows to join AP
+            with the client in an easier fashion.
+          - TYPICAL RF profile is a blend of moderate power and moderate
+            visibility to the client.
+          - LOW RF profile allows you to consume lesser power and has least
+            visibility to the client.
         type: str
-        choices: [ 'HIGH', 'LOW', 'TYPICAL' ]
-
+        choices:
+          - HIGH
+          - LOW
+          - TYPICAL
 requirements:
-- dnacentersdk == 2.6.10
-- python >= 3.5
+  - dnacentersdk == 2.6.10
+  - python >= 3.5
 notes:
-  - SDK Method used are
-    device_onboarding_pnp.DeviceOnboardingPnp.add_device,
+  - SDK Method used are device_onboarding_pnp.DeviceOnboardingPnp.add_device,
     device_onboarding_pnp.DeviceOnboardingPnp.get_device_list,
     device_onboarding_pnp.DeviceOnboardingPnp.claim_a_device_to_a_site,
     device_onboarding_pnp.DeviceOnboardingPnp.delete_device_by_id_from_pnp,
@@ -147,17 +170,13 @@ notes:
     sites.Sites.get_site,
     software_image_management_swim.SoftwareImageManagementSwim.get_software_image_details,
     configuration_templates.ConfigurationTemplates.gets_the_templates_available
-
-  - Paths used are
-    post /dna/intent/api/v1/onboarding/pnp-device
-    post /dna/intent/api/v1/onboarding/pnp-device/site-claim
-    post /dna/intent/api/v1/onboarding/pnp-device/{id}
-    get /dna/intent/api/v1/onboarding/pnp-device/count
-    get /dna/intent/api/v1/onboarding/pnp-device
-    put /onboarding/pnp-device/${id}
-    get /dna/intent/api/v1/site
-    get /dna/intent/api/v1/image/importation
-    get /dna/intent/api/v1/template-programmer/template
+  - Paths used are post /dna/intent/api/v1/onboarding/pnp-device post
+    /dna/intent/api/v1/onboarding/pnp-device/site-claim post
+    /dna/intent/api/v1/onboarding/pnp-device/{id} get
+    /dna/intent/api/v1/onboarding/pnp-device/count get
+    /dna/intent/api/v1/onboarding/pnp-device put /onboarding/pnp-device/${id}
+    get /dna/intent/api/v1/site get /dna/intent/api/v1/image/importation get
+    /dna/intent/api/v1/template-programmer/template
 
 """
 
@@ -235,7 +254,6 @@ EXAMPLES = r"""
     dnac_log: True
     state: merged
     config_verify: True
-    state: merged
     config:
         - device_info:
             - serial_number: FJC271924EQ
@@ -263,7 +281,6 @@ EXAMPLES = r"""
     dnac_log: True
     state: deleted
     config_verify: True
-    state: merged
     config:
         - device_info:
             - serial_number: QD2425L8M7

--- a/plugins/modules/pnp_workflow_manager.py
+++ b/plugins/modules/pnp_workflow_manager.py
@@ -40,20 +40,36 @@ options:
     elements: dict
     required: true
     suboptions:
-      template_name:
-        description: Name of template to be configured on the device.
-        type: str
-      template_params:
-        description: Parameter values for the parameterised templates.
-            Each varibale has a value that needs to be passed as key-value pair
-            in the dictionary. We can pass values as variable_name:variable_value.
-        type: dict
-      image_name:
-        description: Name of image to be configured on the device
-        type: str
-      golden_image:
-        description: Is the image to be condifgured tagged as golden image
-        type: bool
+      device_info:
+        description:
+            - Provides the device-specific information required for adding devices to the PnP database that are not already present.
+            - For adding a single device, the list should contain exactly one set of device information. If a site name is also provided,
+              the device can be claimed immediately after being added.
+            - For bulk import, the list must contain information for more than one device. Bulk import is intended solely for adding devices;
+              claiming must be performed with separate tasks or configurations.
+        type: list
+        required: true
+        elements: dict
+        suboptions:
+          hostname:
+            description:
+            - Defines the desired hostname for the PnP device after it has been claimed.
+            - The hostname can only be assigned or changed during the claim process, not during bulk or single device additions.
+            type: str
+          state:
+            description:
+                - Represents the onboarding state of the PnP device.
+                - Possible values are 'Unclaimed', 'Claimed', or 'Provisioned'.
+            type: str
+          pid:
+            description: Pnp Device's pid.
+            type: str
+          serial_number:
+            description: Pnp Device's serial_number.
+            type: str
+          is_sudi_required:
+            description: Sudi Authentication requiremnet's flag.
+            type: bool
       site_name:
         description: Name of the site for which device will be claimed.
         type: str
@@ -61,6 +77,24 @@ options:
         description: Name of the project under which the template is present
         type: str
         default: Onboarding Configuration
+      template_name:
+        description:
+            - Name of template to be configured on the device.
+            - Supported for EWLC from Cisco Catalyst Center release version 2.3.7.x onwards.
+        type: str
+      template_params:
+        description:
+            - Parameter values for the parameterised templates.
+            - Each varibale has a value that needs to be passed as key-value pair
+              in the dictionary. We can pass values as variable_name:variable_value.
+            - Supported for EWLC from Cisco Catalyst Center release version 2.3.7.x onwards.
+        type: dict
+      image_name:
+        description: Name of image to be configured on the device
+        type: str
+      golden_image:
+        description: Is the image to be condifgured tagged as golden image
+        type: bool
       pnp_type:
         description: Specifies the device type for the Plug and Play (PnP) device.
             - Options include 'Default', 'CatalystWLC', 'AccessPoint', or 'StackSwitch'.
@@ -97,36 +131,6 @@ options:
             - LOW RF profile allows you to consume lesser power and has least visibility to the client.
         type: str
         choices: [ 'HIGH', 'LOW', 'TYPICAL' ]
-      device_info:
-        description:
-            - Provides the device-specific information required for adding devices to the PnP database that are not already present.
-            - For adding a single device, the list should contain exactly one set of device information. If a site name is also provided,
-              the device can be claimed immediately after being added.
-            - For bulk import, the list must contain information for more than one device. Bulk import is intended solely for adding devices;
-              claiming must be performed with separate tasks or configurations.
-        type: list
-        required: true
-        elements: dict
-        suboptions:
-          hostname:
-            description:
-            - Defines the desired hostname for the PnP device after it has been claimed.
-            - The hostname can only be assigned or changed during the claim process, not during bulk or single device additions.
-            type: str
-          state:
-            description:
-                - Represents the onboarding state of the PnP device.
-                - Possible values are 'Unclaimed', 'Claimed', or 'Provisioned'.
-            type: str
-          pid:
-            description: Pnp Device's pid.
-            type: str
-          serial_number:
-            description: Pnp Device's serial_number.
-            type: str
-          is_sudi_required:
-            description: Sudi Authentication requiremnet's flag.
-            type: bool
 
 requirements:
 - dnacentersdk == 2.6.10
@@ -158,7 +162,7 @@ notes:
 """
 
 EXAMPLES = r"""
-- name: Add a new device and claim the device
+- name: Import multiple switches in bulk only
   cisco.dnac.pnp_workflow_manager:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
@@ -172,25 +176,99 @@ EXAMPLES = r"""
     state: merged
     config_verify: True
     config:
-        - template_name: string
-          image_name: string
-          golden_image: bool
-          site_name: string
-          project_name: string
-          pnp_type: string
-          static_ip: string
-          subnet_mask: string
-          gateway: string
-          vlan_id: string
-          ip_interface_name: string
-          rf_profile: string
-          device_info:
-            - hostname: string
-              state: string
-              pid: string
-              serial_number: string
-              add_device_method: string
-              is_sudi_required: string
+        - device_info:
+            - serial_number: QD2425L8M7
+              state: Unclaimed
+              pid: c9300-24P
+              is_sudi_required: False
+            - serial_number: QTC2320E0H9
+              state: Unclaimed
+              pid: c9300-24P
+              hostname: Test-123
+            - serial_number: ETC2320E0HB
+              state: Unclaimed
+              pid: c9300-24P
+
+- name: Add a new EWLC and claim it
+  cisco.dnac.pnp_workflow_manager:
+    dnac_host: "{{dnac_host}}"
+    dnac_username: "{{dnac_username}}"
+    dnac_password: "{{dnac_password}}"
+    dnac_verify: "{{dnac_verify}}"
+    dnac_port: "{{dnac_port}}"
+    dnac_version: "{{dnac_version}}"
+    dnac_debug: "{{dnac_debug}}"
+    dnac_log_level: "{{dnac_log_level}}"
+    dnac_log: True
+    state: merged
+    config_verify: True
+    config:
+        - device_info:
+            - serial_number: FOX2639PAY7
+              hostname: New_WLC
+              state: Unclaimed
+              pid: C9800-CL-K9
+          site_name: Global/USA/San Francisco/BGL_18
+          template_name: Ansible_PNP_WLC
+          template_params:
+            hostname: IAC-EWLC-Claimed
+          project_name: Onboarding Configuration
+          image_name: C9800-40-universalk9_wlc.17.12.01.SPA.bin
+          golden_image: true
+          pnp_type: CatalystWLC
+          static_ip: 204.192.101.10
+          subnet_mask: 255.255.255.0
+          gateway: 204.192.101.1
+          vlan_id: 1101
+          ip_interface_name: TenGigabitEthernet0/0/0
+
+- name: Claim a pre-added switch, apply a template, and perform an image upgrade for a specific site
+  cisco.dnac.pnp_workflow_manager:
+    dnac_host: "{{dnac_host}}"
+    dnac_username: "{{dnac_username}}"
+    dnac_password: "{{dnac_password}}"
+    dnac_verify: "{{dnac_verify}}"
+    dnac_port: "{{dnac_port}}"
+    dnac_version: "{{dnac_version}}"
+    dnac_debug: "{{dnac_debug}}"
+    dnac_log_level: "{{dnac_log_level}}"
+    dnac_log: True
+    state: merged
+    config_verify: True
+    state: merged
+    config:
+        - device_info:
+            - serial_number: FJC271924EQ
+              hostname: Switch
+              state: Unclaimed
+              pid: C9300-48UXM
+          site_name: Global/USA/San Francisco/BGL_18
+          template_name: "Ansible_PNP_Switch"
+          image_name: cat9k_iosxe_npe.17.03.07.SPA.bin
+          project_name: Onboarding Configuration
+          template_params:
+            hostname: SJC-Switch-1
+            interface: TwoGigabitEthernet1/0/2
+
+- name: Remove multiple devices from the PnP dashboard safely (ignores non-existent devices)
+  cisco.dnac.pnp_workflow_manager:
+    dnac_host: "{{dnac_host}}"
+    dnac_username: "{{dnac_username}}"
+    dnac_password: "{{dnac_password}}"
+    dnac_verify: "{{dnac_verify}}"
+    dnac_port: "{{dnac_port}}"
+    dnac_version: "{{dnac_version}}"
+    dnac_debug: "{{dnac_debug}}"
+    dnac_log_level: "{{dnac_log_level}}"
+    dnac_log: True
+    state: deleted
+    config_verify: True
+    state: merged
+    config:
+        - device_info:
+            - serial_number: QD2425L8M7
+            - serial_number: FTC2320E0HA
+            - serial_number: FKC2310E0HB
 """
 
 RETURN = r"""


### PR DESCRIPTION
1.   Git PR Link: https://github.com/madhansansel/dnacenter-ansible/pull/193
2.   Problem Description: Claiming an EWLC with a template is nit supported in Cisco Catalyst Center 235x.
3.   Root cause: Feature was introduced post 237x.
4.   Fix: Have added the same in the documentation  
               