### PR TITLE
Fix the issue of log message while editing the management IP of devic…

### DIFF
--- a/playbooks/inventory_workflow_manager.yml
+++ b/playbooks/inventory_workflow_manager.yml
@@ -58,36 +58,6 @@
             site_name: "Global/USA/San Francisco/BGL_18/floor_test"
             resync_retry_count: 200
             resync_retry_interval: 2
-          provision_wireless_device:
-          - device_ip: "1.1.1.1"
-            site_name: "Global/USA/BGL_18/floor_pnp"
-            managed_ap_locations: ["Global/USA/BGL_18/floor_pnp", "Global/USA/BGL_18/floor_test"]
-            dynamic_interfaces:
-            - interface_ip_address: 23.23.21.12
-              interface_netmask_in_cidr: 24
-              interface_gateway: "gateway"
-              lag_or_port_number: 12
-              vlan_id: 99
-              interface_name: "etherenet0/0"
-            resync_retry_count: 200
-            resync_retry_interval: 2
-          - device_ip: "2.2.2.2"
-            site_name: "Global/USA/BGL_18/floor_test"
-            managed_ap_locations: ["Global/USA/BGL_19/floor_pnp", "Global/USA/BGL_19/floor_test"]
-            dynamic_interfaces:
-            - interface_ip_address: 32.31.12.23
-              interface_netmask_in_cidr: 26
-              interface_gateway: "gateway_test"
-              lag_or_port_number: 33
-              vlan_id: 78
-              interface_name: "etherenet1/1"
-            resync_retry_count: 200
-            resync_retry_interval: 2
-          reprovision_wired_device:
-          - device_ip: "1.1.1.1"
-            site_name: "Global/USA/San Francisco/BGL_18/floor_pnp"
-          - device_ip: "2.2.2.2"
-            site_name: "Global/USA/San Francisco/BGL_18/floor_test"
           update_interface_details:
             description: "{{item.update_interface_details.description}}"
             interface_name: "{{item.interface_name}}"

--- a/playbooks/inventory_workflow_manager.yml
+++ b/playbooks/inventory_workflow_manager.yml
@@ -40,8 +40,7 @@
           type: "{{item.type}}"
           device_resync: "{{item.device_resync}}"
           reboot_device: "{{item.reboot_device}}"
-          update_device_role:
-            role: "{{item.role}}"
+          role: "{{item.role}}"
           add_user_defined_field:
           - name: Test123
             description: "Added first udf for testing"

--- a/playbooks/swim_workflow_manager.yml
+++ b/playbooks/swim_workflow_manager.yml
@@ -19,27 +19,29 @@
         dnac_log: True
         dnac_log_level: DEBUG
         config_verify: True
+        max_timeout: 1000
+        interval_seconds: 1
         config:
         - import_image_details:
             type: "{{ item.type }}"
             url_details:
               payload:
-              - source_url: http://10.197.156.28/stda/abimishr/cat9k_iosxe.17.12.01.SPA.bin
+              - source_url: http://172.21.236.183/swim/V1712_2_CCO/cat9k_iosxe.17.12.02.SPA.bin
                 third_party: False
           tagging_details:
-            image_name: "{{item.image_name}}"
+            image_name: cat9k_iosxe.17.12.02.SPA.bin
+            device_role: ALL
+            device_image_family_name: Cisco Catalyst 9300 Switch
             site_name: "{{item.site_name}}"
-            device_role: "{{ item.device_role }}"
-            device_image_family_name: "{{ item.device_image_family_name }}"
-            tagging: False
-          image_distribution_details:
-            image_name: "{{item.image_name}}"
-            site_name: "{{item.site_name}}"
-            device_role: "{{ item.device_role }}"
-            device_family_name: "{{ item.device_family_name }}"
-            device_series_name: "Catalyst 9300 Series"
+            tagging: True
+          # image_distribution_details:
+          #   image_name: cat9k_iosxe.17.12.02.SPA.bin
+          #   site_name: "{{item.site_name}}"
+          #   device_role: "{{ item.device_role }}"
+          #   device_family_name: "{{ item.device_family_name }}"
+          #   device_series_name: "Catalyst 9300 Series"
           image_activation_details:
-            image_name: "{{item.image_name}}"
+            image_name: cat9k_iosxe.17.12.02.SPA.bin
             site_name: "{{item.site_name}}"
             device_role: "{{ item.device_role }}"
             device_family_name: "{{ item.device_family_name }}"

--- a/plugins/doc_fragments/intent_params.py
+++ b/plugins/doc_fragments/intent_params.py
@@ -95,6 +95,15 @@ options:
         description: Determines the mode of the file. Set to True for 'append' mode. Set to False for 'write' mode.
         type: bool
         default: True
+    danc_api_task_timeout:
+      description:  Defines the timeout in seconds for API calls to retrieve task details. If the task details
+          are not received within this period, the process will end, and a timeout notification will be logged.
+      type: int
+      default: 1200
+    dnac_task_poll_interval:
+      description: Specifies the interval in seconds between successive calls to the API to retrieve task details.
+      type: int
+      default: 2
     validate_response_schema:
         description:
           - Flag for Cisco DNA Center SDK to enable the validation of request bodies against a JSON schema.

--- a/plugins/doc_fragments/workflow_manager_params.py
+++ b/plugins/doc_fragments/workflow_manager_params.py
@@ -101,6 +101,15 @@ options:
           - Flag for Cisco Catalyst Center SDK to enable the validation of request bodies against a JSON schema.
         type: bool
         default: true
+    danc_api_task_timeout:
+      description:  Defines the timeout in seconds for API calls to retrieve task details. If the task details
+          are not received within this period, the process will end, and a timeout notification will be logged.
+      type: int
+      default: 1200
+    dnac_task_poll_interval:
+      description: Specifies the interval in seconds between successive calls to the API to retrieve task details.
+      type: int
+      default: 2
 notes:
     - "Does not support C(check_mode)"
     - "The plugin runs on the control node and does not use any ansible connection plugins instead embedded connection manager from Cisco Catalyst Center SDK"

--- a/plugins/modules/device_credential_intent.py
+++ b/plugins/modules/device_credential_intent.py
@@ -2583,6 +2583,8 @@ def main():
         "dnac_log_file_path": {"type": 'str', "default": 'dnac.log'},
         "dnac_log_append": {"type": 'bool', "default": True},
         "config_verify": {"type": 'bool', "default": False},
+        'danc_api_task_timeout': {'type': 'int', "default": 1200},
+        'dnac_task_poll_interval': {'type': 'int', "default": 2},
         "config": {"type": 'list', "required": True, "elements": 'dict'},
         "state": {"default": 'merged', "choices": ['merged', 'deleted']},
         "validate_response_schema": {"type": 'bool', "default": True},

--- a/plugins/modules/device_credential_workflow_manager.py
+++ b/plugins/modules/device_credential_workflow_manager.py
@@ -2582,6 +2582,8 @@ def main():
         "dnac_log_file_path": {"type": 'str', "default": 'dnac.log'},
         "dnac_log_append": {"type": 'bool', "default": True},
         "config_verify": {"type": 'bool', "default": False},
+        'danc_api_task_timeout': {'type': 'int', "default": 1200},
+        'dnac_task_poll_interval': {'type': 'int', "default": 2},
         "config": {"type": 'list', "required": True, "elements": 'dict'},
         "state": {"default": 'merged', "choices": ['merged', 'deleted']},
         "validate_response_schema": {"type": 'bool', "default": True},

--- a/plugins/modules/discovery_intent.py
+++ b/plugins/modules/discovery_intent.py
@@ -1593,6 +1593,8 @@ def main():
                     "dnac_log_append": {"type": 'bool', "default": True},
                     'validate_response_schema': {'type': 'bool', 'default': True},
                     'config_verify': {"type": 'bool', "default": False},
+                    'danc_api_task_timeout': {'type': 'int', "default": 1200},
+                    'dnac_task_poll_interval': {'type': 'int', "default": 2},
                     'config': {'required': True, 'type': 'list', 'elements': 'dict'},
                     'state': {'default': 'merged', 'choices': ['merged', 'deleted']}
                     }

--- a/plugins/modules/discovery_workflow_manager.py
+++ b/plugins/modules/discovery_workflow_manager.py
@@ -1593,6 +1593,8 @@ def main():
                     "dnac_log_append": {"type": 'bool', "default": True},
                     'validate_response_schema': {'type': 'bool', 'default': True},
                     'config_verify': {"type": 'bool', "default": False},
+                    'danc_api_task_timeout': {'type': 'int', "default": 1200},
+                    'dnac_task_poll_interval': {'type': 'int', "default": 2},
                     'config': {'required': True, 'type': 'list', 'elements': 'dict'},
                     'state': {'default': 'merged', 'choices': ['merged', 'deleted']}
                     }

--- a/plugins/modules/inventory_intent.py
+++ b/plugins/modules/inventory_intent.py
@@ -3576,6 +3576,8 @@ def main():
                     'dnac_log': {'type': 'bool', 'default': False},
                     'validate_response_schema': {'type': 'bool', 'default': True},
                     'config_verify': {'type': 'bool', "default": False},
+                    'danc_api_task_timeout': {'type': 'int', "default": 1200},
+                    'dnac_task_poll_interval': {'type': 'int', "default": 2},
                     'config': {'required': True, 'type': 'list', 'elements': 'dict'},
                     'state': {'default': 'merged', 'choices': ['merged', 'deleted']}
                     }

--- a/plugins/modules/inventory_intent.py
+++ b/plugins/modules/inventory_intent.py
@@ -39,6 +39,22 @@ options:
     elements: dict
     required: True
     suboptions:
+      type:
+        description: Select Device's type from NETWORK_DEVICE, COMPUTE_DEVICE, MERAKI_DASHBOARD, THIRD_PARTY_DEVICE, FIREPOWER_MANAGEMENT_SYSTEM.
+            NETWORK_DEVICE - This refers to traditional networking equipment such as routers, switches, access points, and firewalls. These devices
+                are responsible for routing, switching, and providing connectivity within the network.
+            COMPUTE_DEVICE - These are computing resources such as servers, virtual machines, or containers that are part of the network infrastructure.
+                Cisco Catalyst Center can integrate with compute devices to provide visibility and management capabilities, ensuring that the network and
+                 compute resources work together seamlessly to support applications and services.
+            MERAKI_DASHBOARD - It is cloud-based platform used to manage Meraki networking devices, including wireless access points, switches, security
+                appliances, and cameras.
+            THIRD_PARTY_DEVICE - This category encompasses devices from vendors other than Cisco or Meraki. Cisco Catalyst Center is designed to support
+                integration with third-party devices through open standards and APIs. This allows organizations to manage heterogeneous network
+                environments efficiently using Cisco Catalyst Center's centralized management and automation capabilities.
+            FIREPOWER_MANAGEMENT_SYSTEM - It is a centralized management console used to manage Cisco's Firepower Next-Generation Firewall (NGFW) devices.
+                It provides features such as policy management, threat detection, and advanced security analytics.
+        type: str
+        default: "NETWORK_DEVICE"
       cli_transport:
         description: The essential prerequisite for adding Network devices is the specification of the transport
             protocol (either SSH or Telnet) used by the device.
@@ -150,22 +166,6 @@ options:
                 It allows for the use of usernames, authentication passwords, and encryption keys, providing stronger
                 security compared to v2.
         type: str
-      type:
-        description: Select Device's type from NETWORK_DEVICE, COMPUTE_DEVICE, MERAKI_DASHBOARD, THIRD_PARTY_DEVICE, FIREPOWER_MANAGEMENT_SYSTEM.
-            NETWORK_DEVICE - This refers to traditional networking equipment such as routers, switches, access points, and firewalls. These devices
-                are responsible for routing, switching, and providing connectivity within the network.
-            COMPUTE_DEVICE - These are computing resources such as servers, virtual machines, or containers that are part of the network infrastructure.
-                Cisco Catalyst Center can integrate with compute devices to provide visibility and management capabilities, ensuring that the network and
-                 compute resources work together seamlessly to support applications and services.
-            MERAKI_DASHBOARD - It is cloud-based platform used to manage Meraki networking devices, including wireless access points, switches, security
-                appliances, and cameras.
-            THIRD_PARTY_DEVICE - This category encompasses devices from vendors other than Cisco or Meraki. Cisco Catalyst Center is designed to support
-                integration with third-party devices through open standards and APIs. This allows organizations to manage heterogeneous network
-                environments efficiently using Cisco Catalyst Center's centralized management and automation capabilities.
-            FIREPOWER_MANAGEMENT_SYSTEM - It is a centralized management console used to manage Cisco's Firepower Next-Generation Firewall (NGFW) devices.
-                It provides features such as policy management, threat detection, and advanced security analytics.
-        type: str
-        default: "NETWORK_DEVICE"
       update_mgmt_ipaddresslist:
         description: List of updated management IP addresses for network devices.
         type: list
@@ -201,64 +201,92 @@ options:
         description: Required if need to delete the Provisioned device by clearing current configuration.
         type: bool
         default: False
-      role:
-        description: Role of device which can be ACCESS, CORE, DISTRIBUTION, BORDER ROUTER, UNKNOWN.
-            UNKNOWN - This role is assigned to devices whose roles or functions have not been identified or classified within Cisco Catalsyt Center.
-                This could happen if the platform is unable to determine the device's role based on available information.
-            ACCESS - This role typically represents switches or access points that serve as access points for end-user devices to connect to the network.
-                These devices are often located at the edge of the network and provide connectivity to end-user devices.
-            BORDER ROUTER - These are devices that connect different network domains or segments together. They often serve as
-                gateways between different networks, such as connecting an enterprise network to the internet or connecting
-                multiple branch offices.
-            DISTRIBUTION - This role represents function as distribution switches or routers in hierarchical network designs. They aggregate traffic
-                from access switches and route it toward the core of the network or toward other distribution switches.
-            CORE - This role typically represents high-capacity switches or routers that form the backbone of the network. They handle large volumes
-                of traffic and provide connectivity between different parts of network, such as connecting distribution switches or
-                providing interconnection between different network segments.
-        type: str
-        default: "ACCESS"
-      name:
-        description: Name of Global User Defined Field. Required for creating/deleting UDF and then assigning it to device.
-        type: str
-      description:
-        description: Info about the global user defined field. Also used while updating interface details.
-        type: str
-      value:
-        description: Value to assign to tag with or without the same user defined field name.
-        type: str
-      admin_status:
-        description: Status of Interface of a device, it can be (UP/DOWN).
-        type: str
-      interface_name:
-        description: Specify the list of interface names to update the details of the device interface.
-            (For example, GigabitEthernet1/0/11, FortyGigabitEthernet1/1/2)
-        type: list
-        elements: str
-      vlan_id:
-        description: Unique Id number assigned to a VLAN within a network used only while updating interface details.
-        type: int
-      voice_vlan_id:
-        description: Identifier used to distinguish a specific VLAN that is dedicated to voice traffic used only while updating interface details.
-        type: int
-      deployment_mode:
-        description: Preview/Deploy [Preview means the configuration is not pushed to the device. Deploy makes the configuration pushed to the device]
-        type: str
-        default: "Deploy"
-      clear_mac_address_table:
-        description: Set this to true if you need to clear the MAC address table for a specific device's interface. It's a boolean type,
-            with a default value of False.
-        type: bool
-        default: False
-        version_added: 6.12.0
-      operation_enum:
-        description: enum(CREDENTIALDETAILS, DEVICEDETAILS) 0 to export Device Credential Details Or 1 to export Device Details.
-            CREDENTIALDETAILS - Used for exporting device credentials details like snpm credntials, device crdentails etc.
-            DEVICEDETAILS - Used for exporting device specific details like device hostname, serial number, type, family etc.
-        type: str
-      parameters:
-        description: List of device parameters that needs to be exported to file.
-        type: list
-        elements: str
+      update_device_role:
+        description: This operation will takes dictionary as a parameter and in this we give role of device and for role source
+            we are giving as MANUAL only.
+        type: dict
+        suboptions:
+          role:
+            description: Role of device which can be ACCESS, CORE, DISTRIBUTION, BORDER ROUTER, UNKNOWN.
+                ALL - This role typically represents all devices within the network, regardless of their specific roles or functions.
+                UNKNOWN - This role is assigned to devices whose roles or functions have not been identified or classified within Cisco Catalsyt Center.
+                    This could happen if the platform is unable to determine the device's role based on available information.
+                ACCESS - This role typically represents switches or access points that serve as access points for end-user devices to connect to the network.
+                    These devices are often located at the edge of the network and provide connectivity to end-user devices.
+                BORDER ROUTER - These are devices that connect different network domains or segments together. They often serve as
+                    gateways between different networks, such as connecting an enterprise network to the internet or connecting
+                    multiple branch offices.
+                DISTRIBUTION - This role represents function as distribution switches or routers in hierarchical network designs. They aggregate traffic
+                    from access switches and route it toward the core of the network or toward other distribution switches.
+                CORE - This role typically represents high-capacity switches or routers that form the backbone of the network. They handle large volumes
+                    of traffic and provide connectivity between different parts of network, such as connecting distribution switches or
+                    providing interconnection between different network segments.
+            type: str
+      add_user_defined_field:
+        description: This operation will takes dictionary as a parameter and in this we give details to
+            create/update/delete/assign multiple UDF to a device.
+        type: dict
+        suboptions:
+          name:
+            description: Name of Global User Defined Field. Required for creating/deleting UDF and then assigning it to device.
+            type: str
+          description:
+            description: Info about the global user defined field. Also used while updating interface details.
+            type: str
+          value:
+            description: Value to assign to tag with or without the same user defined field name.
+            type: str
+      update_interface_details:
+        description: This operation will takes dictionary as a parameter and in this we give details to update interface details of device.
+        type: dict
+        suboptions:
+          description:
+            description: Specifies the description of the interface of the device.
+            type: str
+          interface_name:
+            description: Specify the list of interface names to update the details of the device interface.
+                (For example, GigabitEthernet1/0/11, FortyGigabitEthernet1/1/2)
+            type: list
+            elements: str
+          vlan_id:
+            description: Unique Id number assigned to a VLAN within a network used only while updating interface details.
+            type: int
+          voice_vlan_id:
+            description: Identifier used to distinguish a specific VLAN that is dedicated to voice traffic used only while updating interface details.
+            type: int
+          deployment_mode:
+            description: Preview/Deploy [Preview means the configuration is not pushed to the device. Deploy makes the configuration pushed to the device]
+            type: str
+            default: "Deploy"
+          clear_mac_address_table:
+            description: Set this to true if you need to clear the MAC address table for a specific device's interface. It's a boolean type,
+                with a default value of False.
+            type: bool
+            default: False
+          admin_status:
+            description: Status of Interface of a device, it can be (UP/DOWN).
+            type: str
+      export_device_list:
+        description: This operation takes dictionary as parameter and export the device details as well as device credentials
+            details in a csv file.
+        type: dict
+        suboptions:
+          password:
+            description: Specifies the password for the encryption of file while exporting the device credentails into the file.
+            type: str
+          site_name:
+            description: Indicates the exact location where the wired device will be provisioned. This is a string value that should
+                represent the complete hierarchical path of the site (For example, "Global/USA/San Francisco/BGL_18/floor_pnp").
+            type: str
+          operation_enum:
+            description: enum(CREDENTIALDETAILS, DEVICEDETAILS) 0 to export Device Credential Details Or 1 to export Device Details.
+                CREDENTIALDETAILS - Used for exporting device credentials details like snpm credntials, device crdentails etc.
+                DEVICEDETAILS - Used for exporting device specific details like device hostname, serial number, type, family etc.
+            type: str
+          parameters:
+            description: List of device parameters that needs to be exported to file.(For example, ["componentName", "SerialNumber", "Last Sync Status"])
+            type: list
+            elements: str
       provision_wired_device:
         description: This parameter takes a list of dictionaries. Each dictionary provides the IP address of a wired device and
             the name of the site where the device will be provisioned.
@@ -286,75 +314,6 @@ options:
             type: int
             default: 2
             version_added: 6.12.0
-      reprovision_wired_device:
-        description: This parameter takes a list of dictionaries. Each dictionary provides the IP address of a wired device and
-            the name of the site where the device will be re-provisioned.
-        type: list
-        elements: dict
-        version_added: 6.12.0
-        suboptions:
-          device_ip:
-            description: Specifies the IP address of the wired device. This is a string value that should be in the format of
-                standard IPv4 or IPv6 addresses.
-            type: str
-          site_name:
-            description: Indicates the exact location where the wired device will be provisioned. This is a string value that should
-                represent the complete hierarchical path of the site (For example, "Global/USA/San Francisco/BGL_18/floor_pnp").
-            type: str
-      provision_wireless_device:
-        description: This parameter takes a list of dictionaries. Each dictionary provides the IP address of a wireless device and
-            the name of the site where the device will be provisioned along with dynamic interface details.
-        type: list
-        elements: dict
-        version_added: 6.12.0
-        suboptions:
-          device_ip:
-            description: Specifies the IP address of the wirelesss device. This is a string value that should be in the format of
-                standard IPv4 or IPv6 addresses.
-            type: str
-          site_name:
-            description: Indicates the exact location where the wired device will be provisioned. This is a string value that should
-                represent the complete hierarchical path of the site (For example, "Global/USA/San Francisco/BGL_18/floor_pnp").
-            type: str
-          managed_ap_locations:
-            description: Location of the sites allocated for the APs (For example, ["Global/USA/San Francisco/BGL_18/floor_test",
-                "Global/USA/San Francisco/BGL_18/floor_check"])
-            type: list
-            elements: str
-          dynamic_interfaces:
-            description: Interface details of the wireless device
-            type: list
-            elements: dict
-            suboptions:
-              interface_ip_address:
-                description: Ip Address allocated to the interface
-                type: str
-              interface_netmask_in_cidr:
-                description: The netmask of the interface, given in CIDR notation. This is an integer that represents the
-                    number of bits set in the netmask
-                type: int
-              interface_gateway:
-                description: The name identifier for the gateway associated with the interface.
-                type: str
-              lag_or_port_number:
-                description: The Link Aggregation Group (LAG) number or port number assigned to the interface.
-                type: int
-              vlan_id:
-                description: The VLAN (Virtual Local Area Network) ID associated with the network interface.
-                type: int
-              interface_name:
-                description: Name of the interface.
-                type: str
-          resync_retry_count:
-            description: Determines the total number of retry attempts for checking if the device has reached a managed state during
-                the provisioning process. If unspecified, the default value is set to 200 retries.
-            type: int
-            default: 200
-          resync_retry_interval:
-            description: Sets the interval, in seconds, at which the system will recheck the device status throughout the provisioning
-                process. If unspecified, the system will check the device status every 2 seconds by default.
-            type: int
-            default: 2
 
 requirements:
 - dnacentersdk >= 2.5.5
@@ -575,64 +534,6 @@ EXAMPLES = r"""
           resync_interval: 2
         - device_ip: "2.2.2.2"
           site_name: "Global/USA/San Francisco/BGL_18/floor_test"
-          resync_retry_count: 200
-          resync_retry_interval: 2
-
-- name: Re-Provisioned Wired Devices to site in Inventory
-  cisco.dnac.inventory_intent:
-    dnac_host: "{{dnac_host}}"
-    dnac_username: "{{dnac_username}}"
-    dnac_password: "{{dnac_password}}"
-    dnac_verify: "{{dnac_verify}}"
-    dnac_port: "{{dnac_port}}"
-    dnac_version: "{{dnac_version}}"
-    dnac_debug: "{{dnac_debug}}"
-    dnac_log_level: "{{dnac_log_level}}"
-    dnac_log: False
-    state: merged
-    config:
-      - reprovision_wired_device:
-        - device_ip: "1.1.1.1"
-          site_name: "Global/USA/San Francisco/BGL_18/floor_pnp"
-        - device_ip: "2.2.2.2"
-          site_name: "Global/USA/San Francisco/BGL_18/floor_test"
-
-- name: Associate Wireless Devices to site and Provisioned it in Inventory
-  cisco.dnac.inventory_intent:
-    dnac_host: "{{dnac_host}}"
-    dnac_username: "{{dnac_username}}"
-    dnac_password: "{{dnac_password}}"
-    dnac_verify: "{{dnac_verify}}"
-    dnac_port: "{{dnac_port}}"
-    dnac_version: "{{dnac_version}}"
-    dnac_debug: "{{dnac_debug}}"
-    dnac_log_level: "{{dnac_log_level}}"
-    dnac_log: False
-    state: merged
-    config:
-      - provision_wireless_device:
-        - device_ip: "1.1.1.1"
-          site_name: "Global/USA/BGL_18/floor_pnp"
-          managed_ap_locations: ["Global/USA/BGL_18/floor_pnp", "Global/USA/BGL_18/floor_test"]
-          dynamic_interfaces:
-          - interface_ip_address: 23.23.21.12
-            interface_netmask_in_cidr: 24
-            interface_gateway: "gateway"
-            lag_or_port_number: 12
-            vlan_id: 99
-            interface_name: "etherenet0/0"
-          resync_retry_count: 200
-          resync_retry_interval: 2
-        - device_ip: "2.2.2.2"
-          site_name: "Global/USA/BGL_18/floor_test"
-          managed_ap_locations: ["Global/USA/BGL_19/floor_pnp", "Global/USA/BGL_19/floor_test"]
-          dynamic_interfaces:
-          - interface_ip_address: 32.31.12.23
-            interface_netmask_in_cidr: 26
-            interface_gateway: "gateway_test"
-            lag_or_port_number: 33
-            vlan_id: 78
-            interface_name: "etherenet1/1"
           resync_retry_count: 200
           resync_retry_interval: 2
 
@@ -876,7 +777,10 @@ class DnacDevice(DnacBase):
             'snmp_version': {'type': 'str'},
             'update_mgmt_ipaddresslist': {'type': 'list', 'elements': 'dict'},
             'username': {'type': 'str'},
-            'update_device_role': {'type': 'dict'},
+            'update_device_role': {
+                'type': 'dict',
+                'role': {'type': 'str'},
+            },
             'device_updated': {'type': 'bool'},
             'device_resync': {'type': 'bool'},
             'reboot_device': {'type': 'bool'},
@@ -897,6 +801,7 @@ class DnacDevice(DnacBase):
                 'interface_name': {'type': 'list', 'elements': 'str'},
                 'deployment_mode': {'default': 'Deploy', 'type': 'str'},
                 'clear_mac_address_table': {'default': False, 'type': 'bool'},
+                'admin_status': {'type': 'str'},
             },
             'export_device_list': {
                 'type': 'dict',
@@ -908,28 +813,6 @@ class DnacDevice(DnacBase):
                 'type': 'list',
                 'device_ip': {'type': 'str'},
                 'site_name': {'type': 'str'},
-                'resync_retry_count': {'default': 200, 'type': 'int'},
-                'resync_retry_interval': {'default': 2, 'type': 'int'},
-            },
-            'reprovision_wired_device': {
-                'type': 'list',
-                'device_ip': {'type': 'str'},
-                'site_name': {'type': 'str'},
-            },
-            'provision_wireless_device': {
-                'type': 'list',
-                'device_ip': {'type': 'str'},
-                'site_name': {'type': 'str'},
-                'managed_ap_locations': {'type': 'list', 'elements': 'str'},
-                'dynamic_interfaces': {
-                    'type': 'list',
-                    'interface_ip_address': {'type': 'str'},
-                    'interface_netmask_in_cidr': {'type': 'int'},
-                    'interface_gateway': {'type': 'str'},
-                    'lag_or_port_number': {'type': 'int'},
-                    'vlan_id': {'type': 'int'},
-                    'interface_name': {'type': 'str'},
-                },
                 'resync_retry_count': {'default': 200, 'type': 'int'},
                 'resync_retry_interval': {'default': 2, 'type': 'int'},
             }
@@ -1792,96 +1675,6 @@ class DnacDevice(DnacBase):
 
         return self
 
-    def reprovisioned_wired_device(self):
-        """
-        Re-Provision wired devices in Cisco Catalyst Center.
-        Parameters:
-            self (object): An instance of a class used for interacting with Cisco Catalyst Center.
-        Returns:
-            self (object): An instance of the class with updated result, status, and log.
-        Description:
-            This function re-provision wired devices in Cisco Catalyst Center based on the configuration provided.
-            It retrieves the site name and IP addresses of the devices from the list of configuration,
-            attempts to provision each device with site, and monitors the provisioning process.
-        """
-
-        reprovision_wired_list = self.config[0]['reprovision_wired_device']
-        total_devices_to_reprovisioned = len(reprovision_wired_list)
-        device_in_dnac = self.device_exists_in_dnac()
-        device_ip_list = []
-        provision_count, already_provision_count = 0, 0
-
-        for prov_dict in reprovision_wired_list:
-            device_ip = prov_dict['device_ip']
-            device_ip_list.append(device_ip)
-            site_name = prov_dict['site_name']
-            device_type = "Wired"
-
-            if device_ip not in device_in_dnac:
-                self.msg = "Device '{0}' not present in Cisco Catalyst Center so cannot re-provisioned it.".format(device_ip)
-                self.log(self.msg, "WARNING")
-                continue
-
-            if not site_name or not device_ip:
-                self.status = "failed"
-                self.msg = "Site/Devices are required for Re-Provisioning of Wired Devices."
-                self.log(self.msg, "ERROR")
-                self.result['response'] = self.msg
-                return self
-
-            reprovision_wired_params = {
-                'deviceManagementIpAddress': device_ip,
-                'siteNameHierarchy': site_name
-            }
-
-            try:
-                response = self.dnac._exec(
-                    family="sda",
-                    function='re_provision_wired_device',
-                    op_modifies=True,
-                    params=reprovision_wired_params,
-                )
-
-                if response.get("status") == "failed":
-                    description = response.get("description")
-                    error_msg = "Cannot do Re-Provisioning for device {0} beacuse of {1}".format(device_ip, description)
-                    self.log(error_msg)
-                    continue
-
-                task_id = response.get("taskId")
-
-                while True:
-                    execution_details = self.get_task_details(task_id)
-                    progress = execution_details.get("data")
-
-                    if 'processcfs_complete=true' in progress:
-                        self.handle_successful_provisioning(device_ip, execution_details, device_type)
-                        provision_count += 1
-                        break
-                    elif execution_details.get("isError"):
-                        self.handle_failed_provisioning(device_ip, execution_details, device_type)
-                        break
-
-            except Exception as e:
-                # Not returning from here as there might be possiblity that for some devices it comes into exception
-                # but for others it gets provision successfully or If some devices are already provsioned
-                self.handle_provisioning_exception(device_ip, e, device_type)
-                if "already provisioned" in str(e):
-                    self.log(str(e), "INFO")
-                    already_provision_count += 1
-
-        # Check If all the devices are already provsioned, return from here only
-        if already_provision_count == total_devices_to_reprovisioned:
-            self.handle_all_already_provisioned(device_ip_list, device_type)
-        elif provision_count == total_devices_to_reprovisioned:
-            self.handle_all_provisioned(device_type)
-        elif provision_count == 0:
-            self.handle_all_failed_provision(device_type)
-        else:
-            self.handle_partially_provisioned(provision_count, device_type)
-
-        return self
-
     def get_wireless_param(self, prov_dict):
         """
         Get wireless provisioning parameters for a device.
@@ -2216,15 +2009,15 @@ class DnacDevice(DnacBase):
                 if device_ip_address not in device_in_dnac:
                     device_not_in_dnac.append(device_ip_address)
 
-        if self.config[0].get('provision_wireless_device'):
-            provision_wireless_list = self.config[0].get('provision_wireless_device')
+        # if self.config[0].get('provision_wireless_device'):
+        #     provision_wireless_list = self.config[0].get('provision_wireless_device')
 
-            for prov_dict in provision_wireless_list:
-                device_ip_address = prov_dict['device_ip']
-                if device_ip_address not in want_device and device_ip_address not in devices_in_playbook:
-                    devices_in_playbook.append(device_ip_address)
-                if device_ip_address not in device_in_dnac and device_ip_address not in device_not_in_dnac:
-                    device_not_in_dnac.append(device_ip_address)
+        #     for prov_dict in provision_wireless_list:
+        #         device_ip_address = prov_dict['device_ip']
+        #         if device_ip_address not in want_device and device_ip_address not in devices_in_playbook:
+        #             devices_in_playbook.append(device_ip_address)
+        #         if device_ip_address not in device_in_dnac and device_ip_address not in device_not_in_dnac:
+        #             device_not_in_dnac.append(device_ip_address)
 
         self.log("Device(s) {0} exists in Cisco Catalyst Center".format(str(device_in_dnac)), "INFO")
         have["want_device"] = want_device
@@ -2891,9 +2684,9 @@ class DnacDevice(DnacBase):
             elif execution_details.get("endTime"):
                 self.status = "success"
                 self.result['changed'] = True
-                self.result['response'] = execution_details
                 self.msg = """Device '{0}' present in Cisco Catalyst Center and new management ip '{1}' have been
                             updated successfully""".format(device_ip, new_mgmt_ipaddress)
+                self.result['response'] = self.msg
                 self.log(self.msg, "INFO")
                 break
 
@@ -3425,13 +3218,10 @@ class DnacDevice(DnacBase):
         if self.config[0].get('provision_wired_device'):
             self.provisioned_wired_device().check_return_status()
 
-        # This will be used to re-provisioned the wired device in inventory
-        if self.config[0].get('reprovision_wired_device'):
-            self.reprovisioned_wired_device().check_return_status()
-
         # Once Wireless device get added we will assign device to site and Provisioned it
-        if self.config[0].get('provision_wireless_device'):
-            self.provisioned_wireless_devices().check_return_status()
+        # Defer this feature as API issue is there once it's fixed we will addresses it in upcoming release iac2.0
+        # if self.config[0].get('provision_wireless_device'):
+        #     self.provisioned_wireless_devices().check_return_status()
 
         if device_resynced:
             self.resync_devices().check_return_status()
@@ -3713,26 +3503,6 @@ class DnacDevice(DnacBase):
             else:
                 self.log("""Mismatch between playbook's input and Cisco Catalyst Center detected, indicating that
                          the provisioning task may not have executed successfully.""", "INFO")
-
-        if self.config[0].get('reprovision_wired_device'):
-            reprovision_wired_list = self.config[0].get('reprovision_wired_device')
-            re_provision_flag = True
-            reprovision_device_list = []
-
-            for prov_dict in reprovision_wired_list:
-                device_ip = prov_dict['device_ip']
-                reprovision_device_list.append(device_ip)
-                if not self.get_provision_wired_device(device_ip):
-                    re_provision_flag = False
-                    break
-
-            if re_provision_flag:
-                self.status = "success"
-                msg = "Wired devices {0} get re-provisioned and verified successfully.".format(reprovision_device_list)
-                self.log(msg, "INFO")
-            else:
-                self.log("""Mismatch between playbook's input and Cisco Catalyst Center detected, indicating that
-                         the re-provisioning task may not have executed successfully.""", "INFO")
 
         return self
 

--- a/plugins/modules/inventory_workflow_manager.py
+++ b/plugins/modules/inventory_workflow_manager.py
@@ -3569,6 +3569,8 @@ def main():
                     'dnac_log': {'type': 'bool', 'default': False},
                     'validate_response_schema': {'type': 'bool', 'default': True},
                     'config_verify': {'type': 'bool', "default": False},
+                    'danc_api_task_timeout': {'type': 'int', "default": 1200},
+                    'dnac_task_poll_interval': {'type': 'int', "default": 2},
                     'config': {'required': True, 'type': 'list', 'elements': 'dict'},
                     'state': {'default': 'merged', 'choices': ['merged', 'deleted']}
                     }

--- a/plugins/modules/inventory_workflow_manager.py
+++ b/plugins/modules/inventory_workflow_manager.py
@@ -39,6 +39,22 @@ options:
     elements: dict
     required: True
     suboptions:
+      type:
+        description: Select Device's type from NETWORK_DEVICE, COMPUTE_DEVICE, MERAKI_DASHBOARD, THIRD_PARTY_DEVICE, FIREPOWER_MANAGEMENT_SYSTEM.
+            NETWORK_DEVICE - This refers to traditional networking equipment such as routers, switches, access points, and firewalls. These devices
+                are responsible for routing, switching, and providing connectivity within the network.
+            COMPUTE_DEVICE - These are computing resources such as servers, virtual machines, or containers that are part of the network infrastructure.
+                Cisco Catalyst Center can integrate with compute devices to provide visibility and management capabilities, ensuring that the network and
+                 compute resources work together seamlessly to support applications and services.
+            MERAKI_DASHBOARD - It is cloud-based platform used to manage Meraki networking devices, including wireless access points, switches, security
+                appliances, and cameras.
+            THIRD_PARTY_DEVICE - This category encompasses devices from vendors other than Cisco or Meraki. Cisco Catalyst Center is designed to support
+                integration with third-party devices through open standards and APIs. This allows organizations to manage heterogeneous network
+                environments efficiently using Cisco Catalyst Center's centralized management and automation capabilities.
+            FIREPOWER_MANAGEMENT_SYSTEM - It is a centralized management console used to manage Cisco's Firepower Next-Generation Firewall (NGFW) devices.
+                It provides features such as policy management, threat detection, and advanced security analytics.
+        type: str
+        default: "NETWORK_DEVICE"
       cli_transport:
         description: The essential prerequisite for adding Network devices is the specification of the transport
             protocol (either SSH or Telnet) used by the device.
@@ -150,22 +166,6 @@ options:
                 It allows for the use of usernames, authentication passwords, and encryption keys, providing stronger
                 security compared to v2.
         type: str
-      type:
-        description: Select Device's type from NETWORK_DEVICE, COMPUTE_DEVICE, MERAKI_DASHBOARD, THIRD_PARTY_DEVICE, FIREPOWER_MANAGEMENT_SYSTEM.
-            NETWORK_DEVICE - This refers to traditional networking equipment such as routers, switches, access points, and firewalls. These devices
-                are responsible for routing, switching, and providing connectivity within the network.
-            COMPUTE_DEVICE - These are computing resources such as servers, virtual machines, or containers that are part of the network infrastructure.
-                Cisco Catalyst Center can integrate with compute devices to provide visibility and management capabilities, ensuring that the network and
-                 compute resources work together seamlessly to support applications and services.
-            MERAKI_DASHBOARD - It is cloud-based platform used to manage Meraki networking devices, including wireless access points, switches, security
-                appliances, and cameras.
-            THIRD_PARTY_DEVICE - This category encompasses devices from vendors other than Cisco or Meraki. Cisco Catalyst Center is designed to support
-                integration with third-party devices through open standards and APIs. This allows organizations to manage heterogeneous network
-                environments efficiently using Cisco Catalyst Center's centralized management and automation capabilities.
-            FIREPOWER_MANAGEMENT_SYSTEM - It is a centralized management console used to manage Cisco's Firepower Next-Generation Firewall (NGFW) devices.
-                It provides features such as policy management, threat detection, and advanced security analytics.
-        type: str
-        default: "NETWORK_DEVICE"
       update_mgmt_ipaddresslist:
         description: List of updated management IP addresses for network devices.
         type: list
@@ -201,65 +201,92 @@ options:
         description: Required if need to delete the Provisioned device by clearing current configuration.
         type: bool
         default: False
-      role:
-        description: Role of device which can be ACCESS, CORE, DISTRIBUTION, BORDER ROUTER, UNKNOWN.
-            ALL - This role typically represents all devices within the network, regardless of their specific roles or functions.
-            UNKNOWN - This role is assigned to devices whose roles or functions have not been identified or classified within Cisco Catalsyt Center.
-                This could happen if the platform is unable to determine the device's role based on available information.
-            ACCESS - This role typically represents switches or access points that serve as access points for end-user devices to connect to the network.
-                These devices are often located at the edge of the network and provide connectivity to end-user devices.
-            BORDER ROUTER - These are devices that connect different network domains or segments together. They often serve as
-                gateways between different networks, such as connecting an enterprise network to the internet or connecting
-                multiple branch offices.
-            DISTRIBUTION - This role represents function as distribution switches or routers in hierarchical network designs. They aggregate traffic
-                from access switches and route it toward the core of the network or toward other distribution switches.
-            CORE - This role typically represents high-capacity switches or routers that form the backbone of the network. They handle large volumes
-                of traffic and provide connectivity between different parts of network, such as connecting distribution switches or
-                providing interconnection between different network segments.
-        type: str
-        default: "ACCESS"
-      name:
-        description: Name of Global User Defined Field. Required for creating/deleting UDF and then assigning it to device.
-        type: str
-      description:
-        description: Info about the global user defined field. Also used while updating interface details.
-        type: str
-      value:
-        description: Value to assign to tag with or without the same user defined field name.
-        type: str
-      admin_status:
-        description: Status of Interface of a device, it can be (UP/DOWN).
-        type: str
-      interface_name:
-        description: Specify the list of interface names to update the details of the device interface.
-            (For example, GigabitEthernet1/0/11, FortyGigabitEthernet1/1/2)
-        type: list
-        elements: str
-      vlan_id:
-        description: Unique Id number assigned to a VLAN within a network used only while updating interface details.
-        type: int
-      voice_vlan_id:
-        description: Identifier used to distinguish a specific VLAN that is dedicated to voice traffic used only while updating interface details.
-        type: int
-      deployment_mode:
-        description: Preview/Deploy [Preview means the configuration is not pushed to the device. Deploy makes the configuration pushed to the device]
-        type: str
-        default: "Deploy"
-      clear_mac_address_table:
-        description: Set this to true if you need to clear the MAC address table for a specific device's interface. It's a boolean type,
-            with a default value of False.
-        type: bool
-        default: False
-        version_added: 6.12.0
-      operation_enum:
-        description: enum(CREDENTIALDETAILS, DEVICEDETAILS) 0 to export Device Credential Details Or 1 to export Device Details.
-            CREDENTIALDETAILS - Used for exporting device credentials details like snpm credntials, device crdentails etc.
-            DEVICEDETAILS - Used for exporting device specific details like device hostname, serial number, type, family etc.
-        type: str
-      parameters:
-        description: List of device parameters that needs to be exported to file.
-        type: list
-        elements: str
+      update_device_role:
+        description: This operation will takes dictionary as a parameter and in this we give role of device and for role source
+            we are giving as MANUAL only.
+        type: dict
+        suboptions:
+          role:
+            description: Role of device which can be ACCESS, CORE, DISTRIBUTION, BORDER ROUTER, UNKNOWN.
+                ALL - This role typically represents all devices within the network, regardless of their specific roles or functions.
+                UNKNOWN - This role is assigned to devices whose roles or functions have not been identified or classified within Cisco Catalsyt Center.
+                    This could happen if the platform is unable to determine the device's role based on available information.
+                ACCESS - This role typically represents switches or access points that serve as access points for end-user devices to connect to the network.
+                    These devices are often located at the edge of the network and provide connectivity to end-user devices.
+                BORDER ROUTER - These are devices that connect different network domains or segments together. They often serve as
+                    gateways between different networks, such as connecting an enterprise network to the internet or connecting
+                    multiple branch offices.
+                DISTRIBUTION - This role represents function as distribution switches or routers in hierarchical network designs. They aggregate traffic
+                    from access switches and route it toward the core of the network or toward other distribution switches.
+                CORE - This role typically represents high-capacity switches or routers that form the backbone of the network. They handle large volumes
+                    of traffic and provide connectivity between different parts of network, such as connecting distribution switches or
+                    providing interconnection between different network segments.
+            type: str
+      add_user_defined_field:
+        description: This operation will takes dictionary as a parameter and in this we give details to
+            create/update/delete/assign multiple UDF to a device.
+        type: dict
+        suboptions:
+          name:
+            description: Name of Global User Defined Field. Required for creating/deleting UDF and then assigning it to device.
+            type: str
+          description:
+            description: Info about the global user defined field. Also used while updating interface details.
+            type: str
+          value:
+            description: Value to assign to tag with or without the same user defined field name.
+            type: str
+      update_interface_details:
+        description: This operation will takes dictionary as a parameter and in this we give details to update interface details of device.
+        type: dict
+        suboptions:
+          description:
+            description: Specifies the description of the interface of the device.
+            type: str
+          interface_name:
+            description: Specify the list of interface names to update the details of the device interface.
+                (For example, GigabitEthernet1/0/11, FortyGigabitEthernet1/1/2)
+            type: list
+            elements: str
+          vlan_id:
+            description: Unique Id number assigned to a VLAN within a network used only while updating interface details.
+            type: int
+          voice_vlan_id:
+            description: Identifier used to distinguish a specific VLAN that is dedicated to voice traffic used only while updating interface details.
+            type: int
+          deployment_mode:
+            description: Preview/Deploy [Preview means the configuration is not pushed to the device. Deploy makes the configuration pushed to the device]
+            type: str
+            default: "Deploy"
+          clear_mac_address_table:
+            description: Set this to true if you need to clear the MAC address table for a specific device's interface. It's a boolean type,
+                with a default value of False.
+            type: bool
+            default: False
+          admin_status:
+            description: Status of Interface of a device, it can be (UP/DOWN).
+            type: str
+      export_device_list:
+        description: This operation takes dictionary as parameter and export the device details as well as device credentials
+            details in a csv file.
+        type: dict
+        suboptions:
+          password:
+            description: Specifies the password for the encryption of file while exporting the device credentails into the file.
+            type: str
+          site_name:
+            description: Indicates the exact location where the wired device will be provisioned. This is a string value that should
+                represent the complete hierarchical path of the site (For example, "Global/USA/San Francisco/BGL_18/floor_pnp").
+            type: str
+          operation_enum:
+            description: enum(CREDENTIALDETAILS, DEVICEDETAILS) 0 to export Device Credential Details Or 1 to export Device Details.
+                CREDENTIALDETAILS - Used for exporting device credentials details like snpm credntials, device crdentails etc.
+                DEVICEDETAILS - Used for exporting device specific details like device hostname, serial number, type, family etc.
+            type: str
+          parameters:
+            description: List of device parameters that needs to be exported to file.(For example, ["componentName", "SerialNumber", "Last Sync Status"])
+            type: list
+            elements: str
       provision_wired_device:
         description: This parameter takes a list of dictionaries. Each dictionary provides the IP address of a wired device and
             the name of the site where the device will be provisioned.
@@ -287,75 +314,6 @@ options:
             type: int
             default: 2
             version_added: 6.12.0
-      reprovision_wired_device:
-        description: This parameter takes a list of dictionaries. Each dictionary provides the IP address of a wired device and
-            the name of the site where the device will be re-provisioned.
-        type: list
-        elements: dict
-        version_added: 6.12.0
-        suboptions:
-          device_ip:
-            description: Specifies the IP address of the wired device. This is a string value that should be in the format of
-                standard IPv4 or IPv6 addresses.
-            type: str
-          site_name:
-            description: Indicates the exact location where the wired device will be provisioned. This is a string value that should
-                represent the complete hierarchical path of the site (For example, "Global/USA/San Francisco/BGL_18/floor_pnp").
-            type: str
-      provision_wireless_device:
-        description: This parameter takes a list of dictionaries. Each dictionary provides the IP address of a wireless device and
-            the name of the site where the device will be provisioned along with dynamic interface details.
-        type: list
-        elements: dict
-        version_added: 6.12.0
-        suboptions:
-          device_ip:
-            description: Specifies the IP address of the wirelesss device. This is a string value that should be in the format of
-                standard IPv4 or IPv6 addresses.
-            type: str
-          site_name:
-            description: Indicates the exact location where the wired device will be provisioned. This is a string value that should
-                represent the complete hierarchical path of the site (For example, "Global/USA/San Francisco/BGL_18/floor_pnp").
-            type: str
-          managed_ap_locations:
-            description: Location of the sites allocated for the APs (For example, ["Global/USA/San Francisco/BGL_18/floor_test",
-                "Global/USA/San Francisco/BGL_18/floor_check"])
-            type: list
-            elements: str
-          dynamic_interfaces:
-            description: Interface details of the wireless device
-            type: list
-            elements: dict
-            suboptions:
-              interface_ip_address:
-                description: Ip Address allocated to the interface
-                type: str
-              interface_netmask_in_cidr:
-                description: The netmask of the interface, given in CIDR notation. This is an integer that represents the
-                    number of bits set in the netmask
-                type: int
-              interface_gateway:
-                description: The name identifier for the gateway associated with the interface.
-                type: str
-              lag_or_port_number:
-                description: The Link Aggregation Group (LAG) number or port number assigned to the interface.
-                type: int
-              vlan_id:
-                description: The VLAN (Virtual Local Area Network) ID associated with the network interface.
-                type: int
-              interface_name:
-                description: Name of the interface.
-                type: str
-          resync_retry_count:
-            description: Determines the total number of retry attempts for checking if the device has reached a managed state during
-                the provisioning process. If unspecified, the default value is set to 200 retries.
-            type: int
-            default: 200
-          resync_retry_interval:
-            description: Sets the interval, in seconds, at which the system will recheck the device status throughout the provisioning
-                process. If unspecified, the system will check the device status every 2 seconds by default.
-            type: int
-            default: 2
 
 requirements:
 - dnacentersdk >= 2.5.5
@@ -576,64 +534,6 @@ EXAMPLES = r"""
           resync_interval: 2
         - device_ip: "2.2.2.2"
           site_name: "Global/USA/San Francisco/BGL_18/floor_test"
-          resync_retry_count: 200
-          resync_retry_interval: 2
-
-- name: Re-Provisioned Wired Devices to site in Inventory
-  cisco.dnac.inventory_intent:
-    dnac_host: "{{dnac_host}}"
-    dnac_username: "{{dnac_username}}"
-    dnac_password: "{{dnac_password}}"
-    dnac_verify: "{{dnac_verify}}"
-    dnac_port: "{{dnac_port}}"
-    dnac_version: "{{dnac_version}}"
-    dnac_debug: "{{dnac_debug}}"
-    dnac_log_level: "{{dnac_log_level}}"
-    dnac_log: False
-    state: merged
-    config:
-      - reprovision_wired_device:
-        - device_ip: "1.1.1.1"
-          site_name: "Global/USA/San Francisco/BGL_18/floor_pnp"
-        - device_ip: "2.2.2.2"
-          site_name: "Global/USA/San Francisco/BGL_18/floor_test"
-
-- name: Associate Wireless Devices to site and Provisioned it in Inventory
-  cisco.dnac.inventory_workflow_manager:
-    dnac_host: "{{dnac_host}}"
-    dnac_username: "{{dnac_username}}"
-    dnac_password: "{{dnac_password}}"
-    dnac_verify: "{{dnac_verify}}"
-    dnac_port: "{{dnac_port}}"
-    dnac_version: "{{dnac_version}}"
-    dnac_debug: "{{dnac_debug}}"
-    dnac_log_level: "{{dnac_log_level}}"
-    dnac_log: False
-    state: merged
-    config:
-        provision_wireless_device:
-        - device_ip: "1.1.1.1"
-          site_name: "Global/USA/BGL_18/floor_pnp"
-          managed_ap_locations: ["Global/USA/BGL_18/floor_pnp", "Global/USA/BGL_18/floor_test"]
-          dynamic_interfaces:
-          - interface_ip_address: 23.23.21.12
-            interface_netmask_in_cidr: 24
-            interface_gateway: "gateway"
-            lag_or_port_number: 12
-            vlan_id: 99
-            interface_name: "etherenet0/0"
-          resync_retry_count: 200
-          resync_retry_interval: 2
-        - device_ip: "2.2.2.2"
-          site_name: "Global/USA/BGL_18/floor_test"
-          managed_ap_locations: ["Global/USA/BGL_19/floor_pnp", "Global/USA/BGL_19/floor_test"]
-          dynamic_interfaces:
-          - interface_ip_address: 32.31.12.23
-            interface_netmask_in_cidr: 26
-            interface_gateway: "gateway_test"
-            lag_or_port_number: 33
-            vlan_id: 78
-            interface_name: "etherenet1/1"
           resync_retry_count: 200
           resync_retry_interval: 2
 
@@ -876,7 +776,10 @@ class Inventory(DnacBase):
             'snmp_version': {'type': 'str'},
             'update_mgmt_ipaddresslist': {'type': 'list', 'elements': 'dict'},
             'username': {'type': 'str'},
-            'update_device_role': {'type': 'dict'},
+            'update_device_role': {
+                'type': 'dict',
+                'role': {'type': 'str'},
+            },
             'device_updated': {'type': 'bool'},
             'device_resync': {'type': 'bool'},
             'reboot_device': {'type': 'bool'},
@@ -897,6 +800,7 @@ class Inventory(DnacBase):
                 'interface_name': {'type': 'list', 'elements': 'str'},
                 'deployment_mode': {'default': 'Deploy', 'type': 'str'},
                 'clear_mac_address_table': {'default': False, 'type': 'bool'},
+                'admin_status': {'type': 'str'},
             },
             'export_device_list': {
                 'type': 'dict',
@@ -908,28 +812,6 @@ class Inventory(DnacBase):
                 'type': 'list',
                 'device_ip': {'type': 'str'},
                 'site_name': {'type': 'str'},
-                'resync_retry_count': {'default': 200, 'type': 'int'},
-                'resync_retry_interval': {'default': 2, 'type': 'int'},
-            },
-            'reprovision_wired_device': {
-                'type': 'list',
-                'device_ip': {'type': 'str'},
-                'site_name': {'type': 'str'},
-            },
-            'provision_wireless_device': {
-                'type': 'list',
-                'device_ip': {'type': 'str'},
-                'site_name': {'type': 'str'},
-                'managed_ap_locations': {'type': 'list', 'elements': 'str'},
-                'dynamic_interfaces': {
-                    'type': 'list',
-                    'interface_ip_address': {'type': 'str'},
-                    'interface_netmask_in_cidr': {'type': 'int'},
-                    'interface_gateway': {'type': 'str'},
-                    'lag_or_port_number': {'type': 'int'},
-                    'vlan_id': {'type': 'int'},
-                    'interface_name': {'type': 'str'},
-                },
                 'resync_retry_count': {'default': 200, 'type': 'int'},
                 'resync_retry_interval': {'default': 2, 'type': 'int'},
             }
@@ -1790,96 +1672,6 @@ class Inventory(DnacBase):
 
         return self
 
-    def reprovisioned_wired_device(self):
-        """
-        Re-Provision wired devices in Cisco Catalyst Center.
-        Parameters:
-            self (object): An instance of a class used for interacting with Cisco Catalyst Center.
-        Returns:
-            self (object): An instance of the class with updated result, status, and log.
-        Description:
-            This function re-provision wired devices in Cisco Catalyst Center based on the configuration provided.
-            It retrieves the site name and IP addresses of the devices from the list of configuration,
-            attempts to provision each device with site, and monitors the provisioning process.
-        """
-
-        reprovision_wired_list = self.config[0]['reprovision_wired_device']
-        total_devices_to_reprovisioned = len(reprovision_wired_list)
-        device_in_ccc = self.device_exists_in_ccc()
-        device_ip_list = []
-        provision_count, already_provision_count = 0, 0
-
-        for prov_dict in reprovision_wired_list:
-            device_ip = prov_dict['device_ip']
-            device_ip_list.append(device_ip)
-            site_name = prov_dict['site_name']
-            device_type = "Wired"
-
-            if device_ip not in device_in_ccc:
-                self.msg = "Device '{0}' not present in Cisco Catalyst Center so cannot re-provisioned it.".format(device_ip)
-                self.log(self.msg, "WARNING")
-                continue
-
-            if not site_name or not device_ip:
-                self.status = "failed"
-                self.msg = "Site/Devices are required for Re-Provisioning of Wired Devices."
-                self.log(self.msg, "ERROR")
-                self.result['response'] = self.msg
-                return self
-
-            reprovision_wired_params = {
-                'deviceManagementIpAddress': device_ip,
-                'siteNameHierarchy': site_name
-            }
-
-            try:
-                response = self.dnac._exec(
-                    family="sda",
-                    function='re_provision_wired_device',
-                    op_modifies=True,
-                    params=reprovision_wired_params,
-                )
-
-                if response.get("status") == "failed":
-                    description = response.get("description")
-                    error_msg = "Cannot do Re-Provisioning for device {0} beacuse of {1}".format(device_ip, description)
-                    self.log(error_msg)
-                    continue
-
-                task_id = response.get("taskId")
-
-                while True:
-                    execution_details = self.get_task_details(task_id)
-                    progress = execution_details.get("data")
-
-                    if 'processcfs_complete=true' in progress:
-                        self.handle_successful_provisioning(device_ip, execution_details, device_type)
-                        provision_count += 1
-                        break
-                    elif execution_details.get("isError"):
-                        self.handle_failed_provisioning(device_ip, execution_details, device_type)
-                        break
-
-            except Exception as e:
-                # Not returning from here as there might be possiblity that for some devices it comes into exception
-                # but for others it gets provision successfully or If some devices are already provsioned
-                self.handle_provisioning_exception(device_ip, e, device_type)
-                if "already provisioned" in str(e):
-                    self.log(str(e), "INFO")
-                    already_provision_count += 1
-
-        # Check If all the devices are already provsioned, return from here only
-        if already_provision_count == total_devices_to_reprovisioned:
-            self.handle_all_already_provisioned(device_ip_list, device_type)
-        elif provision_count == total_devices_to_reprovisioned:
-            self.handle_all_provisioned(device_type)
-        elif provision_count == 0:
-            self.handle_all_failed_provision(device_type)
-        else:
-            self.handle_partially_provisioned(provision_count, device_type)
-
-        return self
-
     def get_wireless_param(self, prov_dict):
         """
         Get wireless provisioning parameters for a device.
@@ -2209,15 +2001,15 @@ class Inventory(DnacBase):
                 if device_ip_address not in device_in_ccc:
                     device_not_in_ccc.append(device_ip_address)
 
-        if self.config[0].get('provision_wireless_device'):
-            provision_wireless_list = self.config[0].get('provision_wireless_device')
+        # if self.config[0].get('provision_wireless_device'):
+        #     provision_wireless_list = self.config[0].get('provision_wireless_device')
 
-            for prov_dict in provision_wireless_list:
-                device_ip_address = prov_dict['device_ip']
-                if device_ip_address not in want_device and device_ip_address not in devices_in_playbook:
-                    devices_in_playbook.append(device_ip_address)
-                if device_ip_address not in device_in_ccc and device_ip_address not in device_not_in_ccc:
-                    device_not_in_ccc.append(device_ip_address)
+        #     for prov_dict in provision_wireless_list:
+        #         device_ip_address = prov_dict['device_ip']
+        #         if device_ip_address not in want_device and device_ip_address not in devices_in_playbook:
+        #             devices_in_playbook.append(device_ip_address)
+        #         if device_ip_address not in device_in_ccc and device_ip_address not in device_not_in_ccc:
+        #             device_not_in_ccc.append(device_ip_address)
 
         self.log("Device(s) {0} exists in Cisco Catalyst Center".format(str(device_in_ccc)), "INFO")
         have["want_device"] = want_device
@@ -2885,9 +2677,9 @@ class Inventory(DnacBase):
             elif execution_details.get("endTime"):
                 self.status = "success"
                 self.result['changed'] = True
-                self.result['response'] = execution_details
                 self.msg = """Device '{0}' present in Cisco Catalyst Center and new management ip '{1}' have been
                             updated successfully""".format(device_ip, new_mgmt_ipaddress)
+                self.result['response'] = self.msg
                 self.log(self.msg, "INFO")
                 break
 
@@ -3419,13 +3211,10 @@ class Inventory(DnacBase):
         if self.config[0].get('provision_wired_device'):
             self.provisioned_wired_device().check_return_status()
 
-        # This will be used to re-provisioned the wired device in inventory
-        if self.config[0].get('reprovision_wired_device'):
-            self.reprovisioned_wired_device().check_return_status()
-
         # Once Wireless device get added we will assign device to site and Provisioned it
-        if self.config[0].get('provision_wireless_device'):
-            self.provisioned_wireless_devices().check_return_status()
+        # Defer this feature as API issue is there once it's fixed we will addresses it in upcoming release iac2.0
+        # if self.config[0].get('provision_wireless_device'):
+        #     self.provisioned_wireless_devices().check_return_status()
 
         if device_resynced:
             self.resync_devices().check_return_status()
@@ -3707,26 +3496,6 @@ class Inventory(DnacBase):
             else:
                 self.log("""Mismatch between playbook's input and Cisco Catalyst Center detected, indicating that
                          the provisioning task may not have executed successfully.""", "INFO")
-
-        if self.config[0].get('reprovision_wired_device'):
-            reprovision_wired_list = self.config[0].get('reprovision_wired_device')
-            re_provision_flag = True
-            reprovision_device_list = []
-
-            for prov_dict in reprovision_wired_list:
-                device_ip = prov_dict['device_ip']
-                reprovision_device_list.append(device_ip)
-                if not self.get_provision_wired_device(device_ip):
-                    re_provision_flag = False
-                    break
-
-            if re_provision_flag:
-                self.status = "success"
-                msg = "Wired devices {0} get re-provisioned and verified successfully.".format(reprovision_device_list)
-                self.log(msg, "INFO")
-            else:
-                self.log("""Mismatch between playbook's input and Cisco Catalyst Center detected, indicating that
-                         the re-provisioning task may not have executed successfully.""", "INFO")
 
         return self
 

--- a/plugins/modules/inventory_workflow_manager.py
+++ b/plugins/modules/inventory_workflow_manager.py
@@ -201,29 +201,24 @@ options:
         description: Required if need to delete the Provisioned device by clearing current configuration.
         type: bool
         default: False
-      update_device_role:
-        description: This operation will takes dictionary as a parameter and in this we give role of device and for role source
-            we are giving as MANUAL only.
-        type: dict
-        suboptions:
-          role:
-            description: Role of device which can be ACCESS, CORE, DISTRIBUTION, BORDER ROUTER, UNKNOWN.
-                ALL - This role typically represents all devices within the network, regardless of their specific roles or functions.
-                UNKNOWN - This role is assigned to devices whose roles or functions have not been identified or classified within Cisco Catalsyt Center.
-                    This could happen if the platform is unable to determine the device's role based on available information.
-                ACCESS - This role typically represents switches or access points that serve as access points for end-user devices to connect to the network.
-                    These devices are often located at the edge of the network and provide connectivity to end-user devices.
-                BORDER ROUTER - These are devices that connect different network domains or segments together. They often serve as
-                    gateways between different networks, such as connecting an enterprise network to the internet or connecting
-                    multiple branch offices.
-                DISTRIBUTION - This role represents function as distribution switches or routers in hierarchical network designs. They aggregate traffic
-                    from access switches and route it toward the core of the network or toward other distribution switches.
-                CORE - This role typically represents high-capacity switches or routers that form the backbone of the network. They handle large volumes
-                    of traffic and provide connectivity between different parts of network, such as connecting distribution switches or
-                    providing interconnection between different network segments.
-            type: str
+      role:
+        description: Role of device which can be ACCESS, CORE, DISTRIBUTION, BORDER ROUTER, UNKNOWN.
+            ALL - This role typically represents all devices within the network, regardless of their specific roles or functions.
+            UNKNOWN - This role is assigned to devices whose roles or functions have not been identified or classified within Cisco Catalsyt Center.
+                This could happen if the platform is unable to determine the device's role based on available information.
+            ACCESS - This role typically represents switches or access points that serve as access points for end-user devices to connect to the network.
+                These devices are often located at the edge of the network and provide connectivity to end-user devices.
+            BORDER ROUTER - These are devices that connect different network domains or segments together. They often serve as
+                gateways between different networks, such as connecting an enterprise network to the internet or connecting
+                multiple branch offices.
+            DISTRIBUTION - This role represents function as distribution switches or routers in hierarchical network designs. They aggregate traffic
+                from access switches and route it toward the core of the network or toward other distribution switches.
+            CORE - This role typically represents high-capacity switches or routers that form the backbone of the network. They handle large volumes
+                of traffic and provide connectivity between different parts of network, such as connecting distribution switches or
+                providing interconnection between different network segments.
+        type: str
       add_user_defined_field:
-        description: This operation will takes dictionary as a parameter and in this we give details to
+        description: This operation will take dictionary as a parameter and in this we give details to
             create/update/delete/assign multiple UDF to a device.
         type: dict
         suboptions:
@@ -237,7 +232,7 @@ options:
             description: Value to assign to tag with or without the same user defined field name.
             type: str
       update_interface_details:
-        description: This operation will takes dictionary as a parameter and in this we give details to update interface details of device.
+        description: This operation will take dictionary as a parameter and in this we give details to update interface details of device.
         type: dict
         suboptions:
           description:
@@ -267,7 +262,7 @@ options:
             description: Status of Interface of a device, it can be (UP/DOWN).
             type: str
       export_device_list:
-        description: This operation takes dictionary as parameter and export the device details as well as device credentials
+        description: This operation take dictionary as parameter and export the device details as well as device credentials
             details in a csv file.
         type: dict
         suboptions:
@@ -344,6 +339,12 @@ notes:
   - Renamed argument 'ip_address' to 'ip_address_list' option in v6.12.0.
 
   - Removed 'serial_number', 'device_added', 'role_source', options in v6.12.0.
+
+  - Added 'add_user_defined_field', 'update_interface_details', 'export_device_list' options in v6.13.2.
+
+  - Removed 'provision_wireless_device', 'reprovision_wired_device' options in v6.13.2.
+
+  - Added the parameter 'admin_status' options in v6.13.2.
 
 """
 
@@ -551,9 +552,7 @@ EXAMPLES = r"""
     state: merged
     config:
       - ip_address_list: ["1.1.1.1", "2.2.2.2"]
-        device_updated: True
-        update_device_role:
-          role: ACCESS
+        role: ACCESS
 
 - name: Update Interface details with IP Address
   cisco.dnac.inventory_workflow_manager:
@@ -720,6 +719,8 @@ from ansible_collections.cisco.dnac.plugins.module_utils.dnac import (
     DnacBase,
     validate_list_of_dicts,
 )
+# Defer this feature as API issue is there once it's fixed we will addresses it in upcoming release iac2.0
+support_for_provisioning_wireless = False
 
 
 class Inventory(DnacBase):
@@ -776,10 +777,7 @@ class Inventory(DnacBase):
             'snmp_version': {'type': 'str'},
             'update_mgmt_ipaddresslist': {'type': 'list', 'elements': 'dict'},
             'username': {'type': 'str'},
-            'update_device_role': {
-                'type': 'dict',
-                'role': {'type': 'str'},
-            },
+            'role': {'type': 'str'},
             'device_updated': {'type': 'bool'},
             'device_resync': {'type': 'bool'},
             'reboot_device': {'type': 'bool'},
@@ -2001,15 +1999,16 @@ class Inventory(DnacBase):
                 if device_ip_address not in device_in_ccc:
                     device_not_in_ccc.append(device_ip_address)
 
-        # if self.config[0].get('provision_wireless_device'):
-        #     provision_wireless_list = self.config[0].get('provision_wireless_device')
+        if support_for_provisioning_wireless:
+            if self.config[0].get('provision_wireless_device'):
+                provision_wireless_list = self.config[0].get('provision_wireless_device')
 
-        #     for prov_dict in provision_wireless_list:
-        #         device_ip_address = prov_dict['device_ip']
-        #         if device_ip_address not in want_device and device_ip_address not in devices_in_playbook:
-        #             devices_in_playbook.append(device_ip_address)
-        #         if device_ip_address not in device_in_ccc and device_ip_address not in device_not_in_ccc:
-        #             device_not_in_ccc.append(device_ip_address)
+                for prov_dict in provision_wireless_list:
+                    device_ip_address = prov_dict['device_ip']
+                    if device_ip_address not in want_device and device_ip_address not in devices_in_playbook:
+                        devices_in_playbook.append(device_ip_address)
+                    if device_ip_address not in device_in_ccc and device_ip_address not in device_not_in_ccc:
+                        device_not_in_ccc.append(device_ip_address)
 
         self.log("Device(s) {0} exists in Cisco Catalyst Center".format(str(device_in_ccc)), "INFO")
         have["want_device"] = want_device
@@ -2333,8 +2332,7 @@ class Inventory(DnacBase):
             for updating device roles.
         """
 
-        device_role_args = self.config[0].get('update_device_role')
-        role = device_role_args.get('role')
+        role = self.config[0].get('role')
         response = self.get_device_response(device_ip)
 
         return response.get('role') == role
@@ -2915,6 +2913,82 @@ class Inventory(DnacBase):
                 self.log(error_message, "ERROR")
                 raise Exception(error_message)
 
+        # Update the role of devices having the role source as Manual
+        if self.config[0].get('role'):
+            devices_to_update_role = self.get_device_ips_from_config_priority()
+            device_role = self.config[0].get('role')
+            role_update_count = 0
+            for device_ip in devices_to_update_role:
+                device_id = self.get_device_ids([device_ip])
+
+                # Check if the same role of device is present in dnac then no need to change the state
+                response = self.dnac._exec(
+                    family="devices",
+                    function='get_device_list',
+                    params={"managementIpAddress": device_ip}
+                )
+                response = response.get('response')[0]
+
+                if response.get('role') == device_role:
+                    self.status = "success"
+                    self.result['changed'] = False
+                    role_update_count += 1
+                    log_msg = "The device role '{0}' is already set in Cisco Catalyst Center, no update is needed.".format(device_role)
+                    self.log(log_msg, "INFO")
+                    continue
+
+                device_role_params = {
+                    'role': device_role,
+                    'roleSource': "MANUAL",
+                    'id': device_id[0]
+                }
+
+                try:
+                    response = self.dnac._exec(
+                        family="devices",
+                        function='update_device_role',
+                        op_modifies=True,
+                        params=device_role_params,
+                    )
+                    self.log("Received API response from 'update_device_role': {0}".format(str(response)), "DEBUG")
+
+                    if response and isinstance(response, dict):
+                        task_id = response.get('response').get('taskId')
+
+                        while True:
+                            execution_details = self.get_task_details(task_id)
+                            progress = execution_details.get("progress")
+
+                            if 'successfully' in progress or 'succesfully' in progress:
+                                self.status = "success"
+                                self.result['changed'] = True
+                                self.msg = "Device(s) '{0}' role updated successfully to '{1}'".format(str(devices_to_update_role), device_role)
+                                self.result['response'] = self.msg
+                                self.log(self.msg, "INFO")
+                                break
+                            elif execution_details.get("isError"):
+                                self.status = "failed"
+                                failure_reason = execution_details.get("failureReason")
+                                if failure_reason:
+                                    self.msg = "Device role updation get failed because of {0}".format(failure_reason)
+                                else:
+                                    self.msg = "Device role updation get failed"
+                                self.log(self.msg, "ERROR")
+                                self.result['response'] = self.msg
+                                break
+
+                except Exception as e:
+                    error_message = "Error while updating device role '{0}' in Cisco Catalyst Center: {1}".format(device_role, str(e))
+                    self.log(error_message, "ERROR")
+
+            if role_update_count == len(devices_to_update_role):
+                self.status = "success"
+                self.result['changed'] = False
+                self.msg = """The device role '{0}' is already set in Cisco Catalyst Center, no device role update is needed for the
+                  devices {1}.""".format(device_role, str(devices_to_update_role))
+                self.log(self.msg, "INFO")
+                self.result['response'] = self.msg
+
         if device_updated:
             device_to_update = self.get_device_ips_from_config_priority()
             # First check if device present in Cisco Catalyst Center or not
@@ -3092,79 +3166,6 @@ class Inventory(DnacBase):
             if self.config[0].get('update_interface_details'):
                 self.update_interface_detail_of_device(device_to_update).check_return_status()
 
-            # Update the role of devices having the role source as Manual
-            if self.config[0].get('update_device_role'):
-                for device_ip in device_to_update:
-                    device_id = self.get_device_ids([device_ip])
-                    device_role_args = self.config[0].get('update_device_role')
-
-                    if 'role' not in device_role_args:
-                        self.status = "failed"
-                        self.msg = "Mandatory parameter (role) to update Device Role is missing"
-                        self.log(self.msg, "WARNING")
-                        self.result['response'] = self.msg
-                        return self
-
-                    # Check if the same role of device is present in ccc then no need to change the state
-                    response = self.dnac._exec(
-                        family="devices",
-                        function='get_device_list',
-                        params={"managementIpAddress": device_ip}
-                    )
-                    response = response.get('response')[0]
-
-                    if response.get('role') == device_role_args.get('role'):
-                        self.status = "success"
-                        self.result['changed'] = False
-                        log_msg = "The device role '{0}' is already set in Cisco Catalyst Center, no update is needed.".format(device_role_args.get('role'))
-                        self.log(log_msg, "INFO")
-                        continue
-
-                    device_role_params = {
-                        'role': device_role_args.get('role'),
-                        'roleSource': "MANUAL",
-                        'id': device_id[0]
-                    }
-
-                    try:
-                        response = self.dnac._exec(
-                            family="devices",
-                            function='update_device_role',
-                            op_modifies=True,
-                            params=device_role_params,
-                        )
-                        self.log("Received API response from 'update_device_role': {0}".format(str(response)), "DEBUG")
-
-                        if response and isinstance(response, dict):
-                            task_id = response.get('response').get('taskId')
-
-                            while True:
-                                execution_details = self.get_task_details(task_id)
-                                progress = execution_details.get("progress")
-
-                                if 'successfully' in progress or 'succesfully' in progress:
-                                    self.status = "success"
-                                    self.result['changed'] = True
-                                    self.msg = "Device(s) '{0}' role updated successfully to '{1}'".format(str(device_to_update), device_role_args.get('role'))
-                                    self.log(self.msg, "INFO")
-                                    self.result['response'] = self.msg
-                                    break
-                                elif execution_details.get("isError"):
-                                    self.status = "failed"
-                                    failure_reason = execution_details.get("failureReason")
-                                    if failure_reason:
-                                        self.msg = "Device role updation get failed because of {0}".format(failure_reason)
-                                    else:
-                                        self.msg = "Device role updation get failed"
-                                    self.log(self.msg, "ERROR")
-                                    self.result['response'] = self.msg
-                                    break
-
-                    except Exception as e:
-                        error_message = "Error while updating device role in Cisco Catalyst Center: {0}".format(str(e))
-                        self.log(error_message, "ERROR")
-                        raise Exception(error_message)
-
         # If User defined field(UDF) not present then create it and add multiple udf to specific or list of devices
         if self.config[0].get('add_user_defined_field'):
             udf_field_list = self.config[0].get('add_user_defined_field')
@@ -3213,8 +3214,9 @@ class Inventory(DnacBase):
 
         # Once Wireless device get added we will assign device to site and Provisioned it
         # Defer this feature as API issue is there once it's fixed we will addresses it in upcoming release iac2.0
-        # if self.config[0].get('provision_wireless_device'):
-        #     self.provisioned_wireless_devices().check_return_status()
+        if support_for_provisioning_wireless:
+            if self.config[0].get('provision_wireless_device'):
+                self.provisioned_wireless_devices().check_return_status()
 
         if device_resynced:
             self.resync_devices().check_return_status()
@@ -3461,7 +3463,7 @@ class Inventory(DnacBase):
                     self.log("""Mismatch between playbook parameter and Cisco Catalyst Center detected, indicating that
                             the task of creating Global UDF may not have executed successfully.""", "INFO")
 
-        if device_updated and self.config[0].get('update_device_role'):
+        if self.config[0].get('role'):
             device_role_flag = True
 
             for device_ip in device_ips:

--- a/plugins/modules/network_settings_intent.py
+++ b/plugins/modules/network_settings_intent.py
@@ -2190,6 +2190,8 @@ def main():
         "dnac_log_file_path": {"type": 'str', "default": 'dnac.log'},
         "dnac_log_append": {"type": 'bool', "default": True},
         "config_verify": {"type": 'bool', "default": False},
+        "danc_api_task_timeout": {"type": 'int', "default": 1200},
+        "dnac_task_poll_interval": {"type": 'int', "default": 2},
         "config": {"type": 'list', "required": True, "elements": 'dict'},
         "state": {"default": 'merged', "choices": ['merged', 'deleted']},
         "validate_response_schema": {"type": 'bool', "default": True},

--- a/plugins/modules/network_settings_workflow_manager.py
+++ b/plugins/modules/network_settings_workflow_manager.py
@@ -2175,6 +2175,8 @@ def main():
         "dnac_log_file_path": {"type": 'str', "default": 'dnac.log'},
         "dnac_log_append": {"type": 'bool', "default": True},
         "config_verify": {"type": 'bool', "default": False},
+        "danc_api_task_timeout": {"type": 'int', "default": 1200},
+        "dnac_task_poll_interval": {"type": 'int', "default": 2},
         "config": {"type": 'list', "required": True, "elements": 'dict'},
         "state": {"default": 'merged', "choices": ['merged', 'deleted']},
         "validate_response_schema": {"type": 'bool', "default": True},

--- a/plugins/modules/pnp_intent.py
+++ b/plugins/modules/pnp_intent.py
@@ -1172,6 +1172,8 @@ def main():
                     "dnac_log_append": {"type": 'bool', "default": True},
                     'validate_response_schema': {'type': 'bool', 'default': True},
                     'config_verify': {"type": 'bool', "default": False},
+                    'danc_api_task_timeout': {'type': 'int', "default": 1200},
+                    'dnac_task_poll_interval': {'type': 'int', "default": 2},
                     'config': {'required': True, 'type': 'list', 'elements': 'dict'},
                     'state': {'default': 'merged', 'choices': ['merged', 'deleted']}
                     }

--- a/plugins/modules/pnp_workflow_manager.py
+++ b/plugins/modules/pnp_workflow_manager.py
@@ -1172,6 +1172,8 @@ def main():
                     "dnac_log_append": {"type": 'bool', "default": True},
                     'validate_response_schema': {'type': 'bool', 'default': True},
                     'config_verify': {"type": 'bool', "default": False},
+                    'danc_api_task_timeout': {'type': 'int', "default": 1200},
+                    'dnac_task_poll_interval': {'type': 'int', "default": 2},
                     'config': {'required': True, 'type': 'list', 'elements': 'dict'},
                     'state': {'default': 'merged', 'choices': ['merged', 'deleted']}
                     }

--- a/plugins/modules/provision_intent.py
+++ b/plugins/modules/provision_intent.py
@@ -590,6 +590,8 @@ def main():
                     "dnac_log_file_path": {"type": 'str', "default": 'dnac.log'},
                     "dnac_log_append": {"type": 'bool', "default": True},
                     "config_verify": {"type": 'bool', "default": False},
+                    'danc_api_task_timeout': {'type': 'int', "default": 1200},
+                    'dnac_task_poll_interval': {'type': 'int', "default": 2},
                     'validate_response_schema': {'type': 'bool', 'default': True},
                     'config': {'required': True, 'type': 'list', 'elements': 'dict'},
                     'state': {'default': 'merged', 'choices': ['merged', 'deleted']}

--- a/plugins/modules/provision_workflow_manager.py
+++ b/plugins/modules/provision_workflow_manager.py
@@ -704,6 +704,8 @@ def main():
                     "dnac_log_file_path": {"type": 'str', "default": 'dnac.log'},
                     "dnac_log_append": {"type": 'bool', "default": True},
                     "config_verify": {"type": 'bool', "default": False},
+                    'danc_api_task_timeout': {'type': 'int', "default": 1200},
+                    'dnac_task_poll_interval': {'type': 'int', "default": 2},
                     'validate_response_schema': {'type': 'bool', 'default': True},
                     'config': {'required': True, 'type': 'list', 'elements': 'dict'},
                     'state': {'default': 'merged', 'choices': ['merged', 'deleted']}

--- a/plugins/modules/site_intent.py
+++ b/plugins/modules/site_intent.py
@@ -1053,6 +1053,8 @@ def main():
                     'dnac_log': {'type': 'bool', 'default': False},
                     'validate_response_schema': {'type': 'bool', 'default': True},
                     'config_verify': {'type': 'bool', "default": False},
+                    'danc_api_task_timeout': {'type': 'int', "default": 1200},
+                    'dnac_task_poll_interval': {'type': 'int', "default": 2},
                     'config': {'required': True, 'type': 'list', 'elements': 'dict'},
                     'state': {'default': 'merged', 'choices': ['merged', 'deleted']}
                     }

--- a/plugins/modules/site_workflow_manager.py
+++ b/plugins/modules/site_workflow_manager.py
@@ -1052,6 +1052,8 @@ def main():
                     'dnac_log': {'type': 'bool', 'default': False},
                     'validate_response_schema': {'type': 'bool', 'default': True},
                     'config_verify': {'type': 'bool', "default": False},
+                    'danc_api_task_timeout': {'type': 'int', "default": 1200},
+                    'dnac_task_poll_interval': {'type': 'int', "default": 2},
                     'config': {'required': True, 'type': 'list', 'elements': 'dict'},
                     'state': {'default': 'merged', 'choices': ['merged', 'deleted']}
                     }

--- a/plugins/modules/swim_intent.py
+++ b/plugins/modules/swim_intent.py
@@ -1338,7 +1338,17 @@ class DnacSwims(DnacBase):
         device_count = 0
 
         for device_ip, task_id in swim_task_dict.items():
+            start_time = time.time()
+            max_timeout = 1200
+
             while (True):
+                end_time = time.time()
+                if (end_time - start_time) >= max_timeout:
+                    self.log("""Max timeout of 20 min has reached for the task id '{0}' for the device '{1}' and unexpected
+                                 task status so moving out to next task id""".format(task_id, device_ip), "WARNING")
+                    device_ips_list.append(device_ip)
+                    break
+
                 task_details = self.get_task_details(task_id)
 
                 if not task_details.get("isError") and \

--- a/plugins/modules/swim_intent.py
+++ b/plugins/modules/swim_intent.py
@@ -34,6 +34,16 @@ options:
     description: Set to True to verify the Cisco Catalyst Center config after applying the playbook config.
     type: bool
     default: False
+  max_timeout:
+    description: Sets the maximum duration in seconds for attempting to retrieve task details from the API. If the
+        task details are not obtained within this timeframe, the loop will be terminated, and a log message will be
+        generated indicating the timeout.
+    type: int
+    default: 1200
+  interval_seconds:
+    description: Specifies the interval in seconds between successive calls to the API to retrieve task details.
+    type: int
+    default: 2
   state:
     description: The state of Catalyst Center after module completion.
     type: str
@@ -322,6 +332,8 @@ notes:
     post /dna/intent/api/v1/image/importation/golden,
     post /dna/intent/api/v1/image/distribution,
     post /dna/intent/api/v1/image/activation/device,
+
+  - Added the parameter 'max_timeout', 'interval_seconds' options in v6.13.2.
 
 """
 
@@ -1339,13 +1351,13 @@ class DnacSwims(DnacBase):
 
         for device_ip, task_id in swim_task_dict.items():
             start_time = time.time()
-            max_timeout = 1200
+            max_timeout = self.params.get('max_timeout')
 
             while (True):
                 end_time = time.time()
                 if (end_time - start_time) >= max_timeout:
-                    self.log("""Max timeout of 20 min has reached for the task id '{0}' for the device '{1}' and unexpected
-                                 task status so moving out to next task id""".format(task_id, device_ip), "WARNING")
+                    self.log("""Max timeout of {0} sec has reached for the task id '{1}' for the device '{2}' and unexpected
+                                 task status so moving out to next task id""".format(max_timeout, task_id, device_ip), "WARNING")
                     device_ips_list.append(device_ip)
                     break
 
@@ -1365,7 +1377,7 @@ class DnacSwims(DnacBase):
                     self.result['response'] = task_details
                     device_ips_list.append(device_ip)
                     break
-                time.sleep(2)
+                time.sleep(self.params.get('interval_seconds'))
 
         return device_ips_list, device_count
 
@@ -1873,6 +1885,8 @@ def main():
                     'dnac_log': {'type': 'bool', 'default': False},
                     'validate_response_schema': {'type': 'bool', 'default': True},
                     'config_verify': {'type': 'bool', "default": False},
+                    'max_timeout': {'type': 'int', "default": 1200},
+                    'interval_seconds': {'type': 'int', "default": 2},
                     'config': {'required': True, 'type': 'list', 'elements': 'dict'},
                     'state': {'default': 'merged', 'choices': ['merged']}
                     }

--- a/plugins/modules/swim_intent.py
+++ b/plugins/modules/swim_intent.py
@@ -34,13 +34,12 @@ options:
     description: Set to True to verify the Cisco Catalyst Center config after applying the playbook config.
     type: bool
     default: False
-  max_timeout:
-    description: Sets the maximum duration in seconds for attempting to retrieve task details from the API. If the
-        task details are not obtained within this timeframe, the loop will be terminated, and a log message will be
-        generated indicating the timeout.
+  danc_api_task_timeout:
+    description: Defines the timeout in seconds for API calls to retrieve task details. If the task details
+        are not received within this period, the process will end, and a timeout notification will be logged.
     type: int
     default: 1200
-  interval_seconds:
+  dnac_task_poll_interval:
     description: Specifies the interval in seconds between successive calls to the API to retrieve task details.
     type: int
     default: 2
@@ -333,7 +332,7 @@ notes:
     post /dna/intent/api/v1/image/distribution,
     post /dna/intent/api/v1/image/activation/device,
 
-  - Added the parameter 'max_timeout', 'interval_seconds' options in v6.13.2.
+  - Added the parameter 'danc_api_task_timeout', 'dnac_task_poll_interval' options in v6.13.2.
 
 """
 
@@ -1351,7 +1350,7 @@ class DnacSwims(DnacBase):
 
         for device_ip, task_id in swim_task_dict.items():
             start_time = time.time()
-            max_timeout = self.params.get('max_timeout')
+            max_timeout = self.params.get('danc_api_task_timeout')
 
             while (True):
                 end_time = time.time()
@@ -1377,7 +1376,7 @@ class DnacSwims(DnacBase):
                     self.result['response'] = task_details
                     device_ips_list.append(device_ip)
                     break
-                time.sleep(self.params.get('interval_seconds'))
+                time.sleep(self.params.get('dnac_task_poll_interval'))
 
         return device_ips_list, device_count
 
@@ -1885,8 +1884,8 @@ def main():
                     'dnac_log': {'type': 'bool', 'default': False},
                     'validate_response_schema': {'type': 'bool', 'default': True},
                     'config_verify': {'type': 'bool', "default": False},
-                    'max_timeout': {'type': 'int', "default": 1200},
-                    'interval_seconds': {'type': 'int', "default": 2},
+                    'danc_api_task_timeout': {'type': 'int', "default": 1200},
+                    'dnac_task_poll_interval': {'type': 'int', "default": 2},
                     'config': {'required': True, 'type': 'list', 'elements': 'dict'},
                     'state': {'default': 'merged', 'choices': ['merged']}
                     }

--- a/plugins/modules/swim_workflow_manager.py
+++ b/plugins/modules/swim_workflow_manager.py
@@ -1324,7 +1324,18 @@ class Swim(DnacBase):
         device_count = 0
 
         for device_ip, task_id in swim_task_dict.items():
+            start_time = time.time()
+
             while (True):
+                end_time = time.time()
+                max_timeout = 1200
+
+                if (end_time - start_time) >= max_timeout:
+                    self.log("""Max timeout of 20 min has reached for the task id '{0}' for the device '{1}' and unexpected
+                                 task status so moving out to next task id""".format(task_id, device_ip), "WARNING")
+                    device_ips_list.append(device_ip)
+                    break
+
                 task_details = self.get_task_details(task_id)
 
                 if not task_details.get("isError") and \

--- a/plugins/modules/swim_workflow_manager.py
+++ b/plugins/modules/swim_workflow_manager.py
@@ -34,13 +34,12 @@ options:
     description: Set to True to verify the Cisco Catalyst Center config after applying the playbook config.
     type: bool
     default: False
-  max_timeout:
-    description: Sets the maximum duration in seconds for attempting to retrieve task details from the API. If the
-        task details are not obtained within this timeframe, the loop will be terminated, and a log message will be
-        generated indicating the timeout.
+  danc_api_task_timeout:
+    description: Defines the timeout in seconds for API calls to retrieve task details. If the task details
+        are not received within this period, the process will end, and a timeout notification will be logged.
     type: int
     default: 1200
-  interval_seconds:
+  dnac_task_poll_interval:
     description: Specifies the interval in seconds between successive calls to the API to retrieve task details.
     type: int
     default: 2
@@ -320,7 +319,7 @@ notes:
     post /dna/intent/api/v1/image/distribution,
     post /dna/intent/api/v1/image/activation/device,
 
-  - Added the parameter 'max_timeout', 'interval_seconds' options in v6.13.2.
+  - Added the parameter 'danc_api_task_timeout', 'dnac_task_poll_interval' options in v6.13.2.
 
 """
 
@@ -1340,7 +1339,7 @@ class Swim(DnacBase):
 
             while (True):
                 end_time = time.time()
-                max_timeout = self.params.get('max_timeout')
+                max_timeout = self.params.get('danc_api_task_timeout')
 
                 if (end_time - start_time) >= max_timeout:
                     self.log("""Max timeout of {0} has reached for the task id '{1}' for the device '{2}' and unexpected
@@ -1364,7 +1363,7 @@ class Swim(DnacBase):
                     self.result['response'] = task_details
                     device_ips_list.append(device_ip)
                     break
-                time.sleep(self.params.get('interval_seconds'))
+                time.sleep(self.params.get('dnac_task_poll_interval'))
 
         return device_ips_list, device_count
 
@@ -1870,8 +1869,8 @@ def main():
                     'dnac_log': {'type': 'bool', 'default': False},
                     'validate_response_schema': {'type': 'bool', 'default': True},
                     'config_verify': {'type': 'bool', "default": False},
-                    'max_timeout': {'type': 'int', "default": 1200},
-                    'interval_seconds': {'type': 'int', "default": 2},
+                    'danc_api_task_timeout': {'type': 'int', "default": 1200},
+                    'dnac_task_poll_interval': {'type': 'int', "default": 2},
                     'config': {'required': True, 'type': 'list', 'elements': 'dict'},
                     'state': {'default': 'merged', 'choices': ['merged']}
                     }

--- a/plugins/modules/swim_workflow_manager.py
+++ b/plugins/modules/swim_workflow_manager.py
@@ -486,6 +486,7 @@ from ansible_collections.cisco.dnac.plugins.module_utils.dnac import (
 )
 from ansible.module_utils.basic import AnsibleModule
 import os
+import time
 
 
 class Swim(DnacBase):
@@ -1300,6 +1301,50 @@ class Swim(DnacBase):
             self.log(error_message, "ERROR")
             raise Exception(error_message)
 
+    def check_swim_task_status(self, swim_task_dict, swim_task_name):
+        """
+        Check the status of the SWIM (Software Image Management) task for each device.
+        Args:
+            self (object): An instance of a class used for interacting with Cisco Catalyst Center.
+            swim_task_dict (dict): A dictionary containing the mapping of device IP address to the respective task ID.
+            swim_task_name (str): The name of the SWIM task being checked which is either Distribution or Activation.
+        Returns:
+            tuple: A tuple containing two elements:
+                - device_ips_list (list): A list of device IP addresses for which the SWIM task failed.
+                - device_count (int): The count of devices for which the SWIM task was successful.
+        Description:
+            This function iterates through the distribution_task_dict, which contains the mapping of
+            device IP address to their respective task ID. It checks the status of the SWIM task for each device by
+            repeatedly querying for task details until the task is either completed successfully or fails. If the task
+            is successful, the device count is incremented. If the task fails, an error message is logged, and the device
+            IP is appended to the device_ips_list and return a tuple containing the device_ips_list and device_count.
+        """
+
+        device_ips_list = []
+        device_count = 0
+
+        for device_ip, task_id in swim_task_dict.items():
+            while (True):
+                task_details = self.get_task_details(task_id)
+
+                if not task_details.get("isError") and \
+                        ("completed successfully" in task_details.get("progress")):
+                    self.result['changed'] = True
+                    self.status = "success"
+                    self.log("Image {0} successfully for the device '{1}".format(swim_task_name, device_ip), "INFO")
+                    device_count += 1
+                    break
+
+                if task_details.get("isError"):
+                    error_msg = "Image {0} gets failed for the device '{1}'".format(swim_task_name, device_ip)
+                    self.log(error_msg, "ERROR")
+                    self.result['response'] = task_details
+                    device_ips_list.append(device_ip)
+                    break
+                time.sleep(2)
+
+        return device_ips_list, device_count
+
     def get_diff_distribution(self):
         """
         Get image distribution parameters from the playbook and trigger image distribution.
@@ -1375,9 +1420,7 @@ class Swim(DnacBase):
             return self
 
         self.log("Device UUIDs involved in Image Distribution: {0}".format(str(device_uuid_list)), "INFO")
-
-        device_distribution_count = 0
-        device_ips_list = []
+        distribution_task_dict = {}
 
         for device_uuid in device_uuid_list:
             device_management_ip = self.get_device_ip_from_id(device_uuid)
@@ -1399,24 +1442,9 @@ class Swim(DnacBase):
             if response:
                 task_details = {}
                 task_id = response.get("response").get("taskId")
+                distribution_task_dict[device_management_ip] = task_id
 
-                while (True):
-                    task_details = self.get_task_details(task_id)
-
-                    if not task_details.get("isError") and \
-                            ("completed successfully" in task_details.get("progress")):
-                        self.result['changed'] = True
-                        self.status = "success"
-                        self.result['msg'] = "Image with Id '{0}' Distributed successfully".format(image_id)
-                        device_distribution_count += 1
-                        break
-
-                    if task_details.get("isError"):
-                        error_msg = "Image with Id '{0}' Distribution failed".format(image_id)
-                        self.log(error_msg, "ERROR")
-                        self.result['response'] = task_details
-                        device_ips_list.append(device_management_ip)
-                        break
+        device_ips_list, device_distribution_count = self.check_swim_task_status(distribution_task_dict, 'Distribution')
 
         if device_distribution_count == 0:
             self.status = "failed"
@@ -1518,8 +1546,7 @@ class Swim(DnacBase):
             return self
 
         self.log("Device UUIDs involved in Image Activation: {0}".format(str(device_uuid_list)), "INFO")
-        device_activation_count = 0
-        device_ips_list = []
+        activation_task_dict = {}
 
         for device_uuid in device_uuid_list:
             device_management_ip = self.get_device_ip_from_id(device_uuid)
@@ -1548,42 +1575,27 @@ class Swim(DnacBase):
             if response:
                 task_details = {}
                 task_id = response.get("response").get("taskId")
+                activation_task_dict[device_management_ip] = task_id
 
-                while (True):
-                    task_details = self.get_task_details(task_id)
-
-                    if not task_details.get("isError") and \
-                            ("completed successfully" in task_details.get("progress")):
-                        self.result['changed'] = True
-                        self.status = "success"
-                        self.result['msg'] = "Image with Id '{0}' activated successfully".format(image_id)
-                        device_activation_count += 1
-                        break
-
-                    if task_details.get("isError"):
-                        self.msg = "Image with Id '{0}' activation failed".format(image_id)
-                        self.log(self.msg, "ERROR")
-                        self.result['response'] = task_details
-                        device_ips_list.append(device_management_ip)
-                        break
+        device_ips_list, device_activation_count = self.check_swim_task_status(activation_task_dict, 'Activation')
 
         if device_activation_count == 0:
             self.status = "failed"
-            msg = "Image with Id '{0}' activation failed for all devices".format(image_id)
+            self.msg = "Image with Id '{0}' activation failed for all devices".format(image_id)
         elif device_activation_count == len(device_uuid_list):
             self.result['changed'] = True
             self.status = "success"
             self.complete_successful_activation = True
-            msg = "Image with Id '{0}' activated successfully for all devices".format(image_id)
+            self.msg = "Image with Id '{0}' activated successfully for all devices".format(image_id)
         else:
             self.result['changed'] = True
             self.status = "success"
             self.partial_successful_activation = True
-            msg = "Image with Id '{0}' activated and partially successfull".format(image_id)
+            self.msg = "Image with Id '{0}' activated and partially successful.".format(image_id)
             self.log("For Device(s) {0} Image activation gets Failed".format(str(device_ips_list)), "CRITICAL")
 
-        self.result['msg'] = msg
-        self.log(msg, "INFO")
+        self.result['msg'] = self.msg
+        self.log(self.msg, "INFO")
 
         return self
 

--- a/plugins/modules/template_intent.py
+++ b/plugins/modules/template_intent.py
@@ -2767,6 +2767,8 @@ def main():
                     "dnac_log_append": {"type": 'bool', "default": True},
                     'validate_response_schema': {'type': 'bool', 'default': True},
                     "config_verify": {"type": 'bool', "default": False},
+                    'danc_api_task_timeout': {'type': 'int', "default": 1200},
+                    'dnac_task_poll_interval': {'type': 'int', "default": 2},
                     'config': {'required': True, 'type': 'list', 'elements': 'dict'},
                     'state': {'default': 'merged', 'choices': ['merged', 'deleted']}
                     }

--- a/plugins/modules/template_workflow_manager.py
+++ b/plugins/modules/template_workflow_manager.py
@@ -2767,6 +2767,8 @@ def main():
                     "dnac_log_append": {"type": 'bool', "default": True},
                     'validate_response_schema': {'type': 'bool', 'default': True},
                     "config_verify": {"type": 'bool', "default": False},
+                    'danc_api_task_timeout': {'type': 'int', "default": 1200},
+                    'dnac_task_poll_interval': {'type': 'int', "default": 2},
                     'config': {'required': True, 'type': 'list', 'elements': 'dict'},
                     'state': {'default': 'merged', 'choices': ['merged', 'deleted']}
                     }


### PR DESCRIPTION
…e,  Make the Swim distribution/activation should be triggered for all matched filtered devices at once,  Improve task status-checking efficiency of swim distribution/activation task , Update the documentation of inventory module, Remove the reprovisioning of Wired device feature, Defer this feature of Wireless Device Provisioning.

In this commit -

— Fix the issue of log message while editing the management IP of device in inventory .

— Make the Swim distribution/activation should be triggered for all matched filtered devices at once by appending task ids in a list and then iterating each of them to get the task status.

— Improve task status-checking efficiency of swim distribution/activation task by giving a sleep of 2 sec before checking the task status.

— Update the documentation of inventory intent and workflow manager for the ease readability of user.

— Remove the reprovisioning of Wired device feature as it will be handle as part of Provisioning module.

—  Defer this feature of Wireless Device Provisioning from inventory module because of the API issue.

— Remove parameters from the inventory playbook as well and examples from module to avoid confusion.

— Introduce max_timeout, interval_seconds options in the playbook with default as well for the time for which we are going to check the task status with given interval.

— Wrapped the provisioning wireless device code by introducing variable support_for_provisioning_wireless and make it false till API gets fixed.

— Remove variable update_device_role and check if role is given in playbook then check for device role and if it’s not matching then update the devices with given role.

