### PR TITLE
Set the response message in case of failure for any task, fix the iss…

### DIFF
--- a/plugins/module_utils/dnac.py
+++ b/plugins/module_utils/dnac.py
@@ -231,11 +231,11 @@ class DnacBase():
         # self.log("status: {0}, msg:{1}".format(self.status, self.msg), frameIncrement=1)
         self.log("status: {0}, msg: {1}".format(self.status, self.msg), "DEBUG")
         if "failed" in self.status:
-            self.module.fail_json(msg=self.msg, response=[])
+            self.module.fail_json(msg=self.msg, response=self.result.get('response', []))
         elif "exited" in self.status:
             self.module.exit_json(**self.result)
         elif "invalid" in self.status:
-            self.module.fail_json(msg=self.msg, response=[])
+            self.module.fail_json(msg=self.msg, response=self.result.get('response', []))
 
     def is_valid_password(self, password):
         """

--- a/plugins/modules/events_and_notifications_workflow_manager.py
+++ b/plugins/modules/events_and_notifications_workflow_manager.py
@@ -1365,7 +1365,7 @@ class Events(DnacBase):
             try:
                 failure_msg = response.get('errorMessage').get('errors')
             except Exception as e:
-                failure_msg = "Unable to Add syslog destination with name '{0}' in Cisco Catalyst Center".format(name)
+                failure_msg = "Unable to add syslog destination with name '{0}' in Cisco Catalyst Center".format(name)
 
             self.msg = failure_msg
             self.log(self.msg, "ERROR")
@@ -1660,7 +1660,7 @@ class Events(DnacBase):
             if error_messages:
                 self.msg = error_messages.get('errors')
             else:
-                self.msg = "Unable to Add SNMP destination with name '{0}' in Cisco Catalyst Center".format(snmp_params.get('name'))
+                self.msg = "Unable to add SNMP destination with name '{0}' in Cisco Catalyst Center".format(snmp_params.get('name'))
 
             self.log(self.msg, "ERROR")
             self.result['response'] = self.msg
@@ -1925,7 +1925,7 @@ class Events(DnacBase):
             if error_messages:
                 self.msg = error_messages.get('errors')
             else:
-                self.msg = "Unable to Add Webhook destination with name '{0}' in Cisco Catalyst Center".format(webhook_params.get('name'))
+                self.msg = "Unable to add Webhook destination with name '{0}' in Cisco Catalyst Center".format(webhook_params.get('name'))
 
             self.log(self.msg, "ERROR")
             self.result['response'] = self.msg
@@ -2216,7 +2216,7 @@ class Events(DnacBase):
             if error_messages:
                 self.msg = error_messages.get('errors')
             else:
-                self.msg = "Unable to Add Email destination in Cisco Catalyst Center."
+                self.msg = "Unable to add Email destination in Cisco Catalyst Center."
 
             self.log(self.msg, "ERROR")
             self.result['response'] = self.msg
@@ -4547,7 +4547,7 @@ class Events(DnacBase):
             webhook_dest_detail_in_ccc = self.have.get("webhook_destinations")
 
             if not self.have.get("webhook_destinations"):
-                # Need to Add snmp destination in Cisco Catalyst Center with given playbook params
+                # Need to add snmp destination in Cisco Catalyst Center with given playbook params
                 if not url:
                     self.status = "failed"
                     self.msg = "Url is required parameter for creating Webhook destination for creating/updating the event in Cisco Catalyst Center."
@@ -4588,7 +4588,7 @@ class Events(DnacBase):
                     return self
 
             if not self.have.get("email_destination"):
-                # Need to Add email destination in Cisco Catalyst Center with given playbook params
+                # Need to add email destination in Cisco Catalyst Center with given playbook params
                 invalid_email_params = []
 
                 if email_params.get("primarySMTPConfig") and not email_params.get("primarySMTPConfig").get("hostName"):
@@ -4652,7 +4652,7 @@ class Events(DnacBase):
             syslog_details_in_ccc = self.have.get('syslog_destinations')
 
             if not syslog_details_in_ccc:
-                # We need to Add the Syslog Destination in the Catalyst Center
+                # We need to add the Syslog Destination in the Catalyst Center
                 self.add_syslog_destination(syslog_details).check_return_status()
             else:
                 # Check destination needs update and if yes then update Syslog Destination
@@ -4703,7 +4703,7 @@ class Events(DnacBase):
                 return self
 
             if not self.have.get("snmp_destinations"):
-                # Need to Add snmp destination in Cisco Catalyst Center with given playbook params
+                # Need to add snmp destination in Cisco Catalyst Center with given playbook params
                 self.check_snmp_required_parameters(snmp_params).check_return_status()
                 self.log("""Required parameter validated successfully for adding SNMP Destination with name '{0}' in Cisco
                             Catalyst Center.""".format(destination), "INFO")
@@ -4740,7 +4740,7 @@ class Events(DnacBase):
                 itsm_id = itsm_detail_in_ccc[0].get("id")
 
             if not itsm_detail_in_ccc:
-                # Need to Add snmp destination in Cisco Catalyst Center with given playbook params
+                # Need to add snmp destination in Cisco Catalyst Center with given playbook params
                 invalid_itsm_params = []
                 invalid_itsm_params = self.check_required_itsm_param(itsm_params, invalid_itsm_params)
                 connection_setting = itsm_params.get('data').get('ConnectionSettings')

--- a/plugins/modules/events_and_notifications_workflow_manager.py
+++ b/plugins/modules/events_and_notifications_workflow_manager.py
@@ -1658,11 +1658,10 @@ class Events(DnacBase):
             self.status = "failed"
             error_messages = response.get('errorMessage')
             if error_messages:
-                failure_msg = error_messages.get('errors')
+                self.msg = error_messages.get('errors')
             else:
-                failure_msg = "Unable to Add SNMP destination with name '{0}' in Cisco Catalyst Center".format(snmp_params.get('name'))
+                self.msg = "Unable to Add SNMP destination with name '{0}' in Cisco Catalyst Center".format(snmp_params.get('name'))
 
-            self.msg = failure_msg
             self.log(self.msg, "ERROR")
             self.result['response'] = self.msg
 
@@ -1780,11 +1779,10 @@ class Events(DnacBase):
             self.status = "failed"
             error_messages = response.get('errorMessage')
             if error_messages:
-                failure_msg = error_messages.get('errors')
+                self.msg = error_messages.get('errors')
             else:
-                failure_msg = "Unable to update SNMP destination with name '{0}' in Cisco Catalyst Center".format(update_snmp_params.get('name'))
+                self.msg = "Unable to update SNMP destination with name '{0}' in Cisco Catalyst Center".format(update_snmp_params.get('name'))
 
-            self.msg = failure_msg
             self.log(self.msg, "ERROR")
             self.result['response'] = self.msg
 
@@ -1925,11 +1923,10 @@ class Events(DnacBase):
             self.status = "failed"
             error_messages = response.get('errorMessage')
             if error_messages:
-                failure_msg = error_messages.get('errors')
+                self.msg = error_messages.get('errors')
             else:
-                failure_msg = "Unable to Add Webhook destination with name '{0}' in Cisco Catalyst Center".format(webhook_params.get('name'))
+                self.msg = "Unable to Add Webhook destination with name '{0}' in Cisco Catalyst Center".format(webhook_params.get('name'))
 
-            self.msg = failure_msg
             self.log(self.msg, "ERROR")
             self.result['response'] = self.msg
 
@@ -2063,11 +2060,10 @@ class Events(DnacBase):
             error_messages = response.get('errorMessage')
 
             if error_messages:
-                failure_msg = error_messages.get('errors')
+                self.msg = error_messages.get('errors')
             else:
-                failure_msg = "Unable to update rest webhook destination with name '{0}' in Cisco Catalyst Center".format(name)
+                self.msg = "Unable to update rest webhook destination with name '{0}' in Cisco Catalyst Center".format(name)
 
-            self.msg = failure_msg
             self.log(self.msg, "ERROR")
             self.result['response'] = self.msg
 
@@ -2218,11 +2214,10 @@ class Events(DnacBase):
             error_messages = response.get('errorMessage')
 
             if error_messages:
-                failure_msg = error_messages.get('errors')
+                self.msg = error_messages.get('errors')
             else:
-                failure_msg = "Unable to Add Email destination in Cisco Catalyst Center."
+                self.msg = "Unable to Add Email destination in Cisco Catalyst Center."
 
-            self.msg = failure_msg
             self.log(self.msg, "ERROR")
             self.result['response'] = self.msg
 
@@ -2319,11 +2314,10 @@ class Events(DnacBase):
             error_messages = status_response.get('errorMessage')
 
             if error_messages:
-                failure_msg = error_messages.get('errors')
+                self.msg = error_messages.get('errors')
             else:
-                failure_msg = "Unable to update Email destination in Cisco Catalyst Center."
+                self.msg = "Unable to update Email destination in Cisco Catalyst Center."
 
-            self.msg = failure_msg
             self.log(self.msg, "ERROR")
             self.result['response'] = self.msg
 
@@ -3200,12 +3194,12 @@ class Events(DnacBase):
             error_messages = status_response.get('errorMessage')
 
             if error_messages:
-                failure_msg = error_messages.get('errors')
+                self.msg = error_messages.get('errors')
             else:
-                failure_msg = "Unable to add Syslog Event Notification '{0}' in Cisco Catalyst Center.".format(notification_name)
+                self.msg = "Unable to add Syslog Event Notification '{0}' in Cisco Catalyst Center.".format(notification_name)
 
-            self.log(failure_msg, "ERROR")
-            self.result['response'] = failure_msg
+            self.log(self.msg, "ERROR")
+            self.result['response'] = self.msg
 
         except Exception as e:
             self.status = "failed"
@@ -3445,12 +3439,12 @@ class Events(DnacBase):
             error_messages = status_response.get('errorMessage')
 
             if error_messages:
-                failure_msg = error_messages.get('errors')
+                self.msg = error_messages.get('errors')
             else:
-                failure_msg = "Unable to update Syslog Event Notification '{0}' in Cisco Catalyst Center.".format(name)
+                self.msg = "Unable to update Syslog Event Notification '{0}' in Cisco Catalyst Center.".format(name)
 
-            self.log(failure_msg, "ERROR")
-            self.result['response'] = failure_msg
+            self.log(self.msg, "ERROR")
+            self.result['response'] = self.msg
 
         except Exception as e:
             self.status = "failed"
@@ -3746,12 +3740,12 @@ class Events(DnacBase):
             error_messages = status_response.get('errorMessage')
 
             if error_messages:
-                failure_msg = error_messages.get('errors')
+                self.msg = error_messages.get('errors')
             else:
-                failure_msg = "Unable to add Webhook Events Subscription Notification '{0}' in Cisco Catalyst Center.".format(notification_name)
+                self.msg = "Unable to add Webhook Events Subscription Notification '{0}' in Cisco Catalyst Center.".format(notification_name)
 
-            self.log(failure_msg, "ERROR")
-            self.result['response'] = failure_msg
+            self.log(self.msg, "ERROR")
+            self.result['response'] = self.msg
 
         except Exception as e:
             self.status = "failed"
@@ -3880,12 +3874,12 @@ class Events(DnacBase):
             error_messages = status_response.get('errorMessage')
 
             if error_messages:
-                failure_msg = error_messages.get('errors')
+                self.msg = error_messages.get('errors')
             else:
-                failure_msg = "Unable to update webhook Event Subscription Notification '{0}' in Cisco Catalyst Center.".format(name)
+                self.msg = "Unable to update webhook Event Subscription Notification '{0}' in Cisco Catalyst Center.".format(name)
 
-            self.log(failure_msg, "ERROR")
-            self.result['response'] = failure_msg
+            self.log(self.msg, "ERROR")
+            self.result['response'] = self.msg
 
         except Exception as e:
             self.status = "failed"
@@ -4239,12 +4233,12 @@ class Events(DnacBase):
             error_messages = status_response.get('errorMessage')
 
             if error_messages:
-                failure_msg = error_messages.get('errors')
+                self.msg = error_messages.get('errors')
             else:
-                failure_msg = "Unable to add Email Events Subscription Notification '{0}' in Cisco Catalyst Center.".format(notification_name)
+                self.msg = "Unable to add Email Events Subscription Notification '{0}' in Cisco Catalyst Center.".format(notification_name)
 
-            self.log(failure_msg, "ERROR")
-            self.result['response'] = failure_msg
+            self.log(self.msg, "ERROR")
+            self.result['response'] = self.msg
 
         except Exception as e:
             self.status = "failed"
@@ -4414,13 +4408,12 @@ class Events(DnacBase):
             error_messages = status_response.get('errorMessage')
 
             if error_messages:
-                failure_msg = error_messages.get('errors')
+                self.msg = error_messages.get('errors')
             else:
-                failure_msg = "Unable to update Email Event Subscription Notification '{0}' in Cisco Catalyst Center.".format(name)
+                self.msg = "Unable to update Email Event Subscription Notification '{0}' in Cisco Catalyst Center.".format(name)
 
-            self.log(failure_msg, "ERROR")
-            self.result['response'] = failure_msg
-            self.msg = failure_msg
+            self.log(self.msg, "ERROR")
+            self.result['response'] = self.msg
 
         except Exception as e:
             self.status = "failed"
@@ -4471,13 +4464,12 @@ class Events(DnacBase):
             error_messages = status_response.get('errorMessage')
 
             if error_messages:
-                failure_msg = error_messages.get('errors')
+                self.msg = error_messages.get('errors')
             else:
-                failure_msg = "Unable to delete Event Subscription Notification '{0}' from Cisco Catalyst Center.".format(subscription_name)
+                self.msg = "Unable to delete Event Subscription Notification '{0}' from Cisco Catalyst Center.".format(subscription_name)
 
-            self.log(failure_msg, "ERROR")
-            self.result['response'] = failure_msg
-            self.msg = failure_msg
+            self.log(self.msg, "ERROR")
+            self.result['response'] = self.msg
         except Exception as e:
             self.status = "failed"
             self.msg = "Exception occurred while deleting Event Subscription Notification '{0}' due to: {1}".format(subscription_name, str(e))

--- a/plugins/modules/inventory_intent.py
+++ b/plugins/modules/inventory_intent.py
@@ -2803,13 +2803,11 @@ class DnacDevice(DnacBase):
                 else:
                     self.msg = "Device Updation for device '{0}' get failed".format(device_ip)
                 self.log(self.msg, "ERROR")
+                self.result['response'] = self.msg
+                self.check_return_status()
                 break
             elif execution_details.get("endTime"):
-                self.status = "success"
-                self.result['changed'] = True
-                self.msg = "Device '{0}' present in Cisco Catalyst Center and have been updated successfully".format(device_ip)
-                self.result['response'] = self.msg
-                self.log(self.msg, "INFO")
+                self.log("Device '{0}' present in Cisco Catalyst Center and have been updated successfully.".format(device_ip), "INFO")
                 break
 
         return self
@@ -2979,6 +2977,7 @@ class DnacDevice(DnacBase):
         if credential_update:
             device_to_update = self.get_device_ips_from_config_priority()
             device_exist = self.is_device_exist_for_update(device_to_update)
+            update_device_ips = []
 
             if not device_exist:
                 self.msg = """Unable to edit device credentials/details because the device(s) listed: {0} are not present in the
@@ -3330,12 +3329,20 @@ class DnacDevice(DnacBase):
 
                         if response and isinstance(response, dict):
                             self.check_device_update_execution_response(response, device_ip)
+                            update_device_ips.append(device_ip)
                             self.check_return_status()
 
                 except Exception as e:
                     error_message = "Error while updating device in Cisco Catalyst Center: {0}".format(str(e))
                     self.log(error_message, "ERROR")
                     raise Exception(error_message)
+
+            if update_device_ips:
+                self.status = "success"
+                self.result['changed'] = True
+                self.msg = "Device(s) '{0}' present in Cisco Catalyst Center and have been updated successfully.".format(str(update_device_ips))
+                self.result['response'] = self.msg
+                self.log(self.msg, "INFO")
 
         # Update list of interface details on specific or list of devices.
         if self.config[0].get('update_interface_details'):

--- a/plugins/modules/inventory_workflow_manager.py
+++ b/plugins/modules/inventory_workflow_manager.py
@@ -2796,16 +2796,14 @@ class Inventory(DnacBase):
                 else:
                     self.msg = "Device Updation for device '{0}' get failed".format(device_ip)
                 self.log(self.msg, "ERROR")
+                self.result['response'] = self.msg
+                self.check_return_status()
                 break
             elif execution_details.get("endTime"):
-                self.status = "success"
-                self.result['changed'] = True
-                self.msg = "Device '{0}' present in Cisco Catalyst Center and have been updated successfully".format(device_ip)
-                self.result['response'] = self.msg
-                self.log(self.msg, "INFO")
+                self.log("Device '{0}' present in Cisco Catalyst Center and have been updated successfully.".format(device_ip), "INFO")
                 break
 
-        return self
+        return device_ip
 
     def is_device_exist_in_ccc(self, device_ip):
         """
@@ -3161,6 +3159,7 @@ class Inventory(DnacBase):
 
         if credential_update:
             device_to_update = self.get_device_ips_from_config_priority()
+            update_device_ips = []
 
             # Update Device details and credentails
             device_uuids = self.get_device_ids(device_to_update)
@@ -3323,12 +3322,20 @@ class Inventory(DnacBase):
 
                         if response and isinstance(response, dict):
                             self.check_device_update_execution_response(response, device_ip)
+                            update_device_ips.append(device_ip)
                             self.check_return_status()
 
                 except Exception as e:
                     error_message = "Error while updating device in Cisco Catalyst Center: {0}".format(str(e))
                     self.log(error_message, "ERROR")
                     raise Exception(error_message)
+
+            if update_device_ips:
+                self.status = "success"
+                self.result['changed'] = True
+                self.msg = "Device(s) '{0}' present in Cisco Catalyst Center and have been updated successfully.".format(str(update_device_ips))
+                self.result['response'] = self.msg
+                self.log(self.msg, "INFO")
 
         # Update list of interface details on specific or list of devices.
         if self.config[0].get('update_interface_details'):


### PR DESCRIPTION
…ue of creating/updating notification with unsupported events, provide message in console for all the updated devices in inventory.

In this commit -- 

-- Set the response message in case of failure for any task in the dnac.py so that every time in the console response field not be empty.

-- Fix the issue of creating/updating notification with unsupported events like for Syslog Notification event like - Licenses in OOC not supported but it supported for webhook notification so will fail the operation providing the appropriate log message.

-- While updating multiple devices in the inventory module, only the last device message comes in the console which confuse the updation status of other devices so fix this issue by providing the list of devices updated successfully.
