### PR TITLE
Fix for prefix length check

### DIFF
--- a/plugins/modules/discovery_intent.py
+++ b/plugins/modules/discovery_intent.py
@@ -1044,7 +1044,7 @@ class Discovery(DnacBase):
         elif discovery_type == "CIDR":
             if len(ip_address_list) == 1:
                 cidr_notation = ip_address_list[0]
-                if int(cidr_notation.split("/")[1]) not in range (20,31):
+                if int (cidr_notation.split("/")[1]) not in range (20, 31):
                     msg = "Prefix length should be between 20 and 30"
                     self.log(msg, "CRITICAL")
                     self.module.fail_json(msg=msg)

--- a/plugins/modules/discovery_intent.py
+++ b/plugins/modules/discovery_intent.py
@@ -59,7 +59,7 @@ options:
             pass a list with single element like - 10.197.156.22. For CIDR based discovery, we should pass a list with
             single element like - 10.197.156.22/22. For RANGE based discovery, we should pass a list with single element
             and range like - 10.197.156.1-10.197.156.100. For MULTI RANGE based discovery, we should pass a list with multiple
-            elementd like - 10.197.156.1-10.197.156.100 and in next line - 10.197.157.1-10.197.157.100. Maximum of 8 IP address ranges
+            elements like - 10.197.156.1-10.197.156.100 and in next line - 10.197.157.1-10.197.157.100. Maximum of 8 IP address ranges
             are allowed.
         type: list
         elements: str
@@ -1044,6 +1044,10 @@ class Discovery(DnacBase):
         elif discovery_type == "CIDR":
             if len(ip_address_list) == 1:
                 cidr_notation = ip_address_list[0]
+                if int(cidr_notation.split("/")[1]) not in range (20,31):
+                    msg = "Prefix length should be between 20 and 30"
+                    self.log(msg, "CRITICAL")
+                    self.module.fail_json(msg=msg)
                 if len(cidr_notation.split("/")) == 2:
                     ip_address_list = cidr_notation
                 else:

--- a/plugins/modules/discovery_intent.py
+++ b/plugins/modules/discovery_intent.py
@@ -1044,7 +1044,7 @@ class Discovery(DnacBase):
         elif discovery_type == "CIDR":
             if len(ip_address_list) == 1:
                 cidr_notation = ip_address_list[0]
-                if int (cidr_notation.split("/")[1]) not in range (20, 31):
+                if int(cidr_notation.split("/")[1]) not in range(20, 31):
                     msg = "Prefix length should be between 20 and 30"
                     self.log(msg, "CRITICAL")
                     self.module.fail_json(msg=msg)

--- a/plugins/modules/discovery_workflow_manager.py
+++ b/plugins/modules/discovery_workflow_manager.py
@@ -1044,7 +1044,7 @@ class Discovery(DnacBase):
         elif discovery_type == "CIDR":
             if len(ip_address_list) == 1:
                 cidr_notation = ip_address_list[0]
-                if int(cidr_notation.split("/")[1]) not in range (20,31):
+                if int (cidr_notation.split("/")[1]) not in range (20, 31):
                     msg = "Prefix length should be between 20 and 30"
                     self.log(msg, "CRITICAL")
                     self.module.fail_json(msg=msg)

--- a/plugins/modules/discovery_workflow_manager.py
+++ b/plugins/modules/discovery_workflow_manager.py
@@ -59,7 +59,7 @@ options:
             pass a list with single element like - 10.197.156.22. For CIDR based discovery, we should pass a list with
             single element like - 10.197.156.22/22. For RANGE based discovery, we should pass a list with single element
             and range like - 10.197.156.1-10.197.156.100. For MULTI RANGE based discovery, we should pass a list with multiple
-            elementd like - 10.197.156.1-10.197.156.100 and in next line - 10.197.157.1-10.197.157.100. Maximum of 8 IP address ranges
+            elements like - 10.197.156.1-10.197.156.100 and in next line - 10.197.157.1-10.197.157.100. Maximum of 8 IP address ranges
             are allowed.
         type: list
         elements: str
@@ -1044,6 +1044,10 @@ class Discovery(DnacBase):
         elif discovery_type == "CIDR":
             if len(ip_address_list) == 1:
                 cidr_notation = ip_address_list[0]
+                if int(cidr_notation.split("/")[1]) not in range (20,31):
+                    msg = "Prefix length should be between 20 and 30"
+                    self.log(msg, "CRITICAL")
+                    self.module.fail_json(msg=msg)
                 if len(cidr_notation.split("/")) == 2:
                     ip_address_list = cidr_notation
                 else:

--- a/plugins/modules/discovery_workflow_manager.py
+++ b/plugins/modules/discovery_workflow_manager.py
@@ -1044,7 +1044,7 @@ class Discovery(DnacBase):
         elif discovery_type == "CIDR":
             if len(ip_address_list) == 1:
                 cidr_notation = ip_address_list[0]
-                if int (cidr_notation.split("/")[1]) not in range (20, 31):
+                if int(cidr_notation.split("/")[1]) not in range(20, 31):
                     msg = "Prefix length should be between 20 and 30"
                     self.log(msg, "CRITICAL")
                     self.module.fail_json(msg=msg)


### PR DESCRIPTION
1. **Git PR Link:** https://github.com/madhansansel/dnacenter-ansible/pull/317
2. **Problem Description:** Currently, if prefix is not between 20 and 30 the error comes something like this " Invalid prefix length for CIDR discovery or total number of IP''s exceeds 4096 limit". Instead of this, it should be handled like that in UI.
3. **Root Cause**: Haven't done proper error handling.
 4. **Code Changes**: Added  a case to check the prefix length.
 5. **Testing**: Have tested it on outside 20-30 range and inside 20-30 range.
                       
            