### PR TITLE
Bulk update bug fixed

### DIFF
--- a/plugins/module_utils/dnac.py
+++ b/plugins/module_utils/dnac.py
@@ -1014,8 +1014,11 @@ def validate_int(item, param_spec, param_name, invalid_params):
             "range_max": 100    # Optional: maximum allowed value
         }
     """
-
-    item = validation.check_type_int(item)
+    try:
+        item = validation.check_type_int(item)
+    except TypeError as e:
+        invalid_params.append("{0}: value: {1} {2}".format(param_name, item, str(e)))
+        return item
     min_value = 1
     if param_spec.get("range_min") is not None:
         min_value = param_spec.get("range_min")
@@ -1024,8 +1027,10 @@ def validate_int(item, param_spec, param_name, invalid_params):
             return item
         else:
             invalid_params.append(
-                "{0}:{1} : The item exceeds the allowed "
-                "range of max {2}".format(param_name, item, param_spec.get("range_max"))
+                "{0}: {1} : The item exceeds the allowed "
+                "range of min: {2} and max: {3}".format(param_name, item,
+                                                      param_spec.get("range_min"),
+                                                      param_spec.get("range_max"))
             )
     return item
 

--- a/plugins/module_utils/dnac.py
+++ b/plugins/module_utils/dnac.py
@@ -992,7 +992,7 @@ def validate_str(item, param_spec, param_name, invalid_params):
     return item
 
 
-def validate_int(item, param_spec, param_name, invalid_params):
+def validate_integer_within_range(item, param_spec, param_name, invalid_params):
     """
     This function checks that the input `item` is a valid integer and conforms to
     the constraints specified in `param_spec`. If the integer is not valid or does
@@ -1019,17 +1019,14 @@ def validate_int(item, param_spec, param_name, invalid_params):
     except TypeError as e:
         invalid_params.append("{0}: value: {1} {2}".format(param_name, item, str(e)))
         return item
-    min_value = 1
-    if param_spec.get("range_min") is not None:
-        min_value = param_spec.get("range_min")
-    if param_spec.get("range_max"):
-        if min_value <= item <= param_spec.get("range_max"):
-            return item
-        else:
-            invalid_params.append(
-                "{0}: {1} : The item exceeds the allowed range of min: {2} and max: {3}".format(
-                    param_name, item, param_spec.get("range_min"), param_spec.get("range_max"))
-            )
+
+    min_value = param_spec.get("range_min", 1)
+    if param_spec.get("range_max") and not (min_value <= item <= param_spec["range_max"]):
+        invalid_params.append(
+            "{0}: {1} : The item exceeds the allowed range of min: {2} and max: {3}".format(
+                param_name, item, param_spec.get("range_min"), param_spec.get("range_max"))
+        )
+
     return item
 
 
@@ -1155,7 +1152,7 @@ def validate_list_of_dicts(param_list, spec, module=None):
             data_type = spec[param].get("type")
             switch = {
                 "str": validate_str,
-                "int": validate_int,
+                "int": validate_integer_within_range,
                 "bool": validate_bool,
                 "list": validate_list,
                 "dict": validate_dict,

--- a/plugins/module_utils/dnac.py
+++ b/plugins/module_utils/dnac.py
@@ -1027,10 +1027,8 @@ def validate_int(item, param_spec, param_name, invalid_params):
             return item
         else:
             invalid_params.append(
-                "{0}: {1} : The item exceeds the allowed "
-                "range of min: {2} and max: {3}".format(param_name, item,
-                                                      param_spec.get("range_min"),
-                                                      param_spec.get("range_max"))
+                "{0}: {1} : The item exceeds the allowed range of min: {2} and max: {3}".format(
+                    param_name, item, param_spec.get("range_min"), param_spec.get("range_max"))
             )
     return item
 

--- a/plugins/modules/accesspoint_workflow_manager.py
+++ b/plugins/modules/accesspoint_workflow_manager.py
@@ -875,6 +875,7 @@ class Accesspoint(DnacBase):
         super().__init__(module)
         self.supported_states = ["merged"]
         self.payload = module.params
+        self.payload["consolidated_result"] = []
         self.keymap = {}
         self.radio_interface = ["6ghz_radio", "xor_radio", "tri_radio"]
         self.allowed_series = {
@@ -919,9 +920,6 @@ class Accesspoint(DnacBase):
             self.log(self.msg, "ERROR")
             return self
 
-        ap_list = self.payload.get("config")
-        ap_list = self.camel_to_snake_case(ap_list)
-        ap_list = self.update_site_type_key(ap_list)
         accesspoint_spec = {
             "mac_address": {"required": False, "type": "str"},
             "management_ip_address": {"required": False, "type": "str"},
@@ -954,31 +952,35 @@ class Accesspoint(DnacBase):
             "ap_selected_fields": {"required": False, "type": "str"},
             "ap_config_selected_fields": {"required": False, "type": "str"}
         }
+        radio_config_spec = {
+            "admin_status": {"required": False, "type": "str"},
+            "dual_radio_mode": {"required": False, "type": "str"},
+            "antenna_name": {"required": False, "type": "str"},
+            "antenna_gain": {"required": False, "type": "int"},
+            "radio_role_assignment": {"required": False, "type": "str"},
+            "cable_loss": {"required": False, "type": "int"},
+            "antenna_cable_name": {"required": False, "type": "str"},
+            "channel_assignment_mode": {"required": False, "type": "str"},
+            "channel_number": {"required": False, "type": "int"},
+            "power_assignment_mode": {"required": False, "type": "str"},
+            "powerlevel": {"required": False, "type": "int"},
+            "channel_width": {"required": False, "type": "str"},
+            "radio_band": {"required": False, "type": "str"}
+        }
+        ap_list = self.payload.get("config")
+        ap_list = self.camel_to_snake_case(ap_list)
+        ap_list = self.update_site_type_key(ap_list)
 
         invalid_list_radio = []
-        for each_radio in ("2.4ghz_radio", "5ghz_radio", "6ghz_radio", "xor_radio", "tri_radio"):
-            radio_config = ap_list[0].get(each_radio)
-            valid_param_radio, invalid_params_radio = (None, None)
-            if radio_config:
-                radio_config_spec = {
-                    "admin_status": {"required": False, "type": "str"},
-                    "dual_radio_mode": {"required": False, "type": "str"},
-                    "antenna_name": {"required": False, "type": "str"},
-                    "antenna_gain": {"required": False, "type": "int"},
-                    "radio_role_assignment": {"required": False, "type": "str"},
-                    "cable_loss": {"required": False, "type": "int"},
-                    "antenna_cable_name": {"required": False, "type": "str"},
-                    "channel_assignment_mode": {"required": False, "type": "str"},
-                    "channel_number": {"required": False, "type": "int"},
-                    "power_assignment_mode": {"required": False, "type": "str"},
-                    "powerlevel": {"required": False, "type": "int"},
-                    "channel_width": {"required": False, "type": "str"},
-                    "radio_band": {"required": False, "type": "str"}
-                }
-                valid_param_radio, invalid_params_radio = \
-                    validate_list_of_dicts([radio_config], radio_config_spec)
-                if len(invalid_params_radio) > 0:
-                    invalid_list_radio.append(each_radio + str(invalid_params_radio))
+        for each_ap in ap_list:
+            for each_radio in ("2.4ghz_radio", "5ghz_radio", "6ghz_radio", "xor_radio", "tri_radio"):
+                radio_config = each_ap.get(each_radio)
+                valid_param_radio, invalid_params_radio = (None, None)
+                if radio_config:
+                    valid_param_radio, invalid_params_radio = \
+                        validate_list_of_dicts([radio_config], radio_config_spec)
+                    if len(invalid_params_radio) > 0:
+                        invalid_list_radio.append(each_radio + str(invalid_params_radio))
 
         valid_param, invalid_params = validate_list_of_dicts(ap_list, accesspoint_spec)
 
@@ -992,7 +994,7 @@ class Accesspoint(DnacBase):
 
         self.validated_config = valid_param
         self.msg = "Successfully validated playbook config params:{0}".format(
-            self.pprint(valid_param[0]))
+            self.pprint(valid_param))
         self.log(self.msg, "INFO")
         self.status = "success"
         return self
@@ -2584,6 +2586,32 @@ class Accesspoint(DnacBase):
 
         return new_config
 
+    def consolidate_output(self):
+        """
+        Bulk access point changes collect each output update in the response.
+
+        Parameters:
+            self (dict): A dictionary used to collect the execution results.
+
+        Returns:
+            dict: A dictionary containing the result of the access point update response.
+        """
+        each_result = {"changed": self.result["changed"],
+                       "response": self.result["response"].get("accesspoints_verify"),
+                       "ap_update_msg": self.result["ap_update_msg"]}
+        self.payload["consolidated_result"].append(each_result)
+        self.log("Each execution Result {0}".format(self.pprint(self.result)))
+        self.result['changed'] = False
+        for each_cosolidated in self.payload["consolidated_result"]:
+            if each_cosolidated['changed']:
+                self.result['changed'] = True
+                break
+        if self.result['changed']:
+            self.status = "success"
+        self.msg = self.pprint(self.payload["consolidated_result"])
+        self.result['response'] = self.payload["consolidated_result"]
+        return self
+
 
 def main():
     """ main entry point for module execution
@@ -2631,8 +2659,9 @@ def main():
         ccc_network.get_diff_state_apply[state](config).check_return_status()
 
         if config_verify:
-            time.sleep(20)
+            time.sleep(10)
             ccc_network.verify_diff_state_apply[state](config).check_return_status()
+            ccc_network.consolidate_output()
 
     module.exit_json(**ccc_network.result)
 

--- a/plugins/modules/accesspoint_workflow_manager.py
+++ b/plugins/modules/accesspoint_workflow_manager.py
@@ -371,7 +371,7 @@ options:
           power_assignment_mode:
             description: |
               Mode of power assignment for the xor radio interface. Accepts "Global" or "Custom".
-              In Custom, it accepts values 1 to 5.
+              In Custom, it accepts values 1 to 8.
             type: str
             required: False
           power_level:
@@ -429,7 +429,7 @@ options:
           power_assignment_mode:
             description: |
                 Mode of power assignment for the tri radio interface. Accepts "Global" or "Custom".
-                In Custom, it accepts values 1 to 5.
+                In Custom, it accepts values 1 to 8.
             type: str
             required: False
           power_level:
@@ -930,7 +930,7 @@ class Accesspoint(DnacBase):
             "ap_name": {"required": False, "type": "str"},
             "admin_status": {"required": False, "type": "str"},
             "led_status": {"required": False, "type": "str"},
-            "led_brightness_level": {"required": False, "type": "int"},
+            "led_brightness_level": {"required": False, "type": "int", "range_min": 1, "range_max": 8},
             "ap_mode": {"required": False, "type": "str"},
             "location": {"required": False, "type": "str"},
             "is_assigned_site_as_location": {"required": False, "type": "str"},
@@ -963,7 +963,7 @@ class Accesspoint(DnacBase):
             "channel_assignment_mode": {"required": False, "type": "str"},
             "channel_number": {"required": False, "type": "int"},
             "power_assignment_mode": {"required": False, "type": "str"},
-            "powerlevel": {"required": False, "type": "int"},
+            "powerlevel": {"required": False, "type": "int", "range_min": 1, "range_max": 8},
             "channel_width": {"required": False, "type": "str"},
             "radio_band": {"required": False, "type": "str"}
         }


### PR DESCRIPTION
## Description
36103 - Access-Point Configuration: Need support for bulk operations
42969 - Providing string value for LED Brightness level parameter results in module error

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [x] Playbooks are modular and reusable
- [x] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [x] Examples are provided and tested.
- [x] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

