### PR TITLE
Add common helper function to validate server address ipv4, ipv6 and …

### DIFF
--- a/plugins/module_utils/dnac.py
+++ b/plugins/module_utils/dnac.py
@@ -29,6 +29,7 @@ import inspect
 import re
 import socket
 import time
+import ipaddress
 
 
 class DnacBase():
@@ -552,6 +553,31 @@ class DnacBase():
             time.sleep(self.params.get('dnac_task_poll_interval'))
 
         return events_response
+
+    def is_valid_server_address(self, server_address):
+        """
+        Validates the server address to check if it's a valid IPv4, IPv6 address, or a valid hostname.
+        Args:
+            self (object): An instance of a class used for interacting with Cisco Catalyst Center.
+            server_address (str): The server address to validate.
+        Returns:
+            bool: True if the server address is valid, otherwise False.
+        """
+        # Check if the address is a valid IPv4 or IPv6 address
+        try:
+            ipaddress.ip_address(server_address)
+            return True
+        except ValueError:
+            pass
+
+        # Define the regex for a valid hostname
+        hostname_regex = re.compile(r'^(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\.[A-Za-z0-9-]{1,63})*(\.[A-Za-z]{2,6})?$')
+
+        # Check if the address is a valid hostname
+        if hostname_regex.match(server_address):
+            return True
+
+        return False
 
     def is_path_exists(self, file_path):
         """

--- a/plugins/modules/events_and_notifications_workflow_manager.py
+++ b/plugins/modules/events_and_notifications_workflow_manager.py
@@ -1048,9 +1048,8 @@ class Events(DnacBase):
             'snmpVersion': snmp_details.get('snmp_version')
         }
         server_address = snmp_details.get('server_address')
-        pattern = re.compile(r'^[A-Za-z0-9]([A-Za-z0-9.:-]*[A-Za-z0-9])?$')
 
-        if server_address and not re.match(pattern, server_address):
+        if server_address and not self.is_valid_server_address(server_address):
             self.status = "failed"
             self.msg = "Invalid server adderess '{0}' given in the playbook for configuring SNMP destination".format(server_address)
             self.log(self.msg, "ERROR")
@@ -2285,8 +2284,7 @@ class Events(DnacBase):
                 self.log(self.msg, "ERROR")
                 return self
 
-            pattern = re.compile(r'^[A-Za-z0-9]([A-Za-z0-9.:-]*[A-Za-z0-9])?$')
-            if server_address and not pattern.match(server_address):
+            if server_address and not self.is_valid_server_address(server_address):
                 self.status = "failed"
                 self.msg = "Invalid server adderess '{0}' given in the playbook for configuring syslog destination".format(server_address)
                 self.log(self.msg, "ERROR")


### PR DESCRIPTION
…hostname in dnac.py for validation.

In this commit - 

-- In order to validate server_address while configuring Syslog and SNMP destinations in Catalyst Center, write a common helper function to validate server_address in IPv4, IPv6 and valid hostname format.