### PR TITLE
Enhanced log messages for site instead of showing last messages show …

### DIFF
--- a/plugins/modules/inventory_intent.py
+++ b/plugins/modules/inventory_intent.py
@@ -2899,10 +2899,26 @@ class DnacDevice(DnacBase):
         credential_update = self.config[0].get("credential_update", False)
 
         config['type'] = device_type
+        config['ip_address_list'] = devices_to_add
         if device_type == "FIREPOWER_MANAGEMENT_SYSTEM":
             config['http_port'] = self.config[0].get("http_port", "443")
 
-        config['ip_address_list'] = devices_to_add
+        if self.config[0].get('provision_wired_device'):
+            provision_wired_list = self.config[0]['provision_wired_device']
+            device_not_available = []
+            device_in_ccc = self.device_exists_in_dnac()
+
+            for prov_dict in provision_wired_list:
+                device_ip = prov_dict['device_ip']
+                if device_ip not in device_in_ccc:
+                    device_not_available.append(device_ip)
+            if device_not_available:
+                self.status = "failed"
+                self.msg = """Unable to Provision Wired Device(s) because the device(s) listed: {0} are not present in the
+                            Cisco Catalyst Center.""".format(str(device_not_available))
+                self.result['response'] = self.msg
+                self.log(self.msg, "ERROR")
+                return self
 
         if self.config[0].get('update_mgmt_ipaddresslist'):
             device_ip = self.config[0].get('update_mgmt_ipaddresslist')[0].get('existMgmtIpAddress')

--- a/plugins/modules/inventory_workflow_manager.py
+++ b/plugins/modules/inventory_workflow_manager.py
@@ -2890,10 +2890,26 @@ class Inventory(DnacBase):
         credential_update = self.config[0].get("credential_update", False)
 
         config['type'] = device_type
+        config['ip_address_list'] = devices_to_add
         if device_type == "FIREPOWER_MANAGEMENT_SYSTEM":
             config['http_port'] = self.config[0].get("http_port", "443")
 
-        config['ip_address_list'] = devices_to_add
+        if self.config[0].get('provision_wired_device'):
+            provision_wired_list = self.config[0]['provision_wired_device']
+            device_not_available = []
+            device_in_ccc = self.device_exists_in_ccc()
+
+            for prov_dict in provision_wired_list:
+                device_ip = prov_dict['device_ip']
+                if device_ip not in device_in_ccc:
+                    device_not_available.append(device_ip)
+            if device_not_available:
+                self.status = "failed"
+                self.msg = """Unable to Provision Wired Device(s) because the device(s) listed: {0} are not present in the
+                            Cisco Catalyst Center.""".format(str(device_not_available))
+                self.result['response'] = self.msg
+                self.log(self.msg, "ERROR")
+                return self
 
         if self.config[0].get('update_mgmt_ipaddresslist'):
             device_ip = self.config[0].get('update_mgmt_ipaddresslist')[0].get('existMgmtIpAddress')

--- a/plugins/modules/site_workflow_manager.py
+++ b/plugins/modules/site_workflow_manager.py
@@ -342,6 +342,8 @@ class Site(DnacBase):
     def __init__(self, module):
         super().__init__(module)
         self.supported_states = ["merged", "deleted"]
+        self.created_site_list, self.updated_site_list, self.update_not_neeeded_sites = [], [], []
+        self.deleted_site_list, self.site_absent_list = [], []
 
     def validate_input(self):
         """
@@ -448,7 +450,7 @@ class Site(DnacBase):
                     width=map_geometry.get("attributes").get("width"),
                     length=map_geometry.get("attributes").get("length"),
                     height=map_geometry.get("attributes").get("height"),
-                    floorNumber=map_geometry.get("attributes").get("floor_number", "")
+                    floorNumber=map_summary.get('attributes').get('floorIndex')
                 )
             )
 
@@ -665,7 +667,9 @@ class Site(DnacBase):
         """
 
         keys_to_compare = ['length', 'width', 'height']
-        if updated_site['name'] != requested_site['name'] or updated_site['rf_model'] != requested_site['rfModel']:
+        if updated_site['name'] != requested_site['name'] or updated_site.get('rf_model') != requested_site.get('rfModel'):
+            return False
+        if requested_site.get('floorNumber') and int(requested_site.get('floorNumber')) != int(updated_site.get('floorNumber')):
             return False
 
         for key in keys_to_compare:
@@ -780,6 +784,7 @@ class Site(DnacBase):
 
         site_updated = False
         site_created = False
+        site_name = self.want.get("site_name")
 
         # check if the given site exists and/or needs to be updated/created.
         if self.have.get("site_exists"):
@@ -794,14 +799,12 @@ class Site(DnacBase):
                     op_modifies=True,
                     params=site_params,
                 )
+                self.log("Received API response from 'update_site': {0}".format(str(response)), "DEBUG")
                 site_updated = True
-
             else:
                 # Site does not neet update
-                self.result['response'] = self.have.get("current_site")
-                self.msg = "Site - {0} does not need any update".format(self.have.get("current_site"))
-                self.log(self.msg, "INFO")
-                self.result['msg'] = self.msg
+                self.update_not_neeeded_sites.append(site_name)
+                self.log("Site - {0} does not need any update".format(site_name), "INFO")
                 return self
 
         else:
@@ -816,9 +819,9 @@ class Site(DnacBase):
                     site_params['site']['building'] = building_details
             except Exception as e:
                 site_type = site_params['type']
-                site_name = site_params['site'][site_type]['name']
+                name = site_params['site'][site_type]['name']
                 self.log("""The site '{0}' is not categorized as a building; hence, there is no need to filter out 'None'
-                            values from the 'site_params' dictionary.""".format(site_name), "INFO")
+                            values from the 'site_params' dictionary.""".format(name), "INFO")
 
             response = self.dnac._exec(
                 family="sites",
@@ -836,7 +839,6 @@ class Site(DnacBase):
                     execution_details = self.get_execution_details(executionid)
                     if execution_details.get("status") == "SUCCESS":
                         self.result['changed'] = True
-                        self.result['response'] = execution_details
                         break
 
                     elif execution_details.get("bapiError"):
@@ -845,21 +847,15 @@ class Site(DnacBase):
                         break
 
                 if site_updated:
-                    self.msg = "Site - {0} Updated Successfully".format(self.want.get("site_name"))
-                    self.log(self.msg, "INFO")
-                    self.result['msg'] = self.msg
-                    self.result['response'].update({"siteId": self.have.get("site_id")})
-
+                    self.updated_site_list.append(site_name)
+                    self.log("Site - {0} Updated Successfully".format(site_name), "INFO")
                 else:
                     # Get the site id of the newly created site.
                     (site_exists, current_site) = self.site_exists()
 
                     if site_exists:
-                        self.msg = "Site '{0}' created successfully".format(self.want.get("site_name"))
-                        self.log(self.msg, "INFO")
-                        self.log("Current site (have): {0}".format(str(current_site)), "DEBUG")
-                        self.result['msg'] = self.msg
-                        self.result['response'].update({"siteId": current_site.get('site_id')})
+                        self.created_site_list.append(site_name)
+                        self.log("Site '{0}' created successfully".format(site_name), "INFO")
 
         return self
 
@@ -894,11 +890,9 @@ class Site(DnacBase):
                 while True:
                     execution_details = self.get_execution_details(executionid)
                     if execution_details.get("status") == "SUCCESS":
-                        self.msg = "Site '{0}' deleted successfully".format(site_name)
-                        self.result['changed'] = True
-                        self.result['response'] = self.msg
                         self.status = "success"
-                        self.log(self.msg, "INFO")
+                        self.deleted_site_list.append(site_name)
+                        self.log("Site '{0}' deleted successfully".format(site_name), "INFO")
                         break
                     elif execution_details.get("bapiError"):
                         self.log("Error response for 'delete_site' execution: {0}".format(execution_details.get("bapiError")), "ERROR")
@@ -934,12 +928,8 @@ class Site(DnacBase):
         site_name = self.want.get("site_name")
         if not site_exists:
             self.status = "success"
-            self.msg = "Unable to delete site '{0}' as it's not found in Cisco Catalyst Center".format(site_name)
-            self.result.update({'changed': False,
-                                'response': self.msg,
-                                'msg': self.msg})
-            self.log(self.msg, "INFO")
-
+            self.site_absent_list.append(site_name)
+            self.log("Unable to delete site '{0}' as it's not found in Cisco Catalyst Center".format(site_name), "INFO")
             return self
 
         # Check here if the site have the childs then fetch it using get membership API and then sort it
@@ -951,6 +941,7 @@ class Site(DnacBase):
             op_modifies=True,
             params={"site_id": site_id},
         )
+        self.log("Received API response from 'get_membership': {0}".format(str(mem_response)), "DEBUG")
         site_response = mem_response.get("site").get("response")
         self.log("Site {0} response along with it's child sites: {1}".format(site_name, str(site_response)), "DEBUG")
 
@@ -967,9 +958,7 @@ class Site(DnacBase):
 
         # Delete the final parent site
         self.delete_single_site(site_id, site_name)
-        self.msg = "The site '{0}' and its child sites have been deleted successfully".format(site_name)
-        self.result['response'] = self.msg
-        self.log(self.msg, "INFO")
+        self.log("The site '{0}' and its child sites have been deleted successfully".format(site_name), "INFO")
 
         return self
 
@@ -1088,6 +1077,47 @@ def main():
         ccc_site.get_diff_state_apply[state](config).check_return_status()
         if config_verify:
             ccc_site.verify_diff_state_apply[state](config).check_return_status()
+
+    if ccc_site.created_site_list and ccc_site.updated_site_list:
+        ccc_site.result['changed'] = True
+        if ccc_site.update_not_neeeded_sites:
+            msg = """Site(s) '{0}' created successfully as well as Site(s) '{1}' updated successully and the some site(s)
+                    '{2}' needs no update in Cisco Catalyst Center"""
+            ccc_site.msg = msg.format(str(ccc_site.created_site_list), str(ccc_site.updated_site_list), str(ccc_site.update_not_neeeded_sites))
+        else:
+            ccc_site.msg = """Site(s) '{0}' created successfully in Cisco Catalyst Center as well as Site(s) '{1}' updated successully in
+                    Cisco Catalyst Center""".format(str(ccc_site.created_site_list), str(ccc_site.updated_site_list))
+    elif ccc_site.created_site_list:
+        ccc_site.result['changed'] = True
+        if ccc_site.update_not_neeeded_sites:
+            ccc_site.msg = """Site(s) '{0}' created successfully and some site(s) '{1}' not needs any update in Cisco Catalyst
+                            Center.""".format(str(ccc_site.created_site_list), str(ccc_site.update_not_neeeded_sites))
+        else:
+            ccc_site.msg = "Site(s) '{0}' created successfully in Cisco Catalyst Center.".format(str(ccc_site.created_site_list))
+    elif ccc_site.updated_site_list:
+        ccc_site.result['changed'] = True
+        if ccc_site.update_not_neeeded_sites:
+            ccc_site.msg = """Site(s) '{0}' updated successfully and some site(s) '{1}' not needs any update in Cisco Catalyst
+                            Center.""".format(str(ccc_site.updated_site_list), str(ccc_site.update_not_neeeded_sites))
+        else:
+            ccc_site.msg = "Site(s) '{0}' updated successfully in Cisco Catalyst Center.".format(str(ccc_site.updated_site_list))
+    elif ccc_site.update_not_neeeded_sites:
+        ccc_site.result['changed'] = False
+        ccc_site.msg = "Site(s) '{0}' not needs any update in Cisco Catalyst Center.".format(str(ccc_site.update_not_neeeded_sites))
+    elif ccc_site.deleted_site_list and ccc_site.site_absent_list:
+        ccc_site.result['changed'] = True
+        ccc_site.msg = """Given site(s) '{0}' deleted successfully from Cisco Catalyst Center and unable to deleted some site(s) '{1}' as they
+                are not found in Cisco Catalyst Center.""".format(str(ccc_site.deleted_site_list), str(ccc_site.site_absent_list))
+    elif ccc_site.deleted_site_list:
+        ccc_site.result['changed'] = True
+        ccc_site.msg = "Given site(s) '{0}' deleted successfully from Cisco Catalyst Center".format(str(ccc_site.deleted_site_list))
+    else:
+        ccc_site.result['changed'] = False
+        ccc_site.msg = "Unable to delete site(s) '{0}' as it's not found in Cisco Catalyst Center.".format(str(ccc_site.site_absent_list))
+
+    ccc_site.status = "success"
+    ccc_site.result['response'] = ccc_site.msg
+    ccc_site.result['msg'] = ccc_site.msg
 
     module.exit_json(**ccc_site.result)
 


### PR DESCRIPTION
…all possible operation on each site and handle provision for wired device not present in Catalyst Center.

In this commit - 

-- Fix the issue of log message in the console showing for last site only whether it's updated or created or deleted but now with site we capture the result whether it's updated/created or not need any update.

-- Also fix the issue of Wired Device Provisioning for the device that is not present in Catalyst Center by logging the appropriate message.