### PR TITLE
Fix the issue of giving log message clear in case of API failure, int…

### DIFF
--- a/plugins/modules/inventory_intent.py
+++ b/plugins/modules/inventory_intent.py
@@ -2288,7 +2288,7 @@ class DnacDevice(DnacBase):
 
             if response:
                 interface_id = response[0]["id"]
-                self.log("Fetch Interface Id for device '{0}' successfully !!".format(device_ip))
+                self.log("Fetch Interface Id for device '{0}' successfully !!".format(device_ip), "DEBUG")
                 return interface_id
 
         except Exception as e:

--- a/plugins/modules/inventory_intent.py
+++ b/plugins/modules/inventory_intent.py
@@ -2578,8 +2578,8 @@ class DnacDevice(DnacBase):
                 # Check if interface_details is None or does not contain the 'id' key.
                 if interface_details is None or not interface_details.get('id'):
                     self.status = "failed"
-                    self.msg = """Unable to obtain interface details or 'id' not present for device '{0}' with
-                                interface '{1}'.""".format(device_id[0], interface_name)
+                    self.msg = """Failed to retrieve interface details or the 'id' is missing for the device with identifier
+                                '{0}' and interface '{1}'""".format(device_id[0], interface_name)
                     self.log(self.msg, "WARNING")
                     return self
 

--- a/plugins/modules/inventory_workflow_manager.py
+++ b/plugins/modules/inventory_workflow_manager.py
@@ -752,7 +752,7 @@ class Inventory(DnacBase):
             'mac_address_list': {'type': 'list', 'elements': 'str'},
             'netconf_port': {'type': 'str'},
             'password': {'type': 'str'},
-            'serial_number': {'type': 'str'},
+            'serial_number_list': {'type': 'list', 'elements': 'str'},
             'snmp_auth_passphrase': {'type': 'str'},
             'snmp_auth_protocol': {'default': "SHA", 'type': 'str'},
             'snmp_mode': {'type': 'str'},

--- a/plugins/modules/inventory_workflow_manager.py
+++ b/plugins/modules/inventory_workflow_manager.py
@@ -2571,8 +2571,8 @@ class Inventory(DnacBase):
                 # Check if interface_details is None or does not contain the 'id' key.
                 if interface_details is None or not interface_details.get('id'):
                     self.status = "failed"
-                    self.msg = """Unable to obtain interface details or 'id' not present for device '{0}' with
-                                interface '{1}'.""".format(device_id[0], interface_name)
+                    self.msg = """Failed to retrieve interface details or the 'id' is missing for the device with identifier
+                                '{0}' and interface '{1}'""".format(device_id[0], interface_name)
                     self.log(self.msg, "WARNING")
                     return self
 

--- a/plugins/modules/inventory_workflow_manager.py
+++ b/plugins/modules/inventory_workflow_manager.py
@@ -2281,7 +2281,7 @@ class Inventory(DnacBase):
 
                 if response:
                     interface_id = response[0]["id"]
-                    self.log("Fetch Interface Id for device '{0}' successfully !!".format(device_ip))
+                    self.log("Fetch Interface Id for device '{0}' successfully !!".format(device_ip), "DEBUG")
                     return interface_id
 
             except Exception as e:


### PR DESCRIPTION
…erface details not need update by showing changed= 0  in the output and if any interface details updated successfully then show changed=1 in output.

In this commit -

— Fix the issue of giving log message clear in case of API failure, interface details not need update by showing changed= 0  in the output and if any interface details updated successfully then show changed=1 in output.

— Added the code to check whether interface of device needs update or not and if not then show the required log messages.

-- Fix the examples parameter 'resync_interval' to 'resync_retry_interval' match with parameter given in documentation.
