### PR TITLE
Add the exception block in the dnac.py file to get the API failure me…

### DIFF
--- a/plugins/module_utils/dnac.py
+++ b/plugins/module_utils/dnac.py
@@ -1990,6 +1990,14 @@ class DNACSDK(object):
                         self.logger.debug(bapi_error)
                         break
 
+        except exceptions.ApiError as e:
+            self.fail_json(
+                msg=(
+                    "An error occured when executing operation."
+                    " The error was: status_code: {error_status},  {error}"
+                ).format(error_status=to_native(e.response.status_code), error=to_native(e.response.text))
+            )
+
         except exceptions.dnacentersdkException as e:
             self.fail_json(
                 msg=(

--- a/plugins/module_utils/dnac.py
+++ b/plugins/module_utils/dnac.py
@@ -1993,9 +1993,11 @@ class DNACSDK(object):
         except exceptions.ApiError as e:
             self.fail_json(
                 msg=(
-                    "An error occured when executing operation."
+                    "An error occured when executing operation for the family '{family}' "
+                    "having the function '{function}'."
                     " The error was: status_code: {error_status},  {error}"
-                ).format(error_status=to_native(e.response.status_code), error=to_native(e.response.text))
+                ).format(error_status=to_native(e.response.status_code), error=to_native(e.response.text),
+                         family=family_name, function=function_name)
             )
 
         except exceptions.dnacentersdkException as e:

--- a/plugins/module_utils/dnac.py
+++ b/plugins/module_utils/dnac.py
@@ -2003,9 +2003,10 @@ class DNACSDK(object):
         except exceptions.dnacentersdkException as e:
             self.fail_json(
                 msg=(
-                    "An error occured when executing operation."
+                    "An error occured when executing operation for the family '{family}' "
+                    "having the function '{function}'."
                     " The error was: {error}"
-                ).format(error=to_native(e))
+                ).format(error=to_native(e), family=family_name, function=function_name)
             )
         return response
 


### PR DESCRIPTION
…ssage instead of generic Exception message.

## Description

-- Fix the issue of getting generic exception message instead of exact failure Reason in case of API failure in the console as part of API response.

## Type of Change
- [ yes ] Bug fix
- [ no ] New feature
- [ no ] Breaking change
- [ no ] Documentation update

## Checklist
- [ yes] My code follows the style guidelines of this project
- [ yes ] I have performed a self-review of my own code
- [ yes ] I have commented my code, particularly in hard-to-understand areas
- [ yes ] I have made corresponding changes to the documentation
- [ yes ] My changes generate no new warnings
- [ no ] I have added tests that prove my fix is effective or that my feature works
- [ no ] New and existing unit tests pass locally with my changes
- [ no ] Any dependent changes have been merged and published in downstream modules
- [ yes ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ yes ] Tasks are idempotent (can be run multiple times without changing state)
- [ no ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ yes ] Playbooks are modular and reusable
- [ no ] Handlers are used for actions that need to run on change

## Documentation
- [ yes ] All options and parameters are documented clearly.
- [ yes ] Examples are provided and tested.
- [ yes ] Notes and limitations are clearly stated.

