### PR TITLE
rma_workflow_manager bug fixed

### DIFF
--- a/plugins/modules/rma_workflow_manager.py
+++ b/plugins/modules/rma_workflow_manager.py
@@ -445,8 +445,14 @@ class DeviceReplacement(DnacBase):
         config = self.want["config"]
         identifier_keys = [
             ("faulty_device_serial_number", "replacement_device_serial_number"),
+            ("faulty_device_serial_number", "replacement_device_name"),
+            ("faulty_device_serial_number", "replacement_device_ip_address"),
+            ("faulty_device_name", "replacement_device_serial_number"),
             ("faulty_device_name", "replacement_device_name"),
-            ("faulty_device_ip_address", "replacement_device_ip_address")
+            ("faulty_device_name", "replacement_device_ip_address"),
+            ("faulty_device_ip_address","replacement_device_ip_address"),
+            ("faulty_device_ip_address","replacement_device_name"),
+            ("faulty_device_ip_address","replacement_device_serial_number")
         ]
 
         valid_identifier_found = False

--- a/plugins/modules/rma_workflow_manager.py
+++ b/plugins/modules/rma_workflow_manager.py
@@ -450,9 +450,9 @@ class DeviceReplacement(DnacBase):
             ("faulty_device_name", "replacement_device_serial_number"),
             ("faulty_device_name", "replacement_device_name"),
             ("faulty_device_name", "replacement_device_ip_address"),
-            ("faulty_device_ip_address","replacement_device_ip_address"),
-            ("faulty_device_ip_address","replacement_device_name"),
-            ("faulty_device_ip_address","replacement_device_serial_number")
+            ("faulty_device_ip_address", "replacement_device_ip_address"),
+            ("faulty_device_ip_address", "replacement_device_name"),
+            ("faulty_device_ip_address", "replacement_device_serial_number")
         ]
 
         valid_identifier_found = False


### PR DESCRIPTION
## Description
The bug [CSCwm26351] The RMA process can use a mix of various identifiers like device name, IP address, and serial number is addressed in this commit.

## Type of Change
- [ yes ] Bug fix
- [ no ] New feature
- [ no ] Breaking change
- [ no ] Documentation update

## Checklist
- [ yes ] My code follows the style guidelines of this project
- [ yes ] I have performed a self-review of my own code
- [ yes ] I have commented my code, particularly in hard-to-understand areas
- [ no ] I have made corresponding changes to the documentation
- [ yes ] My changes generate no new warnings
- [ yes ] I have added tests that prove my fix is effective or that my feature works
- [ yes ] New and existing unit tests pass locally with my changes
- [ no ] Any dependent changes have been merged and published in downstream modules
- [ yes ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ yes ] Tasks are idempotent (can be run multiple times without changing state)
- [ no ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ yes ] Playbooks are modular and reusable
- [ no ] Handlers are used for actions that need to run on change

## Documentation
- [ yes ] All options and parameters are documented clearly.
- [ yes ] Examples are provided and tested.
- [ yes ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

