### PR TITLE
Fix the issue of exporting more than 800 devices in a batch of 500 at…

### DIFF
--- a/plugins/modules/events_and_notifications_workflow_manager.py
+++ b/plugins/modules/events_and_notifications_workflow_manager.py
@@ -1743,7 +1743,7 @@ class Events(DnacBase):
 
             if update_snmp_params.get('port'):
                 try:
-                    port = int(snmp_params.get('port'))
+                    port = int(update_snmp_params.get('port'))
                     if port not in range(1, 65536):
                         self.status = "failed"
                         self.msg = "Invalid Notification trap port '{0}' given in playbook. Select port from the number range(1, 65535)".format(port)
@@ -1753,7 +1753,7 @@ class Events(DnacBase):
                 except Exception as e:
                     self.status = "failed"
                     self.msg = """Invalid datatype for the Notification trap port '{0}' given in playbook. Select port with correct datatype from the
-                                number range(1, 65535).""".format(port)
+                                number range(1, 65535).""".format(update_snmp_params.get('port'))
                     self.log(self.msg, "ERROR")
                     return self
 
@@ -2116,6 +2116,12 @@ class Events(DnacBase):
             return response[0]
 
         except Exception as e:
+            if "Expecting value: line 1 column 1" in str(e):
+                self.log(
+                    "Getting expection as Email destination is not configured in Cisco Catalyst"
+                    " Center.", "WARNING"
+                )
+                return None
             self.status = "failed"
             self.msg = "Error while getting the details of Email destination present in Cisco Catalyst Center: {0}".format(str(e))
             self.log(self.msg, "ERROR")
@@ -2598,13 +2604,16 @@ class Events(DnacBase):
 
             update_itsm_params['data'] = {}
             update_itsm_params['data']['ConnectionSettings'] = {}
+            url_in_ccc = itsm_in_ccc.get('data').get('ConnectionSettings').get('Url')
+            username_in_ccc = itsm_in_ccc.get('data').get('ConnectionSettings').get('Auth_UserName')
+
             if itsm_params.get('data') is None or itsm_params.get('data').get('ConnectionSettings') is None:
-                update_itsm_params['data']['ConnectionSettings']['Url'] = itsm_in_ccc.get('data').get('ConnectionSettings').get('Url')
-                update_itsm_params['data']['ConnectionSettings']['Auth_UserName'] = itsm_in_ccc.get('data').get('ConnectionSettings').get('Auth_UserName')
+                update_itsm_params['data']['ConnectionSettings']['Url'] = url_in_ccc
+                update_itsm_params['data']['ConnectionSettings']['Auth_UserName'] = username_in_ccc
             else:
                 connection_params = itsm_params.get('data').get('ConnectionSettings')
-                update_itsm_params['data']['ConnectionSettings']['Url'] = connection_params.get('Url')
-                update_itsm_params['data']['ConnectionSettings']['Auth_UserName'] = connection_params.get('Auth_UserName')
+                update_itsm_params['data']['ConnectionSettings']['Url'] = connection_params.get('Url') or url_in_ccc
+                update_itsm_params['data']['ConnectionSettings']['Auth_UserName'] = connection_params.get('Auth_UserName') or username_in_ccc
 
                 if not connection_params.get('Auth_Password'):
                     self.status = "failed"
@@ -4568,7 +4577,7 @@ class Events(DnacBase):
             result_msg_list.append(update_notf_msg)
 
         if self.no_update_notification:
-            no_update_notf_msg = "Event subscription notification(s) '{0}' needs no update in Cisco Catalyst Center.".format(self.no_update_notification)
+            no_update_notf_msg = "Event subscription notification(s) '{0}' need no update in Cisco Catalyst Center.".format(self.no_update_notification)
             result_msg_list.append(no_update_notf_msg)
 
         if self.delete_dest:

--- a/plugins/modules/inventory_intent.py
+++ b/plugins/modules/inventory_intent.py
@@ -1195,34 +1195,44 @@ class DnacDevice(DnacBase):
                 self.result['response'] = self.msg
                 return self
 
-            payload_params = {
-                "deviceUuids": device_uuids,
-                "password": password,
-                "operationEnum": export_device_list.get("operation_enum", "0"),
-                "parameters": export_device_list.get("parameters")
-            }
-
-            response = self.trigger_export_api(payload_params)
-            self.check_return_status()
-
-            if payload_params["operationEnum"] == "0":
-                temp_file_name = response.filename
-                output_file_name = temp_file_name.split(".")[0] + ".csv"
-                csv_reader = self.decrypt_and_read_csv(response, password)
-                self.check_return_status()
-            else:
-                decoded_resp = response.data.decode(encoding='utf-8')
-                self.log("Decoded response of Export Device Credential file: {0}".format(str(decoded_resp)), "DEBUG")
-
-                # Parse the CSV-like string into a list of dictionaries
-                csv_reader = csv.DictReader(StringIO(decoded_resp))
-                current_date = datetime.now()
-                formatted_date = current_date.strftime("%m-%d-%Y")
-                output_file_name = "devices-" + str(formatted_date) + ".csv"
-
+            # Export the device data in a batch of 500 devices at a time
+            start = 0
+            chunk_size = 500
             device_data = []
-            for row in csv_reader:
-                device_data.append(row)
+            first_run = True
+
+            while start < len(device_uuids):
+                device_ids_list = device_uuids[start:start + chunk_size]
+                payload_params = {
+                    "deviceUuids": device_ids_list,
+                    "password": password,
+                    "operationEnum": export_device_list.get("operation_enum", "0"),
+                    "parameters": export_device_list.get("parameters")
+                }
+
+                response = self.trigger_export_api(payload_params)
+                self.check_return_status()
+
+                if payload_params["operationEnum"] == "0":
+                    temp_file_name = response.filename
+                    if first_run:
+                        output_file_name = temp_file_name.split(".")[0] + ".csv"
+                    csv_reader = self.decrypt_and_read_csv(response, password)
+                    self.check_return_status()
+                else:
+                    decoded_resp = response.data.decode(encoding='utf-8')
+                    self.log("Decoded response of Export Device Credential file: {0}".format(str(decoded_resp)), "DEBUG")
+                    # Parse the CSV-like string into a list of dictionaries
+                    csv_reader = csv.DictReader(StringIO(decoded_resp))
+                    current_date = datetime.now()
+                    formatted_date = current_date.strftime("%m-%d-%Y")
+                    if first_run:
+                        output_file_name = "devices-" + str(formatted_date) + ".csv"
+
+                for row in csv_reader:
+                    device_data.append(row)
+                start += chunk_size
+                first_run = False
 
             # Write the data to a CSV file
             with open(output_file_name, 'w', newline='') as csv_file:
@@ -2474,7 +2484,9 @@ class DnacDevice(DnacBase):
         device_ips = self.get_device_ips_from_config_priority()
         device_uuids = self.get_device_ids(device_ips)
         password = "Testing@123"
-        payload_params = {"deviceUuids": device_uuids, "password": password, "operationEnum": "0"}
+        # Split the payload into 500 devices only to match the device credentials
+        device_ids_list = device_uuids[0:500]
+        payload_params = {"deviceUuids": device_ids_list, "password": password, "operationEnum": "0"}
         response = self.trigger_export_api(payload_params)
         self.check_return_status()
         csv_reader = self.decrypt_and_read_csv(response, password)
@@ -3199,10 +3211,21 @@ class DnacDevice(DnacBase):
             csv_reader = self.decrypt_and_read_csv(export_response, password)
             self.check_return_status()
             device_details = {}
+            start = 0
+            chunk_size = 500
 
-            for row in csv_reader:
-                ip_address = row['ip_address']
-                device_details[ip_address] = row
+            while start < len(device_uuids):
+                device_ids_list = device_uuids[start:start + chunk_size]
+                export_payload = {"deviceUuids": device_ids_list, "password": password, "operationEnum": "0"}
+                export_response = self.trigger_export_api(export_payload)
+                self.check_return_status()
+                csv_reader = self.decrypt_and_read_csv(export_response, password)
+                self.check_return_status()
+
+                for row in csv_reader:
+                    ip_address = row['ip_address']
+                    device_details[ip_address] = row
+                start += chunk_size
 
             for device_ip in device_to_update:
                 playbook_params = self.want.get("device_params").copy()

--- a/plugins/modules/inventory_intent.py
+++ b/plugins/modules/inventory_intent.py
@@ -782,6 +782,7 @@ class DnacDevice(DnacBase):
             'device_resync': {'type': 'bool'},
             'reboot_device': {'type': 'bool'},
             'credential_update': {'type': 'bool'},
+            'export_device_details_limit': {'default': 500, 'type': 'bool'},
             'force_sync': {'type': 'bool'},
             'clean_config': {'type': 'bool'},
             'add_user_defined_field': {

--- a/plugins/modules/inventory_intent.py
+++ b/plugins/modules/inventory_intent.py
@@ -189,6 +189,13 @@ options:
         description: Make this as true needed for the Rebooting of Access Points.
         type: bool
         default: False
+      export_device_details_limit:
+        description: Specifies the limit for updating device details or exporting device details/credentials to a file.
+                The default limit is set to 500 devices. This limit is applied when exporting device details/credentials
+                and editing device details.
+                The maximum number of device details/credentials that can be exported in a single API call is 800.
+        type: int
+        default: 500
       credential_update:
         description: Set this to 'True' to update device credentials and other device details. When this parameter is 'True', ensure that
                 the devices are present in Cisco Catalyst Center; only then can update operations be performed on the respective devices.
@@ -1197,12 +1204,12 @@ class DnacDevice(DnacBase):
 
             # Export the device data in a batch of 500 devices at a time
             start = 0
-            chunk_size = 500
+            device_batch_size = self.config[0].get("export_device_details_limit", 500)
             device_data = []
             first_run = True
 
             while start < len(device_uuids):
-                device_ids_list = device_uuids[start:start + chunk_size]
+                device_ids_list = device_uuids[start:start + device_batch_size]
                 payload_params = {
                     "deviceUuids": device_ids_list,
                     "password": password,
@@ -1231,7 +1238,7 @@ class DnacDevice(DnacBase):
 
                 for row in csv_reader:
                     device_data.append(row)
-                start += chunk_size
+                start += device_batch_size
                 first_run = False
 
             # Write the data to a CSV file
@@ -2484,8 +2491,9 @@ class DnacDevice(DnacBase):
         device_ips = self.get_device_ips_from_config_priority()
         device_uuids = self.get_device_ids(device_ips)
         password = "Testing@123"
-        # Split the payload into 500 devices only to match the device credentials
-        device_ids_list = device_uuids[0:500]
+        # Split the payload into 500 devices(by default) only to match the device credentials
+        device_batch_size = self.config[0].get("export_device_details_limit", 500)
+        device_ids_list = device_uuids[0:device_batch_size]
         payload_params = {"deviceUuids": device_ids_list, "password": password, "operationEnum": "0"}
         response = self.trigger_export_api(payload_params)
         self.check_return_status()
@@ -3212,10 +3220,10 @@ class DnacDevice(DnacBase):
             self.check_return_status()
             device_details = {}
             start = 0
-            chunk_size = 500
+            device_batch_size = self.config[0].get("export_device_details_limit", 500)
 
             while start < len(device_uuids):
-                device_ids_list = device_uuids[start:start + chunk_size]
+                device_ids_list = device_uuids[start:start + device_batch_size]
                 export_payload = {"deviceUuids": device_ids_list, "password": password, "operationEnum": "0"}
                 export_response = self.trigger_export_api(export_payload)
                 self.check_return_status()
@@ -3225,7 +3233,7 @@ class DnacDevice(DnacBase):
                 for row in csv_reader:
                     ip_address = row['ip_address']
                     device_details[ip_address] = row
-                start += chunk_size
+                start += device_batch_size
 
             for device_ip in device_to_update:
                 playbook_params = self.want.get("device_params").copy()

--- a/plugins/modules/inventory_workflow_manager.py
+++ b/plugins/modules/inventory_workflow_manager.py
@@ -781,6 +781,7 @@ class Inventory(DnacBase):
             'device_resync': {'type': 'bool'},
             'reboot_device': {'type': 'bool'},
             'credential_update': {'type': 'bool'},
+            'export_device_details_limit': {'default': 500, 'type': 'bool'},
             'force_sync': {'type': 'bool'},
             'clean_config': {'type': 'bool'},
             'add_user_defined_field': {


### PR DESCRIPTION
… a time while updating devices, also fix the issue of creating email destination in fresh set up by handling the exception.

In this commit --

-- Fix the issue of updating devices in a scaled set up(let say 1k devices), while exporting the device details in a csv file export_device_detail API support only 800 devices at a time. So we pass a chunk of 500 devices at a time to export device detail API and store the result and then keep iterating till we get credentials details of all devices and then we can update all devices one by one.

-- Also fix the issue of creating email destination in a fresh set up as when invoking get email destination API, it return 202 response and comes into exception because of which email destination creation gets failed. Like we handled the exception for other destination by returning None if specific exception came and then invoke the create destination API.