### PR TITLE
Adding fix for Infinite Loop Issue while aborting a discovery

### DIFF
--- a/plugins/modules/discovery_intent.py
+++ b/plugins/modules/discovery_intent.py
@@ -1393,7 +1393,7 @@ class Discovery(DnacBase):
             progress = response.get('progress')
             if re.search('Discovery deleted successfully.', response.get('progress')):
                 result = True
-                self.log("The Process is completed", "INFO")
+                self.log("The discovery process is completed", "INFO")
                 self.result.update(dict(discovery_task=response))
                 return result
 

--- a/plugins/modules/discovery_intent.py
+++ b/plugins/modules/discovery_intent.py
@@ -1062,7 +1062,7 @@ class Discovery(DnacBase):
                 self.preprocess_device_discovery_handle_error()
         else:
             if len(ip_address_list) > 8:
-                msg = "Attempt to use more than 8 IP ranges detected. The system allows a maximum of 8."
+                msg = "Maximum of 8 IP ranges are allowed."
                 self.log(msg, "CRITICAL")
                 self.module.fail_json(msg=msg)
             new_ip_collected = []
@@ -1349,7 +1349,7 @@ class Discovery(DnacBase):
             try:
                 progress_value = int(progress)
                 result = True
-                self.log("The Process is completed", "INFO")
+                self.log("The discovery process is completed", "INFO")
                 self.result.update(dict(discovery_task=response))
                 return result
             except Exception:
@@ -1464,6 +1464,7 @@ class Discovery(DnacBase):
         """
 
         result = False
+        aborted = False
         discovery = self.lookup_discovery_by_range_via_name()
 
         if not discovery:
@@ -1474,17 +1475,25 @@ class Discovery(DnacBase):
 
         while True:
             discovery = self.lookup_discovery_by_range_via_name()
-            if discovery.get('discoveryCondition') == 'Complete':
+            discovery_condition = discovery.get('discoveryCondition')
+            if discovery_condition == 'Complete':
                 result = True
                 break
-
+            elif discovery_condition == 'Aborted':
+                aborted = True
+                break
             time.sleep(3)
 
         if not result:
-            msg = 'Cannot find any discovery task with name {0} -- Discovery result: {1}'.format(
-                str(self.validated_config[0].get("discovery_name")), str(discovery))
-            self.log(msg, "CRITICAL")
-            self.module.fail_json(msg=msg)
+            if aborted is True:
+                msg = 'Discovery with name {0} is aborted by the user on the GUI'.format(str(self.validated_config[0].get("discovery_name")))
+                self.log(msg, "CRITICAL")
+                self.module.fail_json(msg=msg)
+            else:
+                msg = 'Cannot find any discovery task with name {0} -- Discovery result: {1}'.format(
+                    str(self.validated_config[0].get("discovery_name")), str(discovery))
+                self.log(msg, "CRITICAL")
+                self.module.fail_json(msg=msg)
 
         self.result.update(dict(discovery_range=discovery))
         return discovery

--- a/plugins/modules/discovery_workflow_manager.py
+++ b/plugins/modules/discovery_workflow_manager.py
@@ -1393,7 +1393,7 @@ class Discovery(DnacBase):
             progress = response.get('progress')
             if re.search('Discovery deleted successfully.', response.get('progress')):
                 result = True
-                self.log("The Process is completed", "INFO")
+                self.log("The discovery process is completed", "INFO")
                 self.result.update(dict(discovery_task=response))
                 return result
 

--- a/plugins/modules/discovery_workflow_manager.py
+++ b/plugins/modules/discovery_workflow_manager.py
@@ -1062,7 +1062,7 @@ class Discovery(DnacBase):
                 self.preprocess_device_discovery_handle_error()
         else:
             if len(ip_address_list) > 8:
-                msg = "Attempt to use more than 8 IP ranges detected. The system allows a maximum of 8."
+                msg = "Maximum of 8 IP ranges are allowed."
                 self.log(msg, "CRITICAL")
                 self.module.fail_json(msg=msg)
             new_ip_collected = []
@@ -1349,7 +1349,7 @@ class Discovery(DnacBase):
             try:
                 progress_value = int(progress)
                 result = True
-                self.log("The Process is completed", "INFO")
+                self.log("The discovery process is completed", "INFO")
                 self.result.update(dict(discovery_task=response))
                 return result
             except Exception:
@@ -1464,6 +1464,7 @@ class Discovery(DnacBase):
         """
 
         result = False
+        aborted = False
         discovery = self.lookup_discovery_by_range_via_name()
 
         if not discovery:
@@ -1474,17 +1475,25 @@ class Discovery(DnacBase):
 
         while True:
             discovery = self.lookup_discovery_by_range_via_name()
-            if discovery.get('discoveryCondition') == 'Complete':
+            discovery_condition = discovery.get('discoveryCondition')
+            if discovery_condition == 'Complete':
                 result = True
                 break
-
+            elif discovery_condition == 'Aborted':
+                aborted = True
+                break
             time.sleep(3)
 
         if not result:
-            msg = 'Cannot find any discovery task with name {0} -- Discovery result: {1}'.format(
-                str(self.validated_config[0].get("discovery_name")), str(discovery))
-            self.log(msg, "CRITICAL")
-            self.module.fail_json(msg=msg)
+            if aborted is True:
+                msg = 'Discovery with name {0} is aborted by the user on the GUI'.format(str(self.validated_config[0].get("discovery_name")))
+                self.log(msg, "CRITICAL")
+                self.module.fail_json(msg=msg)
+            else:
+                msg = 'Cannot find any discovery task with name {0} -- Discovery result: {1}'.format(
+                    str(self.validated_config[0].get("discovery_name")), str(discovery))
+                self.log(msg, "CRITICAL")
+                self.module.fail_json(msg=msg)
 
         self.result.update(dict(discovery_range=discovery))
         return discovery


### PR DESCRIPTION
1. **Git PR Link:** https://github.com/madhansansel/dnacenter-ansible/pull/214
2.  **Problem Description:** The process goes into an infinite loop once we abort the discovery on GUI.
3.  **Root Cause:** We didn't handle the case of "Aborted" discovery condition.
4.  **Code Changes:** Have added a code a check inside the while loop, with an elif condition to check the discovery_c onfition. Along with that, have added a flag to check the aborted state specifically.
5.  **Testing and Automation:** Have tested a discovery by aborting it on the GUI. The following output was collected on the CLI.

TASK [Discovery devices from a CDP seed] **************************************************************************************************************************************************
task path: /home/admin/madhan_ansible/collections/ansible_collections/cisco/dnac/playbooks/Discovery_bug.yml:60
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: admin
<127.0.0.1> EXEC /bin/sh -c 'echo ~admin && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/admin/.ansible/tmp `"&& mkdir "` echo /home/admin/.ansible/tmp/ansible-tmp-1712573344.9937787-2021367-140109690886032 `" && echo ansible-tmp-1712573344.9937787-2021367-140109690886032="` echo /home/admin/.ansible/tmp/ansible-tmp-1712573344.9937787-2021367-140109690886032 `" ) && sleep 0'
Using module file /home/admin/madhan_ansible/collections/ansible_collections/cisco/dnac/plugins/modules/discovery_intent.py
<127.0.0.1> PUT /home/admin/.ansible/tmp/ansible-local-200806999swfl98/tmpgeuwz4vh TO /home/admin/.ansible/tmp/ansible-tmp-1712573344.9937787-2021367-140109690886032/AnsiballZ_discovery_intent.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/admin/.ansible/tmp/ansible-tmp-1712573344.9937787-2021367-140109690886032/ /home/admin/.ansible/tmp/ansible-tmp-1712573344.9937787-2021367-140109690886032/AnsiballZ_discovery_intent.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/home/admin/pyats_env/bin/python3 /home/admin/.ansible/tmp/ansible-tmp-1712573344.9937787-2021367-140109690886032/AnsiballZ_discovery_intent.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/admin/.ansible/tmp/ansible-tmp-1712573344.9937787-2021367-140109690886032/ > /dev/null 2>&1 && sleep 0'
failed: [localhost] (item={'ip_address_list': ['204.1.2.1'], 'discovery_type': 'CDP', 'cdp_level': 1, 'protocol_order': 'ssh', 'state': 'merged', 'discovery_name': 'CDP Discovery'}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "invocation": {
        "module_args": {
            "config": [
                {
                    "cdp_level": 1,
                    "discovery_name": "CDP Discovery",
                    "discovery_type": "CDP",
                    "ip_address_list": [
                        "204.1.2.1"
                    ],
                    "protocol_order": "ssh",
                    "state": "merged"
                }
            ],
            "config_verify": false,
            "dnac_api_task_timeout": 1200,
            "dnac_debug": true,
            "dnac_host": "10.22.40.214",
            "dnac_log": true,
            "dnac_log_append": true,
            "dnac_log_file_path": "dnac.log",
            "dnac_log_level": "DEBUG",
            "dnac_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "dnac_port": "443",
            "dnac_task_poll_interval": 2,
            "dnac_username": "admin",
            "dnac_verify": false,
            "dnac_version": "2.3.5.3",
            "state": "merged",
            "validate_response_schema": true
        }
    },
    "item": {
        "cdp_level": 1,
        "discovery_name": "CDP Discovery",
        "discovery_type": "CDP",
        "ip_address_list": [
            "204.1.2.1"
        ],
        "protocol_order": "ssh",
        "state": "merged"
    },
    "msg": "Discovery with name CDP Discovery is aborted by the user on the GUI"
}
                        