### PR TITLE
Correcting docstring documentation of get_dev_type function

### DIFF
--- a/plugins/modules/provision_workflow_manager.py
+++ b/plugins/modules/provision_workflow_manager.py
@@ -306,7 +306,7 @@ class Provision(DnacBase):
           - device_type: A string indicating the type of the
                        device (wired/wireless).
         Example:
-          Post creation of the validated input, we this method gets the
+          Post creation of the validated input, we use this method to get the
           type of the device.
         """
         try:


### PR DESCRIPTION
1. **Git PR Link:** https://github.com/madhansansel/dnacenter-ansible/pull/323
2. **Problem Description:** Grammatically incorrect documentation of get_dev_type function under the doc string.
3. **Root Cause**: Has been overlooked while writing.
4. **Code Changes**: Fixed it with line "Post creation of the validated input, we use this method to get the type of the device".
 5. **Testing**: Testing is not required since its a documentation change.                       
            