### PR TITLE
rma workflow manager bug fixed

### DIFF
--- a/plugins/modules/rma_workflow_manager.py
+++ b/plugins/modules/rma_workflow_manager.py
@@ -1086,20 +1086,21 @@ class DeviceReplacement(DnacBase):
         while timeout_interval > 0:
             task_details = self.get_task_details(task_id)
 
-            if 'response' in task_details and 'progress' in task_details['response']:
-                task_details['response']['progress'] = task_details['response']['progress'].lower()
-
-            if task_details.get("isError"):
-                error_message = task_details.get("failureReason", "{0}: Task failed.".format(error_prefix))
+            if task_details.get('response', {}).get("isError"):
+                error_message = task_details['response'].get("failureReason", "{0}: Task failed.".format(error_prefix))
                 self.log(error_message, "ERROR")
                 return {"status": "failed", "msg": error_message}
 
-            if 'successful' in task_details.get("progress", ""):
-                self.log(success_message, "INFO")
-                return {"status": "success", "msg": task_details.get("progress")}
+            if 'response' in task_details and 'progress' in task_details['response']:
+                progress = task_details['response']['progress'].lower()
+
+                if 'successful' in progress:
+                    self.log(success_message, "INFO")
+                    return {"status": "success", "msg": progress}
 
             time.sleep(ccc_poll_interval)
             timeout_interval -= ccc_poll_interval
+
 
     def update_rma_profile_messages(self):
         """

--- a/plugins/modules/rma_workflow_manager.py
+++ b/plugins/modules/rma_workflow_manager.py
@@ -1086,6 +1086,9 @@ class DeviceReplacement(DnacBase):
         while timeout_interval > 0:
             task_details = self.get_task_details(task_id)
 
+            if 'response' in task_details and 'progress' in task_details['response']:
+                task_details['response']['progress'] = task_details['response']['progress'].lower()
+
             if task_details.get("isError"):
                 error_message = task_details.get("failureReason", "{0}: Task failed.".format(error_prefix))
                 self.log(error_message, "ERROR")

--- a/plugins/modules/rma_workflow_manager.py
+++ b/plugins/modules/rma_workflow_manager.py
@@ -1101,7 +1101,6 @@ class DeviceReplacement(DnacBase):
             time.sleep(ccc_poll_interval)
             timeout_interval -= ccc_poll_interval
 
-
     def update_rma_profile_messages(self):
         """
         Updates and logs messages based on the status of RMA device replacements.


### PR DESCRIPTION
## Description
Bug fixed - NoneType' object is not subscriptable in Catalyst Center version 2.3.5.6

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [x] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [x] Examples are provided and tested.
- [x] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

