### PR TITLE
Fix for unreachable devices, Ap devices and unmanaged devices backup

### DIFF
--- a/plugins/modules/device_configs_backup_workflow_manager.py
+++ b/plugins/modules/device_configs_backup_workflow_manager.py
@@ -279,7 +279,7 @@ class Device_configs_backup(DnacBase):
         Args:
             self: The instance of the class containing the 'config' attribute to be validated.
         Returns:
-            dev_id_list: The list of device ids based on the parameters passed by the user
+            device_ids: The list of device ids based on the parameters passed by the user
         Example:
             Stored paramters like management ip address/ family can be used to fetch the device ids
             list
@@ -301,42 +301,43 @@ class Device_configs_backup(DnacBase):
         self.log("Response collected from the API 'get_device_list' is {0}".format(str(response)), "DEBUG")
         device_list = response.get("response")
         self.log("Length of the device list fetched from the API 'get_device_list' is {0}".format(str(device_list)), "INFO")
-        original_dev_len = len(device_list)
-        if original_dev_len == 0:
-            msg = "Couldn't find any devices in the inventory that match the given parameters."
+        original_valid_device_count = len(device_list)
+        if original_valid_device_count == 0:
+            msg = "No devices found in the inventory matching the given parameters."
             self.log(msg, "CRITICAL")
             self.module.fail_json(msg=msg)
 
-        changed_dev_list = []
+        valid_devices = []
         for dev_info in device_list:
+            ip_address = dev_info.get("managementIpAddress")
             if dev_info.get("collectionStatus") != "Managed":
                 msg = "Device backup of device with IP address {0} \
-                    is not possible due to collection status not being in Managed state".format(dev_info.get("managementIpAddress"))
+                    is not possible due to collection status not being in Managed state".format(ip_address)
                 self.log(msg, "WARNING")
 
             elif dev_info.get("family") != "Unified AP":
                 msg = "Device backup of device with IP address {0} \
-                    is not possible due to device being an Unified AP".format(dev_info.get("managementIpAddress"))
+                    is not possible due to device being an Unified AP".format(ip_address)
                 self.log(msg, "WARNING")
 
             elif dev_info.get("reachabilityStatus") != "Reachable":
                 msg = "Device backup of device with IP address {0} \
-                    is not possible due to device being not reachable".format(dev_info.get("managementIpAddress"))
+                    is not possible due to device being not reachable".format(ip_address)
                 self.log(msg, "WARNING")
             else:
-                changed_dev_list.append(dev_info)
+                valid_devices.append(dev_info)
 
-        if len(changed_dev_list) == 0:
-            msg = "No device IDs got collected either due to devices \
-                being an Unified Ap or device not being in Managed state or device not being reachable"
+        if len(valid_devices) == 0:
+            msg = "No device IDs were collected because the devices are either Unified APs \
+                not in the Managed state, or not reachable."
             self.log(msg, "CRITICAL")
             self.module.fail_json(msg=msg)
 
-        dev_id_list = [id.get("id") for id in changed_dev_list]
-        dev_len = len(dev_id_list)
-        self.log("Device Ids list collected is {0}".format(dev_id_list), "INFO")
-        self.log("Backup of {0} devices out of {1} devices is possible".format(dev_len, original_dev_len), "INFO")
-        return dev_id_list
+        device_ids = [id.get("id") for id in valid_devices]
+        valid_device_count = len(device_ids)
+        self.log("Collected device IDs: {0}".format(device_ids), "INFO")
+        self.log("Backup of {0} devices out of {1} devices is possible".format(valid_device_count, original_valid_device_count), "INFO")
+        return device_ids
 
     def password_generator(self):
         """


### PR DESCRIPTION
# Default Code Review Template

## Description
Added the fix where devices being AP or being in unmanaged state or being in unreachable state, won't be going for the device config backup. For the same, I added a few conditions by looping through the device list retrieved via 'get device list' API.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [x] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [x] Playbooks are modular and reusable
- [x] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [x] Examples are provided and tested.
- [x] Notes and limitations are clearly stated.


