### PR TITLE
Update the cli_transport type in documentaion to ssh/telnet

### DIFF
--- a/plugins/modules/inventory_intent.py
+++ b/plugins/modules/inventory_intent.py
@@ -57,7 +57,7 @@ options:
         default: "NETWORK_DEVICE"
       cli_transport:
         description: The essential prerequisite for adding Network devices is the specification of the transport
-            protocol (either SSH or Telnet) used by the device.
+            protocol (either ssh or telnet) used by the device.
         type: str
       compute_device:
         description: Indicates whether a device is a compute device.

--- a/plugins/modules/inventory_workflow_manager.py
+++ b/plugins/modules/inventory_workflow_manager.py
@@ -57,7 +57,7 @@ options:
         default: "NETWORK_DEVICE"
       cli_transport:
         description: The essential prerequisite for adding Network devices is the specification of the transport
-            protocol (either SSH or Telnet) used by the device.
+            protocol (either ssh or telnet) used by the device.
         type: str
       compute_device:
         description: Indicates whether a device is a compute device.


### PR DESCRIPTION
In this commit - 

-- Fix the documentation of inventory module while adding/updating device, cli_transport should be ssh or telnet instead of SSH or Telnet.