### PR TITLE
Access Point Cable loss bug has been updated

### DIFF
--- a/plugins/modules/accesspoint_workflow_manager.py
+++ b/plugins/modules/accesspoint_workflow_manager.py
@@ -64,7 +64,7 @@ options:
           - management_ip_address
         type: str
         required: True
-      management_ip_address:
+      hostname:
         description: |
           To identify the specific access point, at least one of the following parameters is required.
           - mac_address
@@ -72,7 +72,7 @@ options:
           - management_ip_address
         type: str
         required: True
-      hostname:
+      management_ip_address:
         description: |
           To identify the specific access point, at least one of the following parameters is required.
           - mac_address

--- a/plugins/modules/accesspoint_workflow_manager.py
+++ b/plugins/modules/accesspoint_workflow_manager.py
@@ -58,23 +58,26 @@ options:
     suboptions:
       mac_address:
         description: |
-          The MAC address used to identify the device. If the MAC address is known,
-          it must be provided and cannot be modified. At least one of the following parameters is required
-          to identify the specific access point: mac_address, hostname or management_ip_address.
+          To identify the specific access point, at least one of the following parameters is required.
+          - mac_address
+          - hostname
+          - management_ip_address
         type: str
         required: True
       management_ip_address:
         description: |
-          The Management IP Address used to identify the device. If the Management IP Address is known,
-          it must be provided and cannot be modified. At least one of the following parameters is required
-          to identify the specific access point: mac_address, hostname or management_ip_address.
+          To identify the specific access point, at least one of the following parameters is required.
+          - mac_address
+          - hostname
+          - management_ip_address
         type: str
         required: True
       hostname:
         description: |
-          The hostname used to identify the device. If the hostname is known,
-          it must be provided and cannot be modified. At least one of the following parameters is required
-          to identify the specific access point: mac_address, hostname or management_ip_address.
+          To identify the specific access point, at least one of the following parameters is required.
+          - mac_address
+          - hostname
+          - management_ip_address
         type: str
         required: True
       rf_profile:
@@ -226,8 +229,8 @@ options:
             required: False
           cable_loss:
             description: |
-              Cable loss in dB for the 2.4GHz radio interface. Valid values range from 0 to 40.
-              This value should be less than the antenna gain value. For example: 2.
+              Cable loss in dB for the 2.4GHz radio interface. Valid values are from 0 to 40.
+              This value must be less than the antenna gain. For example, 2.
             type: int
             required: False
           antenna_cable_name:
@@ -277,8 +280,8 @@ options:
             required: False
           cable_loss:
             description: |
-              Cable loss in dB for the 5GHz radio interface. Valid values range from 0 to 40.
-              This value should be less than the antenna gain value. For example: 3.
+              Cable loss in dB for the 5GHz radio interface. Valid values are from 0 to 40.
+              This value must be less than the antenna gain. For example, 3.
             type: int
             required: False
           antenna_cable_name:
@@ -326,8 +329,8 @@ options:
             required: False
           cable_loss:
             description: |
-              Cable loss in dB for the 6GHz radio interface. Valid values range from 0 to 40.
-              This value should be less than the antenna gain value. For example: 10.
+              Cable loss in dB for the 6GHz radio interface. Valid values are from 0 to 40.
+              This value must be less than the antenna gain. For example, 10.
             type: int
             required: False
           antenna_cable_name:
@@ -385,8 +388,8 @@ options:
             required: False
           cable_loss:
             description: |
-              Cable loss in dB for the XOR radio interface. Valid values range from 0 to 40.
-              This value should be less than the antenna gain value. For example: 5.
+              Cable loss in dB for the XOR radio interface. Valid values are from 0 to 40.
+              This value must be less than the antenna gain. For example, 5.
             type: int
             required: False
           antenna_cable_name:
@@ -458,8 +461,8 @@ options:
             required: False
           cable_loss:
             description: |
-              Cable loss in dB for the TRI radio interface. Valid values range from 0 to 40.
-              This value should be less than the antenna gain value. For example: 6.
+              Cable loss in dB for the TRI radio interface. Valid values are from 0 to 40.
+              This value must be less than the antenna gain. For example, 6.
             type: int
             required: False
           antenna_cable_name:
@@ -1656,12 +1659,12 @@ class Accesspoint(DnacBase):
                             .format(antenna_gain))
 
         cable_loss = radio_config.get("cable_loss")
-        if cable_loss and cable_loss not in range(0, 41):
-            errormsg.append("cable_loss: Invalid '{0}' in playbook, allowed range of min: 0 and max: 40"
-                            .format(cable_loss))
-        elif cable_loss and antenna_gain and cable_loss >= antenna_gain:
-            errormsg.append("cable_loss: Invalid '{0}' in playbook. Must be lesser than antenna_gain: {1} in playbook".
-                            format(cable_loss, antenna_gain))
+        if cable_loss:
+            if not 0 <= cable_loss <= 40:
+                errormsg.append("cable_loss: Invalid '{0}' in playbook. Must be between 0 and 40.".format(cable_loss))
+            elif antenna_gain and cable_loss >= antenna_gain:
+                errormsg.append("cable_loss: Invalid '{0}' in playbook. Must be less than antenna_gain: {1}."
+                                .format(cable_loss, antenna_gain))
 
         channel_assignment_mode = radio_config.get("channel_assignment_mode")
         if channel_assignment_mode and channel_assignment_mode not in ("Global", "Custom"):
@@ -2306,9 +2309,11 @@ class Accesspoint(DnacBase):
                     unmatch_count = unmatch_count + 1
                     self.log("Antenna name unmatched: {0}".format(want_radio[dto_key]), "INFO")
                 elif dto_key == "cable_loss":
-                    actual_gain = int(want_radio.get("antenna_gain", 0)) - int(want_radio[dto_key])
+                    cable_loss = int(want_radio[dto_key])
+                    antenna_gain = int(want_radio.get("antenna_gain", 0))
+                    actual_gain = antenna_gain - cable_loss
                     if current_radio.get(self.keymap["antenna_gain"]) != actual_gain:
-                        temp_dtos[dto_key] = want_radio[dto_key]
+                        temp_dtos[dto_key] = cable_loss
                     self.log("Cable loss set to: {0}".format(want_radio[dto_key]), "INFO")
                 elif dto_key == "antenna_cable_name":
                     temp_dtos[dto_key] = want_radio[dto_key]

--- a/plugins/modules/accesspoint_workflow_manager.py
+++ b/plugins/modules/accesspoint_workflow_manager.py
@@ -1652,11 +1652,13 @@ class Accesspoint(DnacBase):
 
         antenna_gain = radio_config.get("antenna_gain")
         if antenna_gain and antenna_gain not in range(0, 41):
-            errormsg.append("antenna_gain: Invalid '{0}' in playbook".format(antenna_gain))
+            errormsg.append("antenna_gain: Invalid '{0}' in playbook, allowed range of min: 0 and max: 40"
+                            .format(antenna_gain))
 
         cable_loss = radio_config.get("cable_loss")
         if cable_loss and cable_loss not in range(0, 41):
-            errormsg.append("cable_loss: Invalid '{0}' in playbook".format(cable_loss))
+            errormsg.append("cable_loss: Invalid '{0}' in playbook, allowed range of min: 0 and max: 40"
+                            .format(cable_loss))
         elif cable_loss and antenna_gain and cable_loss >= antenna_gain:
             errormsg.append("cable_loss: Invalid '{0}' in playbook. Must be lesser than antenna_gain: {1} in playbook".
                             format(cable_loss, antenna_gain))

--- a/plugins/modules/accesspoint_workflow_manager.py
+++ b/plugins/modules/accesspoint_workflow_manager.py
@@ -58,6 +58,7 @@ options:
     suboptions:
       mac_address:
         description: |
+          The MAC address used to identify the device. If provided, it cannot be modified.
           To identify the specific access point, at least one of the following parameters is required.
           - mac_address
           - hostname
@@ -66,6 +67,7 @@ options:
         required: True
       hostname:
         description: |
+          The Host Name used to identify the device. If provided, it cannot be modified.
           To identify the specific access point, at least one of the following parameters is required.
           - mac_address
           - hostname
@@ -74,6 +76,7 @@ options:
         required: True
       management_ip_address:
         description: |
+          The Management IP Address used to identify the device. If provided, it cannot be modified.
           To identify the specific access point, at least one of the following parameters is required.
           - mac_address
           - hostname

--- a/tests/unit/modules/dnac/fixtures/accesspoint_workflow_manager.json
+++ b/tests/unit/modules/dnac/fixtures/accesspoint_workflow_manager.json
@@ -50,7 +50,7 @@
                 "channel_number": 44,
                 "powerlevel": 2,
                 "cable_loss": 13,
-                "antenna_gain": 1,
+                "antenna_gain": 19,
                 "radio_band": "5 Ghz",
                 "channel_width": "80 MHz"
             },


### PR DESCRIPTION
## Description
59877 - Access Points: Observing irrelevant error message when configuring cable loss

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [x] Playbooks are modular and reusable
- [x] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [x] Examples are provided and tested.
- [x] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

