### PR TITLE
Fix for the missing conditional check for network_aaa and client_and_endpoint_aaa

### DIFF
--- a/plugins/modules/network_settings_workflow_manager.py
+++ b/plugins/modules/network_settings_workflow_manager.py
@@ -2365,8 +2365,8 @@ class NetworkSettings(DnacBase):
             client_and_endpoint_aaa = want_network_details.get("settings").get("clientAndEndpoint_aaa")
 
             # Check update is required or not
-            if not (network_aaa.get("sharedSecret") or
-                    client_and_endpoint_aaa.get("sharedSecret") or
+            if not ((network_aaa and network_aaa.get("sharedSecret")) or
+                    (client_and_endpoint_aaa and client_and_endpoint_aaa.get("sharedSecret")) or
                     self.requires_update(have_network_details, want_network_details, self.network_obj_params)):
 
                 self.log("Network in site '{0}' doesn't require an update.".format(site_name), "INFO")


### PR DESCRIPTION
## Description
Fix for the missing conditional check for network_aaa and client_and_endpoint_aaa
When checking for the requires update we the update for the following changes
1. If the user provides shared_secret key under the network_aaa
2. If the user provides shared_secret key under the client_and_endpoint_aaa
3. If there is a difference between the user config and CCC config.

For 1 and 2, additional validations were added.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

