### PR TITLE
Update the documentation for the updation of device, it must be prese…

### DIFF
--- a/plugins/modules/inventory_intent.py
+++ b/plugins/modules/inventory_intent.py
@@ -192,7 +192,9 @@ options:
       credential_update:
         description: Make this as true needed for the updation of device credentials and other device details. Also if this parameter
             is set to True then make sure that the device(s) must be present in Cisco Catalyst Center then only we can perform the
-            update operations for the respective device(s).
+            update operations for the respective device(s). Otherwise if some devices are missing then module will try to add them in
+            Cisco Catalsyt Center and while adding if some required parameter is missing then module will failed and stop the execution
+            and we cannot perform the update operation for the devices that are already there.
         type: bool
         default: False
       clean_config:

--- a/plugins/modules/inventory_intent.py
+++ b/plugins/modules/inventory_intent.py
@@ -190,11 +190,11 @@ options:
         type: bool
         default: False
       credential_update:
-        description: Make this as true needed for the updation of device credentials and other device details. Also if this parameter
-            is set to True then make sure that the device(s) must be present in Cisco Catalyst Center then only we can perform the
-            update operations for the respective device(s). Otherwise if some devices are missing then module will try to add them in
-            Cisco Catalsyt Center and while adding if some required parameter is missing then module will failed and stop the execution
-            and we cannot perform the update operation for the devices that are already there.
+        description: Set this to 'True' to update device credentials and other device details. When this parameter is 'True', ensure that
+                the devices are present in Cisco Catalyst Center; only then can update operations be performed on the respective devices.
+                If the parameter is 'True' and any device is not present, the module will attempt to add it.  If required parameters are
+                missing during this addition, the module will fail and stop execution, preventing update operations for devices that are
+                already present.
         type: bool
         default: False
       clean_config:

--- a/plugins/modules/inventory_intent.py
+++ b/plugins/modules/inventory_intent.py
@@ -190,7 +190,9 @@ options:
         type: bool
         default: False
       credential_update:
-        description: Make this as true needed for the updation of device credentials and other device details.
+        description: Make this as true needed for the updation of device credentials and other device details. Also if this parameter
+            is set to True then make sure that the device(s) must be present in Cisco Catalyst Center then only we can perform the
+            update operations for the respective device(s).
         type: bool
         default: False
       clean_config:

--- a/plugins/modules/inventory_workflow_manager.py
+++ b/plugins/modules/inventory_workflow_manager.py
@@ -192,7 +192,9 @@ options:
       credential_update:
         description: Make this as true needed for the updation of device credentials and other device details. Also if this parameter
             is set to True then make sure that the device(s) must be present in Cisco Catalyst Center then only we can perform the
-            update operations for the respective device(s).
+            update operations for the respective device(s). Otherwise if some devices are missing then module will try to add them in
+            Cisco Catalsyt Center and while adding if some required parameter is missing then module will failed and stop the execution
+            and we cannot perform the update operation for the devices that are already there.
         type: bool
         default: False
       clean_config:

--- a/plugins/modules/inventory_workflow_manager.py
+++ b/plugins/modules/inventory_workflow_manager.py
@@ -190,11 +190,11 @@ options:
         type: bool
         default: False
       credential_update:
-        description: Make this as true needed for the updation of device credentials and other device details. Also if this parameter
-            is set to True then make sure that the device(s) must be present in Cisco Catalyst Center then only we can perform the
-            update operations for the respective device(s). Otherwise if some devices are missing then module will try to add them in
-            Cisco Catalsyt Center and while adding if some required parameter is missing then module will failed and stop the execution
-            and we cannot perform the update operation for the devices that are already there.
+        description: Set this to 'True' to update device credentials and other device details. When this parameter is 'True', ensure that
+                the devices are present in Cisco Catalyst Center; only then can update operations be performed on the respective devices.
+                If the parameter is 'True' and any device is not present, the module will attempt to add it.  If required parameters are
+                missing during this addition, the module will fail and stop execution, preventing update operations for devices that are
+                already present.
         type: bool
         default: False
       clean_config:

--- a/plugins/modules/inventory_workflow_manager.py
+++ b/plugins/modules/inventory_workflow_manager.py
@@ -190,7 +190,9 @@ options:
         type: bool
         default: False
       credential_update:
-        description: Make this as true needed for the updation of device credentials and other device details.
+        description: Make this as true needed for the updation of device credentials and other device details. Also if this parameter
+            is set to True then make sure that the device(s) must be present in Cisco Catalyst Center then only we can perform the
+            update operations for the respective device(s).
         type: bool
         default: False
       clean_config:


### PR DESCRIPTION
…nt in Catalyst Center.

In this commit --

-- Update the documentation for the updation of device such that if you give the parameter credential_update as True then playbook input devices for which you want to update the details must be present in Catalyst Center otherwise you have to give required details for the addition of those devices as first attempt will be adding the device which doesnot exist in Catalyst Center.