### PR TITLE
Fix the issue of removing header while configuring webhook destination

### DIFF
--- a/plugins/module_utils/dnac.py
+++ b/plugins/module_utils/dnac.py
@@ -326,6 +326,21 @@ class DnacBase():
 
         return result
 
+    def get_device_details_limit(self):
+        """
+        Retrieves the limit for 'get_device_list' API to collect the device details..
+        Parameters:
+            self (object): An instance of a class that provides access to Cisco Catalyst Center.
+        Returns:
+            int: The limit for 'get_device_list' api device details, which is set to 500 by default.
+        Description:
+            This method returns a predefined limit for the number of device details that can be processed or retrieved
+            from 'get_device_list' api. Currently, the limit is set to a fixed value of 500.
+        """
+
+        api_response_limit = 500
+        return api_response_limit
+
     def check_task_response_status(self, response, validation_string, api_name, data=False):
         """
         Get the site id from the site name.

--- a/plugins/modules/events_and_notifications_workflow_manager.py
+++ b/plugins/modules/events_and_notifications_workflow_manager.py
@@ -1960,19 +1960,16 @@ class Events(DnacBase):
             If they are not identical, it sets the update_needed flag to True.
         """
 
-        update_needed = False
-
         if len(playbook_header) == 0 and ccc_header:
-            update_needed = True
-        elif playbook_header and not ccc_header:
-            update_needed = True
-        else:
-            playbook_dict = {item['name']: item['value'] for item in playbook_header}
-            ccc_dict = {item['name']: item['value'] for item in ccc_header}
+            return True
 
-            return playbook_dict != ccc_dict
+        if playbook_header and not ccc_header:
+            return True
 
-        return update_needed
+        playbook_dict = {item['name']: item['value'] for item in playbook_header}
+        ccc_dict = {item['name']: item['value'] for item in ccc_header}
+
+        return playbook_dict != ccc_dict
 
     def webhook_dest_needs_update(self, webhook_params, webhook_dest_detail_in_ccc):
         """

--- a/plugins/modules/events_and_notifications_workflow_manager.py
+++ b/plugins/modules/events_and_notifications_workflow_manager.py
@@ -1962,7 +1962,7 @@ class Events(DnacBase):
 
         update_needed = False
 
-        if playbook_header == [] and ccc_header:
+        if len(playbook_header) == 0 and ccc_header:
             update_needed = True
         elif playbook_header and not ccc_header:
             update_needed = True
@@ -1970,8 +1970,7 @@ class Events(DnacBase):
             playbook_dict = {item['name']: item['value'] for item in playbook_header}
             ccc_dict = {item['name']: item['value'] for item in ccc_header}
 
-            if not playbook_dict == ccc_dict:
-                update_needed = True
+            return playbook_dict != ccc_dict
 
         return update_needed
 
@@ -4527,7 +4526,7 @@ class Events(DnacBase):
             url = webhook_params.get('url')
 
             regex_pattern = re.compile(
-                r'^(https?:\/\/)?'  # protocol
+                r'^https:\/\/'  # ensure the URL starts with https://
                 r'((([a-z\d]([a-z\d-]*[a-z\d])*)\.)+[a-z]{2,}|'  # domain name
                 r'((\d{1,3}\.){3}\d{1,3})|'  # OR IPv4 address
                 r'(\[[0-9a-fA-F:.]+\]))'  # OR IPv6 address

--- a/plugins/modules/inventory_intent.py
+++ b/plugins/modules/inventory_intent.py
@@ -861,22 +861,22 @@ class DnacDevice(DnacBase):
         # If no information is available, return an empty list
         return []
 
-    def device_exists_in_dnac(self):
+    def get_existing_devices_in_ccc(self):
         """
-        Check which devices already exists in Cisco Catalyst Center and return both device_exist and device_not_exist in dnac.
+        Check which devices already exists and retrieve the list of devices that already exist in Cisco Catalyst Center.
         Parameters:
             self (object): An instance of a class used for interacting with Cisco Cisco Catalyst Center.
         Returns:
-            list: A list of devices that exist in Cisco Catalyst Center.
+            list: A list of management IP addresses for devices that exist in Cisco Catalyst Center.
         Description:
             Queries Cisco Catalyst Center to check which devices are already present in Cisco Catalyst Center and store
             its management IP address in the list of devices that exist.
         Example:
-            To use this method, create an instance of the class and call 'device_exists_in_dnac' on it,
+            To use this method, create an instance of the class and call 'get_existing_devices_in_ccc' on it,
             The method returns a list of management IP addressesfor devices that exist in Cisco Catalyst Center.
         """
 
-        existing_devices_in_dnac = set()
+        existing_devices_in_ccc = set()
         offset = 0
         limit = self.get_device_details_limit()
         initial_exec = False
@@ -907,17 +907,17 @@ class DnacDevice(DnacBase):
                 self.log("Received API response from 'get_device_list': {0}".format(str(response)), "DEBUG")
                 for ip in response:
                     device_ip = ip["managementIpAddress"]
-                    existing_devices_in_dnac.add(device_ip)
+                    existing_devices_in_ccc.add(device_ip)
 
             except Exception as e:
                 self.status = "failed"
                 self.msg = "Error while fetching device details from Cisco Catalyst Center: {0}".format(str(e))
                 self.log(self.msg, "CRITICAL")
                 self.check_return_status()
-        self.log("Devices present in Cisco Catalyst Center: {0}".format(str(existing_devices_in_dnac)), "DEBUG")
-        existing_devices_in_dnac = list(existing_devices_in_dnac)
+        self.log("Devices present in Cisco Catalyst Center: {0}".format(str(existing_devices_in_ccc)), "DEBUG")
+        existing_devices_in_ccc = list(existing_devices_in_ccc)
 
-        return existing_devices_in_dnac
+        return existing_devices_in_ccc
 
     def is_udf_exist(self, field_name):
         """
@@ -1283,7 +1283,7 @@ class DnacDevice(DnacBase):
         # Code for triggers the resync operation using the retrieved device IDs and force sync parameter.
         device_ips = self.get_device_ips_from_config_priority()
         input_device_ips = device_ips.copy()
-        device_in_dnac = self.device_exists_in_dnac()
+        device_in_dnac = self.get_existing_devices_in_ccc()
 
         for device_ip in input_device_ips:
             if device_ip not in device_in_dnac:
@@ -2019,7 +2019,7 @@ class DnacDevice(DnacBase):
         want_device = self.get_device_ips_from_config_priority()
 
         # Get the list of device that are present in Cisco Catalyst Center
-        device_in_dnac = self.device_exists_in_dnac()
+        device_in_dnac = self.get_existing_devices_in_ccc()
         device_not_in_dnac, devices_in_playbook = [], []
 
         for ip in want_device:
@@ -2927,7 +2927,7 @@ class DnacDevice(DnacBase):
         if self.config[0].get('provision_wired_device'):
             provision_wired_list = self.config[0]['provision_wired_device']
             device_not_available = []
-            device_in_ccc = self.device_exists_in_dnac()
+            device_in_ccc = self.get_existing_devices_in_ccc()
 
             for prov_dict in provision_wired_list:
                 device_ip = prov_dict['device_ip']
@@ -3697,7 +3697,7 @@ class DnacDevice(DnacBase):
         self.log("Current State (have): {0}".format(str(self.have)), "INFO")
         self.log("Desired State (want): {0}".format(str(self.want)), "INFO")
         input_devices = self.have["want_device"]
-        device_in_dnac = self.device_exists_in_dnac()
+        device_in_dnac = self.get_existing_devices_in_ccc()
 
         if self.config[0].get('add_user_defined_field'):
             udf_field_list = self.config[0].get('add_user_defined_field')

--- a/plugins/modules/inventory_intent.py
+++ b/plugins/modules/inventory_intent.py
@@ -878,7 +878,7 @@ class DnacDevice(DnacBase):
 
         device_in_dnac = set()
         offset = 0
-        limit = 500
+        limit = self.get_device_details_limit()
         initial_exec = False
 
         while True:
@@ -901,7 +901,7 @@ class DnacDevice(DnacBase):
                 offset = offset + 1
                 response = response.get("response")
                 if not response:
-                    self.log("There is no device details present in Cisco Catalyst Center", "INFO")
+                    self.log("There are no device details received from 'get_device_list' API.", "INFO")
                     break
 
                 self.log("Received API response from 'get_device_list': {0}".format(str(response)), "DEBUG")

--- a/plugins/modules/inventory_intent.py
+++ b/plugins/modules/inventory_intent.py
@@ -876,7 +876,7 @@ class DnacDevice(DnacBase):
             The method returns a list of management IP addressesfor devices that exist in Cisco Catalyst Center.
         """
 
-        device_in_dnac = set()
+        existing_devices_in_dnac = set()
         offset = 0
         limit = self.get_device_details_limit()
         initial_exec = False
@@ -893,11 +893,11 @@ class DnacDevice(DnacBase):
                         }
                     )
                 else:
+                    initial_exec = True
                     response = self.dnac._exec(
                         family="devices",
                         function='get_device_list',
                     )
-                initial_exec = True
                 offset = offset + 1
                 response = response.get("response")
                 if not response:
@@ -907,17 +907,17 @@ class DnacDevice(DnacBase):
                 self.log("Received API response from 'get_device_list': {0}".format(str(response)), "DEBUG")
                 for ip in response:
                     device_ip = ip["managementIpAddress"]
-                    device_in_dnac.add(device_ip)
+                    existing_devices_in_dnac.add(device_ip)
 
             except Exception as e:
                 self.status = "failed"
                 self.msg = "Error while fetching device details from Cisco Catalyst Center: {0}".format(str(e))
                 self.log(self.msg, "CRITICAL")
                 self.check_return_status()
-        self.log("Devices present in Cisco Catalyst Center are : {0}".format(str(device_in_dnac)), "DEBUG")
-        device_in_dnac = list(device_in_dnac)
+        self.log("Devices present in Cisco Catalyst Center: {0}".format(str(existing_devices_in_dnac)), "DEBUG")
+        existing_devices_in_dnac = list(existing_devices_in_dnac)
 
-        return device_in_dnac
+        return existing_devices_in_dnac
 
     def is_udf_exist(self, field_name):
         """

--- a/plugins/modules/inventory_workflow_manager.py
+++ b/plugins/modules/inventory_workflow_manager.py
@@ -875,7 +875,7 @@ class Inventory(DnacBase):
             The method returns a list of management IP addressesfor devices that exist in Cisco Catalyst Center.
         """
 
-        device_in_ccc = set()
+        existing_devices_in_ccc = set()
         offset = 0
         limit = self.get_device_details_limit()
         initial_exec = False
@@ -892,11 +892,11 @@ class Inventory(DnacBase):
                         }
                     )
                 else:
+                    initial_exec = True
                     response = self.dnac._exec(
                         family="devices",
                         function='get_device_list',
                     )
-                initial_exec = True
                 offset = offset + 1
                 response = response.get("response")
                 if not response:
@@ -906,7 +906,7 @@ class Inventory(DnacBase):
                 self.log("Received API response from 'get_device_list': {0}".format(str(response)), "DEBUG")
                 for ip in response:
                     device_ip = ip["managementIpAddress"]
-                    device_in_ccc.add(device_ip)
+                    existing_devices_in_ccc.add(device_ip)
 
             except Exception as e:
                 self.status = "failed"
@@ -914,10 +914,10 @@ class Inventory(DnacBase):
                 self.log(self.msg, "CRITICAL")
                 self.check_return_status()
 
-        self.log("Devices present in Cisco Catalyst Center are : {0}".format(str(device_in_ccc)), "DEBUG")
-        device_in_ccc = list(device_in_ccc)
+        self.log("Devices present in Cisco Catalyst Center: {0}".format(str(existing_devices_in_ccc)), "DEBUG")
+        existing_devices_in_ccc = list(existing_devices_in_ccc)
 
-        return device_in_ccc
+        return existing_devices_in_ccc
 
     def is_udf_exist(self, field_name):
         """

--- a/plugins/modules/inventory_workflow_manager.py
+++ b/plugins/modules/inventory_workflow_manager.py
@@ -860,18 +860,18 @@ class Inventory(DnacBase):
         # If no information is available, return an empty list
         return []
 
-    def device_exists_in_ccc(self):
+    def get_existing_devices_in_ccc(self):
         """
-        Check which devices already exists in Cisco Catalyst Center and return both device_exist and device_not_exist in Cisco Catalyst Center.
+        Check which devices already exists and retrieve the list of devices that already exist in Cisco Catalyst Center.
         Parameters:
             self (object): An instance of a class used for interacting with Cisco Cisco Catalyst Center.
         Returns:
-            list: A list of devices that exist in Cisco Catalyst Center.
+            list: A list of management IP addresses for devices that exist in Cisco Catalyst Center.
         Description:
             Queries Cisco Catalyst Center to check which devices are already present in Cisco Catalyst Center and store
             its management IP address in the list of devices that exist.
         Example:
-            To use this method, create an instance of the class and call 'device_exists_in_ccc' on it,
+            To use this method, create an instance of the class and call 'get_existing_devices_in_ccc' on it,
             The method returns a list of management IP addressesfor devices that exist in Cisco Catalyst Center.
         """
 
@@ -1282,7 +1282,7 @@ class Inventory(DnacBase):
         # Code for triggers the resync operation using the retrieved device IDs and force sync parameter.
         device_ips = self.get_device_ips_from_config_priority()
         input_device_ips = device_ips.copy()
-        device_in_ccc = self.device_exists_in_ccc()
+        device_in_ccc = self.get_existing_devices_in_ccc()
 
         for device_ip in input_device_ips:
             if device_ip not in device_in_ccc:
@@ -2012,7 +2012,7 @@ class Inventory(DnacBase):
         want_device = self.get_device_ips_from_config_priority()
 
         # Get the list of device that are present in Cisco Catalyst Center
-        device_in_ccc = self.device_exists_in_ccc()
+        device_in_ccc = self.get_existing_devices_in_ccc()
         device_not_in_ccc, devices_in_playbook = [], []
 
         for ip in want_device:
@@ -2919,7 +2919,7 @@ class Inventory(DnacBase):
         if self.config[0].get('provision_wired_device'):
             provision_wired_list = self.config[0]['provision_wired_device']
             device_not_available = []
-            device_in_ccc = self.device_exists_in_ccc()
+            device_in_ccc = self.get_existing_devices_in_ccc()
 
             for prov_dict in provision_wired_list:
                 device_ip = prov_dict['device_ip']
@@ -3693,7 +3693,7 @@ class Inventory(DnacBase):
         self.log("Current State (have): {0}".format(str(self.have)), "INFO")
         self.log("Desired State (want): {0}".format(str(self.want)), "INFO")
         input_devices = self.have["want_device"]
-        device_in_ccc = self.device_exists_in_ccc()
+        device_in_ccc = self.get_existing_devices_in_ccc()
 
         if self.config[0].get('add_user_defined_field'):
             udf_field_list = self.config[0].get('add_user_defined_field')

--- a/plugins/modules/inventory_workflow_manager.py
+++ b/plugins/modules/inventory_workflow_manager.py
@@ -877,7 +877,7 @@ class Inventory(DnacBase):
 
         device_in_ccc = set()
         offset = 0
-        limit = 500
+        limit = self.get_device_details_limit()
         initial_exec = False
 
         while True:
@@ -900,7 +900,7 @@ class Inventory(DnacBase):
                 offset = offset + 1
                 response = response.get("response")
                 if not response:
-                    self.log("There is no device details present in Cisco Catalyst Center", "INFO")
+                    self.log("There are no device details received from 'get_device_list' API.", "INFO")
                     break
 
                 self.log("Received API response from 'get_device_list': {0}".format(str(response)), "DEBUG")

--- a/plugins/modules/swim_intent.py
+++ b/plugins/modules/swim_intent.py
@@ -800,7 +800,7 @@ class DnacSwims(DnacBase):
             'role': device_role
         }
         offset = 0
-        limit = 500
+        limit = self.get_device_details_limit()
         initial_exec = False
         site_memberships_ids, device_response_ids = [], []
 

--- a/plugins/modules/swim_intent.py
+++ b/plugins/modules/swim_intent.py
@@ -799,37 +799,61 @@ class DnacSwims(DnacBase):
             'family': device_family,
             'role': device_role
         }
-        device_list_response = self.dnac._exec(
-            family="devices",
-            function='get_device_list',
-            op_modifies=True,
-            params=device_params,
-        )
-
-        device_response = device_list_response.get('response')
-        if not response or not device_response:
-            self.log("Failed to retrieve devices associated with the site '{0}' due to empty API response.".format(site_name), "INFO")
-            return device_uuid_list
-
+        offset = 0
+        limit = 500
+        initial_exec = False
         site_memberships_ids, device_response_ids = [], []
 
-        for item in site_response_list:
-            if item["reachabilityStatus"] != "Reachable":
-                self.log("""Device '{0}' is currently '{1}' and cannot be included in the SWIM distribution/activation
-                            process.""".format(item["managementIpAddress"], item["reachabilityStatus"]), "INFO")
-                continue
-            self.log("""Device '{0}' from site '{1}' is ready for the SWIM distribution/activation
-                        process.""".format(item["managementIpAddress"], site_name), "INFO")
-            site_memberships_ids.append(item["instanceUuid"])
+        while True:
+            try:
+                if initial_exec:
+                    device_params["limit"] = limit
+                    device_params["offset"] = offset * limit
+                    device_list_response = self.dnac._exec(
+                        family="devices",
+                        function='get_device_list',
+                        params=device_params
+                    )
+                else:
+                    device_list_response = self.dnac._exec(
+                        family="devices",
+                        function='get_device_list',
+                        op_modifies=True,
+                        params=device_params,
+                    )
+                initial_exec = True
+                offset = offset + 1
+                device_response = device_list_response.get('response')
 
-        for item in device_response:
-            if item["reachabilityStatus"] != "Reachable":
-                self.log("""Unable to proceed with the device '{0}' for SWIM distribution/activation as its status is
-                            '{1}'.""".format(item["managementIpAddress"], item["reachabilityStatus"]), "INFO")
-                continue
-            self.log("""Device '{0}' matches to the specified filter requirements and is set for SWIM
-                      distribution/activation.""".format(item["managementIpAddress"]), "INFO")
-            device_response_ids.append(item["instanceUuid"])
+                if not response or not device_response:
+                    self.log("Failed to retrieve devices associated with the site '{0}' due to empty API response.".format(site_name), "INFO")
+                    break
+
+                for item in site_response_list:
+                    if item["reachabilityStatus"] != "Reachable":
+                        self.log("""Device '{0}' is currently '{1}' and cannot be included in the SWIM distribution/activation
+                                    process.""".format(item["managementIpAddress"], item["reachabilityStatus"]), "INFO")
+                        continue
+                    self.log("""Device '{0}' from site '{1}' is ready for the SWIM distribution/activation
+                                process.""".format(item["managementIpAddress"], site_name), "INFO")
+                    site_memberships_ids.append(item["instanceUuid"])
+
+                for item in device_response:
+                    if item["reachabilityStatus"] != "Reachable":
+                        self.log("""Unable to proceed with the device '{0}' for SWIM distribution/activation as its status is
+                                    '{1}'.""".format(item["managementIpAddress"], item["reachabilityStatus"]), "INFO")
+                        continue
+                    self.log("""Device '{0}' matches to the specified filter requirements and is set for SWIM
+                            distribution/activation.""".format(item["managementIpAddress"]), "INFO")
+                    device_response_ids.append(item["instanceUuid"])
+            except Exception as e:
+                self.msg = "An exception occured while fetching the device uuids from Cisco Catalyst Center: {0}".format(str(e))
+                self.log(self.msg, "ERROR")
+                return device_uuid_list
+
+        if not device_response_ids or not site_memberships_ids:
+            self.log("Failed to retrieve devices associated with the site '{0}' due to empty API response.".format(site_name), "INFO")
+            return device_uuid_list
 
         # Find the intersection of device IDs with the response get from get_membership api and get_device_list api with provided filters
         device_uuid_list = set(site_memberships_ids).intersection(set(device_response_ids))

--- a/plugins/modules/swim_intent.py
+++ b/plugins/modules/swim_intent.py
@@ -815,13 +815,13 @@ class DnacSwims(DnacBase):
                         params=device_params
                     )
                 else:
+                    initial_exec = True
                     device_list_response = self.dnac._exec(
                         family="devices",
                         function='get_device_list',
                         op_modifies=True,
                         params=device_params,
                     )
-                initial_exec = True
                 offset = offset + 1
                 device_response = device_list_response.get('response')
 

--- a/plugins/modules/swim_workflow_manager.py
+++ b/plugins/modules/swim_workflow_manager.py
@@ -801,13 +801,13 @@ class Swim(DnacBase):
                         params=device_params
                     )
                 else:
+                    initial_exec = True
                     device_list_response = self.dnac._exec(
                         family="devices",
                         function='get_device_list',
                         op_modifies=True,
                         params=device_params,
                     )
-                initial_exec = True
                 offset = offset + 1
                 device_response = device_list_response.get('response')
 

--- a/plugins/modules/swim_workflow_manager.py
+++ b/plugins/modules/swim_workflow_manager.py
@@ -786,7 +786,7 @@ class Swim(DnacBase):
             'role': device_role
         }
         offset = 0
-        limit = 500
+        limit = self.get_device_details_limit()
         initial_exec = False
         site_memberships_ids, device_response_ids = [], []
 

--- a/plugins/modules/swim_workflow_manager.py
+++ b/plugins/modules/swim_workflow_manager.py
@@ -785,37 +785,61 @@ class Swim(DnacBase):
             'family': device_family,
             'role': device_role
         }
-        device_list_response = self.dnac._exec(
-            family="devices",
-            function='get_device_list',
-            op_modifies=True,
-            params=device_params,
-        )
-
-        device_response = device_list_response.get('response')
-        if not response or not device_response:
-            self.log("Failed to retrieve devices associated with the site '{0}' due to empty API response.".format(site_name), "INFO")
-            return device_uuid_list
-
+        offset = 0
+        limit = 500
+        initial_exec = False
         site_memberships_ids, device_response_ids = [], []
 
-        for item in site_response_list:
-            if item["reachabilityStatus"] != "Reachable":
-                self.log("""Device '{0}' is currently '{1}' and cannot be included in the SWIM distribution/activation
-                            process.""".format(item["managementIpAddress"], item["reachabilityStatus"]), "INFO")
-                continue
-            self.log("""Device '{0}' from site '{1}' is ready for the SWIM distribution/activation
-                        process.""".format(item["managementIpAddress"], site_name), "INFO")
-            site_memberships_ids.append(item["instanceUuid"])
+        while True:
+            try:
+                if initial_exec:
+                    device_params["limit"] = limit
+                    device_params["offset"] = offset * limit
+                    device_list_response = self.dnac._exec(
+                        family="devices",
+                        function='get_device_list',
+                        params=device_params
+                    )
+                else:
+                    device_list_response = self.dnac._exec(
+                        family="devices",
+                        function='get_device_list',
+                        op_modifies=True,
+                        params=device_params,
+                    )
+                initial_exec = True
+                offset = offset + 1
+                device_response = device_list_response.get('response')
 
-        for item in device_response:
-            if item["reachabilityStatus"] != "Reachable":
-                self.log("""Unable to proceed with the device '{0}' for SWIM distribution/activation as its status is
-                            '{1}'.""".format(item["managementIpAddress"], item["reachabilityStatus"]), "INFO")
-                continue
-            self.log("""Device '{0}' matches to the specified filter requirements and is set for SWIM
-                      distribution/activation.""".format(item["managementIpAddress"]), "INFO")
-            device_response_ids.append(item["instanceUuid"])
+                if not response or not device_response:
+                    self.log("Failed to retrieve devices associated with the site '{0}' due to empty API response.".format(site_name), "INFO")
+                    break
+
+                for item in site_response_list:
+                    if item["reachabilityStatus"] != "Reachable":
+                        self.log("""Device '{0}' is currently '{1}' and cannot be included in the SWIM distribution/activation
+                                    process.""".format(item["managementIpAddress"], item["reachabilityStatus"]), "INFO")
+                        continue
+                    self.log("""Device '{0}' from site '{1}' is ready for the SWIM distribution/activation
+                                process.""".format(item["managementIpAddress"], site_name), "INFO")
+                    site_memberships_ids.append(item["instanceUuid"])
+
+                for item in device_response:
+                    if item["reachabilityStatus"] != "Reachable":
+                        self.log("""Unable to proceed with the device '{0}' for SWIM distribution/activation as its status is
+                                    '{1}'.""".format(item["managementIpAddress"], item["reachabilityStatus"]), "INFO")
+                        continue
+                    self.log("""Device '{0}' matches to the specified filter requirements and is set for SWIM
+                            distribution/activation.""".format(item["managementIpAddress"]), "INFO")
+                    device_response_ids.append(item["instanceUuid"])
+            except Exception as e:
+                self.msg = "An exception occured while fetching the device uuids from Cisco Catalyst Center: {0}".format(str(e))
+                self.log(self.msg, "ERROR")
+                return device_uuid_list
+
+        if not device_response_ids or not site_memberships_ids:
+            self.log("Failed to retrieve devices associated with the site '{0}' due to empty API response.".format(site_name), "INFO")
+            return device_uuid_list
 
         # Find the intersection of device IDs with the response get from get_membership api and get_device_list api with provided filters
         device_uuid_list = set(site_memberships_ids).intersection(set(device_response_ids))


### PR DESCRIPTION
In this commit -

-- Fix the issue of removing header from existing Webhook destination as part of update operation by passing an empty list in the playbook.

-- Also fix the issue with updating webhook destination with headers.

-- Fix the issue of getting devices from inventory if it's more than 500 as 'get_device_list' API only fetch 500 devices at a time because of which module like inventory and swim gets failed.