### PR TITLE
Adding the condition for put API of wired device

### DIFF
--- a/plugins/modules/provision_workflow_manager.py
+++ b/plugins/modules/provision_workflow_manager.py
@@ -378,7 +378,7 @@ class Provision(DnacBase):
             )
             self.log("Response collected from 'get_task_by_id' API is {0}".format(str(response)), "DEBUG")
             response = response.response
-            self.log("Task status for the task id {0} is {1}".format(str(task_id), str(response)), "INFO")
+            self.log("Task status for the task id {0} is {1}".format(str(task_id), str(response.get("progress"))), "INFO")
             if response.get('isError') or re.search(
                 'failed', response.get('progress'), flags=re.IGNORECASE
             ):
@@ -387,7 +387,7 @@ class Provision(DnacBase):
                 self.module.fail_json(msg=msg)
                 return False
 
-            if response.get('progress') == 'TASK_PROVISION' and response.get("isError") is False:
+            if response.get('progress') in ["TASK_PROVISION", "TASK_MODIFY_PUT"] and response.get("isError") is False:
                 result = True
                 break
 


### PR DESCRIPTION
Problem: For few cases where we want to re-provision a wired device, we see that it goes into the progress as TASK_MODIFY_PUT. Due to not handling the case properly, it may lead to the task getting stuck inside the while loop endlessly.

Fix: Have added TASK_MODIFY_PUT check in the if check of get_task_status method.