### PR TITLE
Adding try and error exception for provision module

### DIFF
--- a/plugins/modules/provision_workflow_manager.py
+++ b/plugins/modules/provision_workflow_manager.py
@@ -488,7 +488,7 @@ class Provision(DnacBase):
                         "device_management_ip_address": self.validated_config[0]["management_ip_address"]
                     },
                 )
-            except:
+            except Exception:
                 status_response = {}
             self.log("Wired device's status Response collected from 'get_provisioned_wired_device' API is:{0}".format(str(status_response)), "DEBUG")
             status = status_response.get("status")

--- a/plugins/modules/provision_workflow_manager.py
+++ b/plugins/modules/provision_workflow_manager.py
@@ -479,14 +479,17 @@ class Provision(DnacBase):
 
         device_type = self.want.get("device_type")
         if device_type == "wired":
-            status_response = self.dnac_apply['exec'](
-                family="sda",
-                function="get_provisioned_wired_device",
-                op_modifies=True,
-                params={
-                    "device_management_ip_address": self.validated_config[0]["management_ip_address"]
-                },
-            )
+            try:
+                status_response = self.dnac_apply['exec'](
+                    family="sda",
+                    function="get_provisioned_wired_device",
+                    op_modifies=True,
+                    params={
+                        "device_management_ip_address": self.validated_config[0]["management_ip_address"]
+                    },
+                )
+            except:
+                status_response = {}
             self.log("Wired device's status Response collected from 'get_provisioned_wired_device' API is:{0}".format(str(status_response)), "DEBUG")
             status = status_response.get("status")
             self.log("The provisioned status of the wired device is {0}".format(status), "INFO")


### PR DESCRIPTION
1. **Git PR Link:** https://github.com/madhansansel/dnacenter-ansible/pull/222
2.  **Problem Description:** The exception comes while trying to provision a device Exception: An error occured when executing operation. The error was: [400] Bad Request - This device is not provisioned to any site. deviceManagementIpAddress = 204.1.2.5.
3.  **Root Cause:** Try and error was not handled for get wired provisioned devices API.
4.  **Code Changes:** Have added a try and except block.
5.  **Testing and Automation:**  This is the logs for the execution of Provision Workflow.

TASK [Provision a wired device to a site] ********************************************************************************************************************************************************
task path: /home/admin/madhan_ansible/collections/ansible_collections/cisco/dnac/playbooks/device_provision_workflow.yml:40
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: admin
<127.0.0.1> EXEC /bin/sh -c 'echo ~admin && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/admin/.ansible/tmp `"&& mkdir "` echo /home/admin/.ansible/tmp/ansible-tmp-1713267040.8635395-1876122-9346180407370 `" && echo ansible-tmp-1713267040.8635395-1876122-9346180407370="` echo /home/admin/.ansible/tmp/ansible-tmp-1713267040.8635395-1876122-9346180407370 `" ) && sleep 0'
Using module file /home/admin/madhan_ansible/collections/ansible_collections/cisco/dnac/plugins/modules/provision_workflow_manager.py
<127.0.0.1> PUT /home/admin/.ansible/tmp/ansible-local-1875409l9slk_63/tmp7uv46v1o TO /home/admin/.ansible/tmp/ansible-tmp-1713267040.8635395-1876122-9346180407370/AnsiballZ_provision_workflow_manager.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/admin/.ansible/tmp/ansible-tmp-1713267040.8635395-1876122-9346180407370/ /home/admin/.ansible/tmp/ansible-tmp-1713267040.8635395-1876122-9346180407370/AnsiballZ_provision_workflow_manager.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/home/admin/pyats_env/bin/python3 /home/admin/.ansible/tmp/ansible-tmp-1713267040.8635395-1876122-9346180407370/AnsiballZ_provision_workflow_manager.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/admin/.ansible/tmp/ansible-tmp-1713267040.8635395-1876122-9346180407370/ > /dev/null 2>&1 && sleep 0'
changed: [localhost] => {
    "changed": true,
    "diff": [
        {
            "dynamic_interfaces": null,
            "managed_ap_locations": null,
            "management_ip_address": "204.1.2.5",
            "site_name_hierarchy": "Global/USA/SAN JOSE/BLD23"
        }
    ],
    "invocation": {
        "module_args": {
            "config": [
                {
                    "management_ip_address": "204.1.2.5",
                    "site_name_hierarchy": "Global/USA/SAN JOSE/BLD23"
                }
            ],
            "config_verify": true,
            "dnac_api_task_timeout": 1200,
            "dnac_debug": true,
            "dnac_host": "10.22.40.214",
            "dnac_log": true,
            "dnac_log_append": true,
            "dnac_log_file_path": "dnac.log",
            "dnac_log_level": "DEBUG",
            "dnac_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "dnac_port": "443",
            "dnac_task_poll_interval": 2,
            "dnac_username": "admin",
            "dnac_verify": false,
            "dnac_version": "2.3.5.3",
            "state": "merged",
            "validate_response_schema": true
        }
    },
    "msg": "Provision done Successfully",
    "provision_task": {
        "data": "workflow_id=450c8bfa-b7eb-4a71-b268-521c65635c5e;cfs_id=4837f8ca-6ed8-4a97-9050-b77bb41b9324;rollback_status=not_supported;rollback_taskid=0;failure_task=NA;processcfs_complete=true",
        "id": "b3069c95-8303-472b-be6c-98483d18254b",
        "instanceTenantId": "6614a1943ab97209a62e3252",
        "isError": false,
        "lastUpdate": 1713267050490,
        "progress": "TASK_MODIFY_PUT",
        "serviceType": "NCSP",
        "startTime": 1713267049099,
        "version": 1713267050490
    },
    "response": "b3069c95-8303-472b-be6c-98483d18254b"
}
Read vars_file '{{ CLUSTERFILE }}'
META: ran handlers
Read vars_file '{{ CLUSTERFILE }}'
META: ran handlers

PLAY RECAP ***************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0  