### PR TITLE
Handle the invalid input handle for which predefined options are pres…

### DIFF
--- a/plugins/module_utils/dnac.py
+++ b/plugins/module_utils/dnac.py
@@ -572,11 +572,12 @@ class DnacBase():
 
         # Define the regex for a valid hostname
         hostname_regex = re.compile(
-            r'^(?!-)'  # Hostname must not start with a hyphen
-            r'[A-Za-z0-9-]{1,63}'  # Hostname segment must be 1-63 characters long
-            r'(?!-)$'  # Hostname segment must not end with a hyphen
-            r'(\.[A-Za-z0-9-]{1,63})*'  # Each segment can be 1-63 characters long
-            r'(\.[A-Za-z]{2,6})$'  # Top-level domain must be 2-6 alphabetic characters
+            r'^('  # Start of the string
+            r'([A-Za-z0-9]+([A-Za-z0-9-]*[A-Za-z0-9])?\.)+[A-Za-z]{2,6}|'  # Domain name (e.g., example.com)
+            r'localhost|'  # Localhost
+            r'(\d{1,3}\.)+\d{1,3}|'  # Custom IPv4-like format (e.g., 2.2.3.31.3.4.4)
+            r'[A-Fa-f0-9:]+$'  # IPv6 address (e.g., 2f8:192:3::40:41:41:42)
+            r')$'  # End of the string
         )
 
         # Check if the address is a valid hostname

--- a/plugins/modules/events_and_notifications_workflow_manager.py
+++ b/plugins/modules/events_and_notifications_workflow_manager.py
@@ -2210,13 +2210,16 @@ class Events(DnacBase):
             regex_pattern = re.compile(
                 r'^https://'  # Ensure the URL starts with "https://"
                 r'('
-                r'(([A-Za-z0-9-]+\.)+[A-Za-z]{2,6}|'  # Domain name (e.g., example.com)
+                r'(([A-Za-z0-9-*.&@]+\.)+[A-Za-z]{2,6})|'  # Domain name with wildcards and special characters
                 r'localhost|'  # Localhost
-                r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|'  # IPv4 address (e.g., 192.168.0.1)
-                r'\[[A-Fa-f0-9:]+\]'  # IPv6 address (e.g., [2001:db8::1])
+                r'(?:(?:\d{1,3}\.){3}\d{1,3}\b\.?)'  # Partial or complete IPv4 address with optional trailing dot
+                r'(\[[A-Fa-f0-9:]+\])?'  # Optional IPv6 address in square brackets (e.g., [2001:db8::1])
+                r'|'  # Alternation for different valid segments
+                r'([A-Za-z-_.&@]+)'  # Hostname with allowed special characters
                 r')'
-                r'(:\d+)?'  # Optional port (e.g., :8080)
-                r'(\/[A-Za-z0-9._~:/?#[@!$&\'()*+,;=-]*)?$)'  # Path and query (optional)
+                r'(:\d+)?'  # Optional port
+                r'(\/[A-Za-z0-9._~:/?#[@!$&\'()*+,;=-]*)?'  # Optional path
+                r'$'  # End of the string
             )
             url = webhook_params.get('url')
 


### PR DESCRIPTION
…ent for SNMP, Syslog and Email destination and also fix the enhanced validation issue of server_address.

In this commit - 

-- Handle the invalid input given in the playbook for the parameters for which predefined options are there like snmp_mode should be AUTH_PRIVACY", "AUTH_NO_PRIVACY", "NO_AUTH_NO_PRIVACY", similar in email destination while configuring the primary smtp server and show appropriate log and console message to the user instead of some random 404 error.

-- Fix the enhanced issue of validation of the parameter server_address by making change in the hostname regex and check and against the following input from both Ansible playbook and in GUI to match the behaviour - 

# Test cases
print(validate_hostname("example.com"))  # True
print(validate_hostname("localhost"))  # True
print(validate_hostname("192.168.0.1"))  # True
print(validate_hostname("[2001:db8::1]"))  # True
print(validate_hostname("example.com:8080"))  # False
print(validate_hostname("example.com-"))  # False
print(validate_hostname("example-.com"))  # False
print(validate_hostname("-example.com"))  # False
print(validate_hostname("cisco@check.com"))  # False
print(validate_hostname("cic$dhj).com"))  # False
print(validate_hostname("2.2.3.31.3.4.4"))  # True
print(validate_hostname("12.2.1.2"))  # True
print(validate_hostname("2f8:192:3::40:41:41:42"))  # True
print(validate_hostname("syslog.cisco.com"))  # True