### PR TITLE
Handle invalid site type given in playbook while creating/updating/de…

### DIFF
--- a/plugins/modules/site_intent.py
+++ b/plugins/modules/site_intent.py
@@ -528,6 +528,12 @@ class DnacSite(DnacBase):
         typeinfo = params.get("type")
         site_info = {}
 
+        if typeinfo not in ["area", "building", "floor"]:
+            self.status = "failed"
+            self.msg = "Invalid site type '{0}' given in the playbook. Please select one of the type - 'area', 'building', 'floor'".format(typeinfo)
+            self.log(self.msg, "ERROR")
+            self.check_return_status()
+
         if typeinfo == 'area':
             area_details = params.get('site').get('area')
             site_info['area'] = {

--- a/plugins/modules/site_workflow_manager.py
+++ b/plugins/modules/site_workflow_manager.py
@@ -524,8 +524,15 @@ class Site(DnacBase):
           type. If the site type is 'floor', it ensures that the 'rfModel'
           parameter is stored in uppercase.
         """
+
         typeinfo = params.get("type")
         site_info = {}
+
+        if typeinfo not in ["area", "building", "floor"]:
+            self.status = "failed"
+            self.msg = "Invalid site type '{0}' given in the playbook. Please select one of the type - 'area', 'building', 'floor'".format(typeinfo)
+            self.log(self.msg, "ERROR")
+            self.check_return_status()
 
         if typeinfo == 'area':
             area_details = params.get('site').get('area')


### PR DESCRIPTION
…leting site.

In this commit -

-- Handle the invalid site type given in the playbook for creating/updating/deleting any site in the Catalyst Center.

-- Make the required change in both the module intent and workflow manager one.