### PR TITLE
Update the notes in the documentation stating that module expects val…

### DIFF
--- a/plugins/modules/events_and_notifications_workflow_manager.py
+++ b/plugins/modules/events_and_notifications_workflow_manager.py
@@ -477,9 +477,9 @@ requirements:
 - python >= 3.5
 
 notes:
-  - To ensure the module operates correctly for scaled sets, which involve creating or updating multiple destinations and handling
-    event subscription notifications, please provide valid input in the playbook. If any failure is encountered, the module will
-    halt execution without proceeding to further operations.
+  - To ensure the module operates correctly with scaled sets—such as creating or updating multiple destinations and handling event
+    subscription notifications—please ensure that valid input is provided in the playbook. If any failure occurs, the module will
+    halt execution and will not proceed to subsequent operations.
   - Configuring the webhook destination with headers now supports starting from dnacentersdk version 2.9.1 onwards. This enhancement is in
     alignment with Catalyst Center Release 2.3.7.5.
   - Configuring the SNMP destination now supports starting from dnacentersdk version 2.9.1 onwards. This enhancement is in

--- a/plugins/modules/events_and_notifications_workflow_manager.py
+++ b/plugins/modules/events_and_notifications_workflow_manager.py
@@ -477,6 +477,9 @@ requirements:
 - python >= 3.5
 
 notes:
+  - To ensure the module operates correctly for scaled sets, which involve creating or updating multiple destinations and handling
+    event subscription notifications, please provide valid input in the playbook. If any failure is encountered, the module will
+    halt execution without proceeding to further operations.
   - Configuring the webhook destination with headers now supports starting from dnacentersdk version 2.9.1 onwards. This enhancement is in
     alignment with Catalyst Center Release 2.3.7.5.
   - Configuring the SNMP destination now supports starting from dnacentersdk version 2.9.1 onwards. This enhancement is in


### PR DESCRIPTION
…id input for successful execution.

In this commit - 

-- Update the notes section in the documentation stating that for complete and successful execution in scaled set up make sure to give correct input in the playbook and also if any failure encounter then module will stop the execution immediately without moving to the next destination/notification.