### PR TITLE
Update device credentials giving error because API is taking empty st…

### DIFF
--- a/plugins/modules/inventory_intent.py
+++ b/plugins/modules/inventory_intent.py
@@ -3235,6 +3235,10 @@ class DnacDevice(DnacBase):
                 if not playbook_params['httpPort']:
                     playbook_params['httpPort'] = device_data.get('http_port', None)
 
+                for key, value in playbook_params.items():
+                    if value == " ":
+                        playbook_params[key] = None
+
                 try:
                     if playbook_params['updateMgmtIPaddressList']:
                         new_mgmt_ipaddress = playbook_params['updateMgmtIPaddressList'][0]['newMgmtIpAddress']

--- a/plugins/modules/inventory_workflow_manager.py
+++ b/plugins/modules/inventory_workflow_manager.py
@@ -3227,6 +3227,10 @@ class Inventory(DnacBase):
                 if not playbook_params['httpPort']:
                     playbook_params['httpPort'] = device_data.get('http_port', None)
 
+                for key, value in playbook_params.items():
+                    if value == " ":
+                        playbook_params[key] = None
+
                 try:
                     if playbook_params['updateMgmtIPaddressList']:
                         new_mgmt_ipaddress = playbook_params['updateMgmtIPaddressList'][0]['newMgmtIpAddress']
@@ -3251,6 +3255,8 @@ class Inventory(DnacBase):
 
                     else:
                         self.log("Playbook parameter for updating devices: {0}".format(str(playbook_params)), "DEBUG")
+                        # import epdb;
+                        # epdb.serve(port=8888)
                         response = self.dnac._exec(
                             family="devices",
                             function='sync_devices',


### PR DESCRIPTION
…ring for http credentials from exported csv file.

In this commit - 

-- Fix the error of API giving 404 error while updating device credentials as http credentials is taking as empty string from the exported csv file.
