### PR TITLE
RMA workflow bugs fixed

### DIFF
--- a/plugins/modules/rma_workflow_manager.py
+++ b/plugins/modules/rma_workflow_manager.py
@@ -1094,11 +1094,7 @@ class DeviceReplacement(DnacBase):
             self.log("Replacement device serial number is missing", "WARNING")
             return self
 
-        import_params = dict(
-            payload={
-                "replacementDeviceSerialNumber": replacement_device_serial
-            }
-        )
+        import_params = {"replacementDeviceSerialNumber": replacement_device_serial}
 
         try:
             response = self.dnac._exec(
@@ -1162,9 +1158,9 @@ def main():
         ccc_device_replacement.get_have().check_return_status()
         ccc_device_replacement.rma_device_replacement_pre_check().check_return_status()
         ccc_device_replacement.mark_faulty_device_for_replacement().check_return_status()
-        # ccc_device_replacement.get_diff_state_apply[state](config).check_return_status()
-        # if config_verify:
-        #     ccc_device_replacement.verify_diff_state_apply[state](config).check_return_status()
+        ccc_device_replacement.get_diff_state_apply[state](config).check_return_status()
+        if config_verify:
+            ccc_device_replacement.verify_diff_state_apply[state](config).check_return_status()
 
     ccc_device_replacement.update_rma_profile_messages().check_return_status()
 

--- a/plugins/modules/rma_workflow_manager.py
+++ b/plugins/modules/rma_workflow_manager.py
@@ -563,7 +563,7 @@ class DeviceReplacement(DnacBase):
 
         self.log("The faulty device and the replacement device belong to the same platform, family and series.", "DEBUG")
 
-        if self.have["faulty_device_reachability_status"] != "Reachable":
+        if self.have["replacement_device_reachability_status"] != "Reachable":
             self.msg = "The replacement device is not reachable. Unable to proceed with the RMA device replacement."
             self.log(self.msg, "ERROR")
             self.status = "failed"

--- a/plugins/modules/rma_workflow_manager.py
+++ b/plugins/modules/rma_workflow_manager.py
@@ -468,41 +468,41 @@ class DeviceReplacement(DnacBase):
                 valid_identifier_found = True
 
                 # Check if faulty device exists
-                faulty_device_param = self.device_exists(faulty_identifier, faulty_key)
+                faulty_device_params = self.device_exists(faulty_identifier, faulty_key)
 
-                if not faulty_device_param:
+                if not faulty_device_params:
                     self.msg = "Faulty device '{0}' not found in Cisco Catalyst Center".format(faulty_identifier)
                     self.log(self.msg, "ERROR")
                     self.status = "failed"
                     return self
 
-                have["faulty_device_id"] = faulty_device_param.get("device_id")
-                have["faulty_device_serial_number"] = faulty_device_param.get("serial_number")
-                have["faulty_device_name"] = faulty_device_param.get("device_name")
-                have["faulty_device_family_name"] = faulty_device_param.get("family_name")
-                have["faulty_device_series_name"] = faulty_device_param.get("series_name")
-                have["faulty_device_reachability_status"] = faulty_device_param.get("reachability_status")
-                have["faulty_device_platform_id"] = faulty_device_param.get("platform_id")
+                have["faulty_device_id"] = faulty_device_params.get("device_id")
+                have["faulty_device_serial_number"] = faulty_device_params.get("serial_number")
+                have["faulty_device_name"] = faulty_device_params.get("device_name")
+                have["faulty_device_family_name"] = faulty_device_params.get("family_name")
+                have["faulty_device_series_name"] = faulty_device_params.get("series_name")
+                have["faulty_device_reachability_status"] = faulty_device_params.get("reachability_status")
+                have["faulty_device_platform_id"] = faulty_device_params.get("platform_id")
                 have[faulty_key] = faulty_identifier
                 have["faulty_device_exists"] = True
                 self.log("Faulty device '{0}' found in Cisco Catalyst Center".format(faulty_identifier), "INFO")
 
                 # Check if replacement device exists
-                replacement_device_param = self.device_exists(replacement_identifier, replacement_key)
+                replacement_device_params = self.device_exists(replacement_identifier, replacement_key)
 
-                if not replacement_device_param:
+                if not replacement_device_params:
                     self.msg = "Replacement device '{0}' not found in Cisco Catalyst Center".format(replacement_identifier)
                     self.log(self.msg, "ERROR")
                     self.status = "failed"
                     return self
 
-                have["replacement_device_id"] = replacement_device_param.get("device_id")
-                have["replacement_device_serial_number"] = replacement_device_param.get("serial_number")
-                have["replacement_device_name"] = replacement_device_param.get("device_name")
-                have["replacement_device_family_name"] = replacement_device_param.get("family_name")
-                have["replacement_device_series_name"] = replacement_device_param.get("series_name")
-                have["replacement_device_reachability_status"] = replacement_device_param.get("reachability_status")
-                have["replacement_device_platform_id"] = replacement_device_param.get("platform_id")
+                have["replacement_device_id"] = replacement_device_params.get("device_id")
+                have["replacement_device_serial_number"] = replacement_device_params.get("serial_number")
+                have["replacement_device_name"] = replacement_device_params.get("device_name")
+                have["replacement_device_family_name"] = replacement_device_params.get("family_name")
+                have["replacement_device_series_name"] = replacement_device_params.get("series_name")
+                have["replacement_device_reachability_status"] = replacement_device_params.get("reachability_status")
+                have["replacement_device_platform_id"] = replacement_device_params.get("platform_id")
                 have[replacement_key] = replacement_identifier
                 have["replacement_device_exists"] = True
                 self.log("Replacement device '{0}' found in Cisco Catalyst Center".format(replacement_identifier), "INFO")

--- a/plugins/modules/rma_workflow_manager.py
+++ b/plugins/modules/rma_workflow_manager.py
@@ -544,22 +544,22 @@ class DeviceReplacement(DnacBase):
         Returns:
             self (object): An instance of a class used for interacting with Cisco Catalyst Center.
         Description:
-            This method verifies that the faulty device and the replacement device belong to the same family and series, 
+            This method verifies that the faulty device and the replacement device belong to the same family and series,
             ensuring they are compatible for replacement. It also checks the network reachability of the replacement device.
-            If both checks pass, the method logs a success message and proceeds. If either check fails, it logs an error, 
+            If both checks pass, the method logs a success message and proceeds. If either check fails, it logs an error,
             updates the status to 'failed', and returns the instance for further handling in the RMA workflow.
         """
 
-        if (self.have["faulty_device_platform_id"] != self.have["replacement_device_platform_id"] and
-            self.have["faulty_device_family_name"] != self.have["replacement_device_family_name"] and
-            self.have["faulty_device_series_name"] != self.have["replacement_device_series_name"]):
-            self.msg = (
-                "The faulty device and the replacement device do not belong to the same platform, family and series."
-                " The faulty device and the replacement device should belong to the same platform"
-            )
-            self.log(self.msg, "ERROR")
-            self.status = "failed"
-            return self
+        if self.have["faulty_device_platform_id"] != self.have["replacement_device_platform_id"]:
+            if self.have["faulty_device_family_name"] != self.have["replacement_device_family_name"]:
+                if self.have["faulty_device_series_name"] != self.have["replacement_device_series_name"]:
+                    self.msg = (
+                        "The faulty device and the replacement device do not belong to the same platform, family and series."
+                        " The faulty device and the replacement device should belong to the same platform"
+                    )
+                    self.log(self.msg, "ERROR")
+                    self.status = "failed"
+                    return self
 
         self.log("The faulty device and the replacement device belong to the same platform, family and series.", "DEBUG")
 
@@ -689,15 +689,15 @@ class DeviceReplacement(DnacBase):
         Parameters:
             - self (object): An instance of the class that interacts with Cisco Catalyst Center and contains device details.
         Returns:
-            bool: 
+            bool:
                 - True if the faulty device is found and is in the "READY-FOR-REPLACEMENT" state.
                 - False if the faulty device is not found or is not in the "READY-FOR-REPLACEMENT" state.
         Description:
-            This method retrieves a list of devices marked for replacement from Cisco Catalyst Center 
-            using the `device_replacement` API. It iterates through the returned devices to find 
+            This method retrieves a list of devices marked for replacement from Cisco Catalyst Center
+            using the `device_replacement` API. It iterates through the returned devices to find
             the specified faulty device based on its serial number, which is stored in the `self.have` attribute.
-            If the faulty device is found and its status is "READY-FOR-REPLACEMENT", the method logs a debug message 
-            indicating that the device is already marked for replacement and returns `True`. 
+            If the faulty device is found and its status is "READY-FOR-REPLACEMENT", the method logs a debug message
+            indicating that the device is already marked for replacement and returns `True`.
             If the device is not in the "READY-FOR-REPLACEMENT" state or is not found, it returns `False`.
         """
         response = self.dnac._exec(
@@ -708,10 +708,10 @@ class DeviceReplacement(DnacBase):
         self.log("Received API response from 'return_replacement_devices_with_details': {0}".format(str(response)), "DEBUG")
 
         for device in devices:
-          if device.get("faultyDeviceSerialNumber") == self.have.get("faulty_device_serial_number"):
-            if device.get("replacementStatus") == "READY-FOR-REPLACEMENT":
-                self.log("The device '{0}' is already in the 'MARKED-FOR-REPLACEMENT' state.".format(device.get("faultyDeviceName")), "DEBUG")
-                return True
+            if device.get("faultyDeviceSerialNumber") == self.have.get("faulty_device_serial_number"):
+                if device.get("replacementStatus") == "READY-FOR-REPLACEMENT":
+                    self.log("The device '{0}' is already in the 'MARKED-FOR-REPLACEMENT' state.".format(device.get("faultyDeviceName")), "DEBUG")
+                    return True
         return False
 
     def mark_faulty_device_for_replacement(self):
@@ -1043,11 +1043,11 @@ class DeviceReplacement(DnacBase):
             self (object): The current instance of the class with updated `result` and `msg` attributes.
         Description:
             This method generates and updates status messages regarding the RMA (Return Material Authorization) device replacement process.
-            It checks if there are any faulty and replacement devices specified for replacement. If both are present, it constructs a 
+            It checks if there are any faulty and replacement devices specified for replacement. If both are present, it constructs a
             success message detailing the completion of the replacement process for the faulty device(s) with the corresponding replacement device(s).
             If no faulty or replacement devices are found, it sets a message indicating that no replacements were performed.
-            The method then updates the `result` attribute with the status of the operation (`changed` set to True if replacements occurred) 
-            and logs the final message using the appropriate log level. The constructed message is also stored in `result["response"]` 
+            The method then updates the `result` attribute with the status of the operation (`changed` set to True if replacements occurred)
+            and logs the final message using the appropriate log level. The constructed message is also stored in `result["response"]`
             for further reference.
         """
         self.result["changed"] = False

--- a/plugins/modules/rma_workflow_manager.py
+++ b/plugins/modules/rma_workflow_manager.py
@@ -468,10 +468,9 @@ class DeviceReplacement(DnacBase):
                 valid_identifier_found = True
 
                 # Check if faulty device exists
-                (faulty_device_id, faulty_device_serial_number, faulty_device_name,
-                 faulty_device_family_name, faulty_device_series_name, faulty_device_reachability_status, faulty_device_platform_id) = self.device_exists(
-                     faulty_identifier, faulty_key)
-                if faulty_device_id is None or faulty_device_serial_number is None:
+                (faulty_device_id, faulty_device_serial_number, faulty_device_name, faulty_device_family_name, faulty_device_series_name,
+                 faulty_device_reachability_status, faulty_device_platform_id, error_message) = self.device_exists(faulty_identifier, faulty_key)
+                if error_message:
                     self.msg = "Faulty device '{0}' not found in Cisco Catalyst Center".format(faulty_identifier)
                     self.log(self.msg, "ERROR")
                     self.status = "failed"
@@ -490,9 +489,9 @@ class DeviceReplacement(DnacBase):
 
                 # Check if replacement device exists
                 (replacement_device_id, replacement_device_serial_number, replacement_device_name,
-                 replacement_device_family_name, replacement_device_series_name,
-                 replacement_device_reachability_status, replacement_device_platform_id) = self.device_exists(replacement_identifier, replacement_key)
-                if replacement_device_id is None or replacement_device_serial_number is None:
+                 replacement_device_family_name, replacement_device_series_name, replacement_device_reachability_status,
+                 replacement_device_platform_id, error_message) = self.device_exists(replacement_identifier, replacement_key)
+                if error_message:
                     self.msg = "Replacement device '{0}' not found in Cisco Catalyst Center".format(replacement_identifier)
                     self.log(self.msg, "ERROR")
                     self.status = "failed"
@@ -597,7 +596,7 @@ class DeviceReplacement(DnacBase):
             params["serialNumber"] = identifier
         else:
             self.log("Invalid identifier type provided", "ERROR")
-            return None, None
+            return None, None, None, None, None, None, None, {"Error"}
 
         try:
             response = self.dnac._exec(
@@ -619,7 +618,7 @@ class DeviceReplacement(DnacBase):
                     reachability_status = device.get('reachabilityStatus')
                     platform_id = device.get('platformId')
                     if device_id and serial_number and device_name and series_name and family_name and reachability_status and platform_id:
-                        return device_id, serial_number, device_name, series_name, family_name, reachability_status, platform_id
+                        return device_id, serial_number, device_name, series_name, family_name, reachability_status, platform_id, {}
                     self.log("Device found but ID or serial number missing", "ERROR")
                 else:
                     self.log("Device not found in Cisco Catalyst Center", "ERROR")
@@ -628,7 +627,7 @@ class DeviceReplacement(DnacBase):
         except Exception as e:
             self.log("Exception occurred while querying device: {0}".format(str(e)), "ERROR")
 
-        return None, None
+        return None, None, None, None, None, None, None, {"Error"}
 
     def validate_device_replacement_params(self):
         """
@@ -1160,7 +1159,7 @@ def main():
         ccc_device_replacement.get_have().check_return_status()
         ccc_device_replacement.rma_device_replacement_pre_check().check_return_status()
         ccc_device_replacement.mark_faulty_device_for_replacement().check_return_status()
-        ccc_device_replacement.get_diff_state_apply[state](config).check_return_status()
+        # ccc_device_replacement.get_diff_state_apply[state](config).check_return_status()
         if config_verify:
             ccc_device_replacement.verify_diff_state_apply[state](config).check_return_status()
 

--- a/plugins/modules/rma_workflow_manager.py
+++ b/plugins/modules/rma_workflow_manager.py
@@ -551,15 +551,13 @@ class DeviceReplacement(DnacBase):
         """
 
         if self.have["faulty_device_platform_id"] != self.have["replacement_device_platform_id"]:
-            if self.have["faulty_device_family_name"] != self.have["replacement_device_family_name"]:
-                if self.have["faulty_device_series_name"] != self.have["replacement_device_series_name"]:
-                    self.msg = (
-                        "The faulty device and the replacement device do not belong to the same platform, family and series."
-                        " The faulty device and the replacement device should belong to the same platform"
-                    )
-                    self.log(self.msg, "ERROR")
-                    self.status = "failed"
-                    return self
+            self.msg = (
+                "The faulty device and the replacement device do not belong to the same platform, family and series."
+                " These attributes must match for a valid replacement."
+            )
+            self.log(self.msg, "ERROR")
+            self.status = "failed"
+            return self
 
         self.log("The faulty device and the replacement device belong to the same platform, family and series.", "DEBUG")
 
@@ -569,7 +567,7 @@ class DeviceReplacement(DnacBase):
             self.status = "failed"
             return self
 
-        self.log("The replacement device is reachable.", "DEBUG")
+        self.log("The replacement device '{0}' is reachable.".format(self.have.get("replacement_device_name")), "DEBUG")
         return self
 
     def device_exists(self, identifier, identifier_type):
@@ -712,6 +710,7 @@ class DeviceReplacement(DnacBase):
                 if device.get("replacementStatus") == "READY-FOR-REPLACEMENT":
                     self.have["device_replacement_id"] = device.get("id")
                     return True
+
         return False
 
     def mark_faulty_device_for_replacement(self):
@@ -765,7 +764,7 @@ class DeviceReplacement(DnacBase):
                 self.msg = "Exception occurred while marking device for replacement: {0}".format(str(e))
                 self.log(self.msg, "ERROR")
 
-        self.log("The device '{0}' is already in the 'MARKED-FOR-REPLACEMENT' state.".format(self.have.get("faulty_device_name")), "DEBUG")
+        self.log("The device '{0}' is already in the 'READY-FOR-REPLACEMENT' state.".format(self.have.get("faulty_device_name")), "DEBUG")
         return self
 
     def get_diff_replaced(self, config):

--- a/plugins/modules/rma_workflow_manager.py
+++ b/plugins/modules/rma_workflow_manager.py
@@ -468,41 +468,41 @@ class DeviceReplacement(DnacBase):
                 valid_identifier_found = True
 
                 # Check if faulty device exists
-                faulty_device_param_dict = self.device_exists(faulty_identifier, faulty_key)
+                faulty_device_param = self.device_exists(faulty_identifier, faulty_key)
 
-                if not faulty_device_param_dict:
+                if not faulty_device_param:
                     self.msg = "Faulty device '{0}' not found in Cisco Catalyst Center".format(faulty_identifier)
                     self.log(self.msg, "ERROR")
                     self.status = "failed"
                     return self
 
-                have["faulty_device_id"] = faulty_device_param_dict.get("device_id")
-                have["faulty_device_serial_number"] = faulty_device_param_dict.get("serial_number")
-                have["faulty_device_name"] = faulty_device_param_dict.get("device_name")
-                have["faulty_device_family_name"] = faulty_device_param_dict.get("family_name")
-                have["faulty_device_series_name"] = faulty_device_param_dict.get("series_name")
-                have["faulty_device_reachability_status"] = faulty_device_param_dict.get("reachability_status")
-                have["faulty_device_platform_id"] = faulty_device_param_dict.get("platform_id")
+                have["faulty_device_id"] = faulty_device_param.get("device_id")
+                have["faulty_device_serial_number"] = faulty_device_param.get("serial_number")
+                have["faulty_device_name"] = faulty_device_param.get("device_name")
+                have["faulty_device_family_name"] = faulty_device_param.get("family_name")
+                have["faulty_device_series_name"] = faulty_device_param.get("series_name")
+                have["faulty_device_reachability_status"] = faulty_device_param.get("reachability_status")
+                have["faulty_device_platform_id"] = faulty_device_param.get("platform_id")
                 have[faulty_key] = faulty_identifier
                 have["faulty_device_exists"] = True
                 self.log("Faulty device '{0}' found in Cisco Catalyst Center".format(faulty_identifier), "INFO")
 
                 # Check if replacement device exists
-                replacement_device_param_dict = self.device_exists(replacement_identifier, replacement_key)
+                replacement_device_param = self.device_exists(replacement_identifier, replacement_key)
 
-                if not replacement_device_param_dict:
+                if not replacement_device_param:
                     self.msg = "Replacement device '{0}' not found in Cisco Catalyst Center".format(replacement_identifier)
                     self.log(self.msg, "ERROR")
                     self.status = "failed"
                     return self
 
-                have["replacement_device_id"] = faulty_device_param_dict.get("device_id")
-                have["replacement_device_serial_number"] = faulty_device_param_dict.get("serial_number")
-                have["replacement_device_name"] = faulty_device_param_dict.get("device_name")
-                have["replacement_device_family_name"] = faulty_device_param_dict.get("family_name")
-                have["replacement_device_series_name"] = faulty_device_param_dict.get("series_name")
-                have["replacement_device_reachability_status"] = faulty_device_param_dict.get("reachability_status")
-                have["replacement_device_platform_id"] = faulty_device_param_dict.get("platform_id")
+                have["replacement_device_id"] = replacement_device_param.get("device_id")
+                have["replacement_device_serial_number"] = replacement_device_param.get("serial_number")
+                have["replacement_device_name"] = replacement_device_param.get("device_name")
+                have["replacement_device_family_name"] = replacement_device_param.get("family_name")
+                have["replacement_device_series_name"] = replacement_device_param.get("series_name")
+                have["replacement_device_reachability_status"] = replacement_device_param.get("reachability_status")
+                have["replacement_device_platform_id"] = replacement_device_param.get("platform_id")
                 have[replacement_key] = replacement_identifier
                 have["replacement_device_exists"] = True
                 self.log("Replacement device '{0}' found in Cisco Catalyst Center".format(replacement_identifier), "INFO")


### PR DESCRIPTION
## Description
The below issues are fixed
1 The bulk RMA return log only returns for one process and is not clear
2 Replace devices with faulty devices that have been manually marked for replacement before not work
3 RMA need pre-check before trigger RMA workflow
4 The function 'return_replacement_devices_with_details' does not work correctly with the filter
5 The function 'def verify_diff_replaced()' does not operate reliably

## Type of Change
- [ yes ] Bug fix
- [ no ] New feature
- [ no ] Breaking change
- [ no ] Documentation update

## Checklist
- [ yes ] My code follows the style guidelines of this project
- [ yes ] I have performed a self-review of my own code
- [ yes ] I have commented my code, particularly in hard-to-understand areas
- [ no ] I have made corresponding changes to the documentation
- [ yes ] My changes generate no new warnings
- [ yes ] I have added tests that prove my fix is effective or that my feature works
- [ yes ] New and existing unit tests pass locally with my changes
- [ no ] Any dependent changes have been merged and published in downstream modules
- [ yes ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ yes ] Tasks are idempotent (can be run multiple times without changing state)
- [ no ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ yes ] Playbooks are modular and reusable
- [ no ] Handlers are used for actions that need to run on change

## Documentation
- [ yes ] All options and parameters are documented clearly.
- [ yes ] Examples are provided and tested.
- [ yes ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

