### PR TITLE
Enhanced log result messaged for updating role of multiple devices

### DIFF
--- a/plugins/modules/inventory_intent.py
+++ b/plugins/modules/inventory_intent.py
@@ -3032,6 +3032,7 @@ class DnacDevice(DnacBase):
             devices_to_update_role = self.get_device_ips_from_config_priority()
             device_role = self.config[0].get('role')
             role_update_count = 0
+            role_updated_list = []
             for device_ip in devices_to_update_role:
                 device_id = self.get_device_ids([device_ip])
 
@@ -3076,10 +3077,8 @@ class DnacDevice(DnacBase):
 
                             if 'successfully' in progress or 'succesfully' in progress:
                                 self.status = "success"
-                                self.result['changed'] = True
-                                self.msg = "Device(s) '{0}' role updated successfully to '{1}'".format(str(devices_to_update_role), device_role)
-                                self.result['response'] = self.msg
-                                self.log(self.msg, "INFO")
+                                self.log("Device '{0}' role updated successfully to '{1}'".format(device_ip, device_role), "INFO")
+                                role_updated_list.append(device_ip)
                                 break
                             elif execution_details.get("isError"):
                                 self.status = "failed"
@@ -3100,9 +3099,16 @@ class DnacDevice(DnacBase):
                 self.status = "success"
                 self.result['changed'] = False
                 self.msg = """The device role '{0}' is already set in Cisco Catalyst Center, no device role update is needed for the
-                  devices {1}.""".format(device_role, str(devices_to_update_role))
+                  device(s) {1}.""".format(device_role, str(devices_to_update_role))
                 self.log(self.msg, "INFO")
                 self.result['response'] = self.msg
+
+            if role_updated_list:
+                self.status = "success"
+                self.result['changed'] = True
+                self.msg = "Device(s) '{0}' role updated successfully to '{1}'".format(str(role_updated_list), device_role)
+                self.result['response'] = self.msg
+                self.log(self.msg, "INFO")
 
         if credential_update:
             device_to_update = self.get_device_ips_from_config_priority()

--- a/plugins/modules/inventory_workflow_manager.py
+++ b/plugins/modules/inventory_workflow_manager.py
@@ -3023,6 +3023,7 @@ class Inventory(DnacBase):
             devices_to_update_role = self.get_device_ips_from_config_priority()
             device_role = self.config[0].get('role')
             role_update_count = 0
+            role_updated_list = []
             for device_ip in devices_to_update_role:
                 device_id = self.get_device_ids([device_ip])
 
@@ -3067,10 +3068,8 @@ class Inventory(DnacBase):
 
                             if 'successfully' in progress or 'succesfully' in progress:
                                 self.status = "success"
-                                self.result['changed'] = True
-                                self.msg = "Device(s) '{0}' role updated successfully to '{1}'".format(str(devices_to_update_role), device_role)
-                                self.result['response'] = self.msg
-                                self.log(self.msg, "INFO")
+                                self.log("Device '{0}' role updated successfully to '{1}'".format(device_ip, device_role), "INFO")
+                                role_updated_list.append(device_ip)
                                 break
                             elif execution_details.get("isError"):
                                 self.status = "failed"
@@ -3091,9 +3090,16 @@ class Inventory(DnacBase):
                 self.status = "success"
                 self.result['changed'] = False
                 self.msg = """The device role '{0}' is already set in Cisco Catalyst Center, no device role update is needed for the
-                  devices {1}.""".format(device_role, str(devices_to_update_role))
+                  device(s) {1}.""".format(device_role, str(devices_to_update_role))
                 self.log(self.msg, "INFO")
                 self.result['response'] = self.msg
+
+            if role_updated_list:
+                self.status = "success"
+                self.result['changed'] = True
+                self.msg = "Device(s) '{0}' role updated successfully to '{1}'".format(str(role_updated_list), device_role)
+                self.result['response'] = self.msg
+                self.log(self.msg, "INFO")
 
         if credential_update:
             device_to_update = self.get_device_ips_from_config_priority()


### PR DESCRIPTION
In this commit - 

-- Enhanced log messages for updating device role of multiple devices in which some of the devices are already updated but  log messages show that all devices role updated successfully with changed =1 in output.