### PR TITLE
Rename the fabric modules to sda_fabric for devices, sites and transits

### DIFF
--- a/playbooks/sda_fabric_devices_workflow_manager.yml
+++ b/playbooks/sda_fabric_devices_workflow_manager.yml
@@ -5,7 +5,7 @@
   connection: local
   tasks:
     - name: Add the SDA fabric device as BORDER and CONTROL node and do L2 and L3 handoff.
-      cisco.dnac.fabric_devices_workflow_manager:
+      cisco.dnac.sda_fabric_devices_workflow_manager:
         dnac_host: "{{ dnac_host }}"
         dnac_port: "{{ dnac_port }}"
         dnac_username: "{{ dnac_username }}"
@@ -54,7 +54,7 @@
                     external_vlan_id: 444
 
     - name: Delete the SDA fabric device and remove L2 and L3 handoff configurations
-      cisco.dnac.fabric_devices_workflow_manager:
+      cisco.dnac.sda_fabric_devices_workflow_manager:
         dnac_host: "{{ dnac_host }}"
         dnac_port: "{{ dnac_port }}"
         dnac_username: "{{ dnac_username }}"

--- a/playbooks/sda_fabric_sites_zones_workflow_manager.yml
+++ b/playbooks/sda_fabric_sites_zones_workflow_manager.yml
@@ -8,7 +8,7 @@
     - "credentials.yml"
   tasks:
     - name: Configure the fabric sites/zones and authentication profile template in Cisco Catalyst Center.
-      cisco.dnac.fabric_sites_zones_workflow_manager:
+      cisco.dnac.sda_fabric_sites_zones_workflow_manager:
         dnac_host: "{{dnac_host}}"
         dnac_username: "{{dnac_username}}"
         dnac_password: "{{dnac_password}}"

--- a/playbooks/sda_fabric_transits_workflow_manager.yml
+++ b/playbooks/sda_fabric_transits_workflow_manager.yml
@@ -5,7 +5,7 @@
   connection: local
   tasks:
     - name: Create the SDA fabric transits with transit_type as IP_BASED_TRANSIT
-      cisco.dnac.fabric_transits_workflow_manager:
+      cisco.dnac.sda_fabric_transits_workflow_manager:
         dnac_host: "{{ dnac_host }}"
         dnac_port: "{{ dnac_port }}"
         dnac_username: "{{ dnac_username }}"
@@ -28,7 +28,7 @@
               autonomous_system_number: 1234 # between 1 and 4294967295
 
     - name: Create the SDA fabric transits with transit_type as SDA_LISP_BGP_TRANSIT
-      cisco.dnac.fabric_transits_workflow_manager:
+      cisco.dnac.sda_fabric_transits_workflow_manager:
         dnac_host: "{{ dnac_host }}"
         dnac_port: "{{ dnac_port }}"
         dnac_username: "{{ dnac_username }}"
@@ -52,7 +52,7 @@
                 - 10.0.0.2
 
     - name: Create the SDA fabric transits with transit_type as SDA_LISP_PUB_SUB_TRANSIT
-      cisco.dnac.fabric_transits_workflow_manager:
+      cisco.dnac.sda_fabric_transits_workflow_manager:
         dnac_host: "{{ dnac_host }}"
         dnac_port: "{{ dnac_port }}"
         dnac_username: "{{ dnac_username }}"
@@ -79,7 +79,7 @@
                 - 11.0.0.4
 
     - name: Update the SDA fabric transits with transit_type as SDA_LISP_BGP_TRANSIT
-      cisco.dnac.fabric_transits_workflow_manager:
+      cisco.dnac.sda_fabric_transits_workflow_manager:
         dnac_host: "{{ dnac_host }}"
         dnac_port: "{{ dnac_port }}"
         dnac_username: "{{ dnac_username }}"
@@ -103,7 +103,7 @@
                 - 10.0.0.4
 
     - name: Update the SDA fabric transits with transit_type as SDA_LISP_PUB_SUB_TRANSIT
-      cisco.dnac.fabric_transits_workflow_manager:
+      cisco.dnac.sda_fabric_transits_workflow_manager:
         dnac_host: "{{ dnac_host }}"
         dnac_port: "{{ dnac_port }}"
         dnac_username: "{{ dnac_username }}"
@@ -130,7 +130,7 @@
                 - 11.0.0.8
 
     - name: Delete the SDA fabric transits
-      cisco.dnac.fabric_transits_workflow_manager:
+      cisco.dnac.sda_fabric_transits_workflow_manager:
         dnac_host: "{{ dnac_host }}"
         dnac_port: "{{ dnac_port }}"
         dnac_username: "{{ dnac_username }}"

--- a/plugins/modules/sda_fabric_devices_workflow_manager.py
+++ b/plugins/modules/sda_fabric_devices_workflow_manager.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 __author__ = ['Muthu Rakesh, Madhan Sankaranarayanan']
 DOCUMENTATION = r"""
 ---
-module: fabric_devices_workflow_manager
+module: sda_fabric_devices_workflow_manager
 short_description: Manage SDA fabric devices in Cisco Catalyst Center.
 description:
 - Perform operations on SDA fabric devices, including adding, updating, and deleting fabric devices.
@@ -359,7 +359,7 @@ notes:
 
 EXAMPLES = r"""
 - name: Create SDA fabric device with device role as CONTROL_PLANE_NODE
-  cisco.dnac.fabric_devices_workflow_manager:
+  cisco.dnac.sda_fabric_devices_workflow_manager:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
     dnac_password: "{{dnac_password}}"
@@ -379,7 +379,7 @@ EXAMPLES = r"""
           device_roles: [CONTROL_PLANE_NODE]
 
 - name: Update the SDA fabric device with the device roles with BORDER_NODE and add L2 Handoff
-  cisco.dnac.fabric_devices_workflow_manager:
+  cisco.dnac.sda_fabric_devices_workflow_manager:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
     dnac_password: "{{dnac_password}}"
@@ -411,7 +411,7 @@ EXAMPLES = r"""
 
 
 - name: Add the L3 Handoff with SDA Transit to the SDA fabric device
-  cisco.dnac.fabric_devices_workflow_manager:
+  cisco.dnac.sda_fabric_devices_workflow_manager:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
     dnac_password: "{{dnac_password}}"
@@ -438,7 +438,7 @@ EXAMPLES = r"""
               is_multicast_over_transit_enabled: false
 
 - name: Add L3 Handoff with IP Transit to the SDA fabric device with external_connectivity_ip_pool_name
-  cisco.dnac.fabric_devices_workflow_manager:
+  cisco.dnac.sda_fabric_devices_workflow_manager:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
     dnac_password: "{{dnac_password}}"
@@ -466,7 +466,7 @@ EXAMPLES = r"""
               tcp_mss_adjustment: 2
 
 - name: Add L3 Handoff with IP Transit to the SDA fabric device with local and remote network
-  cisco.dnac.fabric_devices_workflow_manager:
+  cisco.dnac.sda_fabric_devices_workflow_manager:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
     dnac_password: "{{dnac_password}}"
@@ -497,7 +497,7 @@ EXAMPLES = r"""
               remote_ipv6_address: 2009:db8::2/64
 
 - name: Update the border settings of the SDA Devices
-  cisco.dnac.fabric_devices_workflow_manager:
+  cisco.dnac.sda_fabric_devices_workflow_manager:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
     dnac_password: "{{dnac_password}}"
@@ -524,7 +524,7 @@ EXAMPLES = r"""
               prepend_autonomous_system_count: 3
 
 - name: Update the L3 Handoffs with SDA Transit and IP Transit.
-  cisco.dnac.fabric_devices_workflow_manager:
+  cisco.dnac.sda_fabric_devices_workflow_manager:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
     dnac_password: "{{dnac_password}}"
@@ -562,7 +562,7 @@ EXAMPLES = r"""
               remote_ipv6_address: 2009:db8::2/64
 
 - name: Delete the L2 Handoff
-  cisco.dnac.fabric_devices_workflow_manager:
+  cisco.dnac.sda_fabric_devices_workflow_manager:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
     dnac_password: "{{dnac_password}}"
@@ -585,7 +585,7 @@ EXAMPLES = r"""
               internal_vlan_id: 550
 
 - name: Delete the L3 Handoff with SDA Transit
-  cisco.dnac.fabric_devices_workflow_manager:
+  cisco.dnac.sda_fabric_devices_workflow_manager:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
     dnac_password: "{{dnac_password}}"
@@ -607,7 +607,7 @@ EXAMPLES = r"""
               transit_network_name: SDA_PUB_SUB_TRANSIT
 
 - name: Delete the L3 Handoff with IP Transit
-  cisco.dnac.fabric_devices_workflow_manager:
+  cisco.dnac.sda_fabric_devices_workflow_manager:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
     dnac_password: "{{dnac_password}}"
@@ -631,7 +631,7 @@ EXAMPLES = r"""
               virtual_network_name: L3VN1
 
 - name: Delete the device along with L2 Handoff and L3 Handoff
-  cisco.dnac.fabric_devices_workflow_manager:
+  cisco.dnac.sda_fabric_devices_workflow_manager:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
     dnac_password: "{{dnac_password}}"
@@ -845,7 +845,7 @@ from ansible_collections.cisco.dnac.plugins.module_utils.dnac import (
 
 
 class FabricDevices(DnacBase):
-    """Class containing member attributes for fabric_devices_workflow_manager module"""
+    """Class containing member attributes for sda_fabric_devices_workflow_manager module"""
 
     def __init__(self, module):
         super().__init__(module)

--- a/plugins/modules/sda_fabric_sites_zones_workflow_manager.py
+++ b/plugins/modules/sda_fabric_sites_zones_workflow_manager.py
@@ -11,7 +11,7 @@ __author__ = ("Abhishek Maheshwari, Madhan Sankaranarayanan")
 
 DOCUMENTATION = r"""
 ---
-module: fabric_sites_zones_workflow_manager
+module: sda_fabric_sites_zones_workflow_manager
 short_description: Manage fabric site(s)/zone(s) and update the authentication profile template in Cisco Catalyst Center.
 description:
 - Creating fabric site(s) for the SDA operation in Cisco Catalyst Center.
@@ -133,7 +133,7 @@ notes:
 
 EXAMPLES = r"""
 - name: Create a fabric site for SDA with the specified name.
-  cisco.dnac.fabric_sites_zones_workflow_manager:
+  cisco.dnac.sda_fabric_sites_zones_workflow_manager:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
     dnac_password: "{{dnac_password}}"
@@ -151,7 +151,7 @@ EXAMPLES = r"""
           is_pub_sub_enabled: False
 
 - name: Update a fabric site for SDA with the specified name.
-  cisco.dnac.fabric_sites_zones_workflow_manager:
+  cisco.dnac.sda_fabric_sites_zones_workflow_manager:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
     dnac_password: "{{dnac_password}}"
@@ -168,7 +168,7 @@ EXAMPLES = r"""
           authentication_profile: "Open Authentication"
 
 - name: Update a fabric zone for SDA with the specified name.
-  cisco.dnac.fabric_sites_zones_workflow_manager:
+  cisco.dnac.sda_fabric_sites_zones_workflow_manager:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
     dnac_password: "{{dnac_password}}"
@@ -186,7 +186,7 @@ EXAMPLES = r"""
           authentication_profile: "Closed Authentication"
 
 - name: Update fabric zone for sda with given name.
-  cisco.dnac.fabric_sites_zones_workflow_manager:
+  cisco.dnac.sda_fabric_sites_zones_workflow_manager:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
     dnac_password: "{{dnac_password}}"
@@ -204,7 +204,7 @@ EXAMPLES = r"""
           authentication_profile: "Open Authentication"
 
 - name: Update/customise authentication profile template for fabric site/zone.
-  cisco.dnac.fabric_sites_zones_workflow_manager:
+  cisco.dnac.sda_fabric_sites_zones_workflow_manager:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
     dnac_password: "{{dnac_password}}"
@@ -228,7 +228,7 @@ EXAMPLES = r"""
             number_of_hosts: "Single"
 
 - name: Deleting/removing fabric site from sda from Cisco Catalyst Center
-  cisco.dnac.fabric_sites_zones_workflow_manager:
+  cisco.dnac.sda_fabric_sites_zones_workflow_manager:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
     dnac_password: "{{dnac_password}}"
@@ -244,7 +244,7 @@ EXAMPLES = r"""
           site_name: "Global/Test_SDA/Bld1"
 
 - name: Deleting/removing fabric zone from sda from Cisco Catalyst Center
-  cisco.dnac.fabric_sites_zones_workflow_manager:
+  cisco.dnac.sda_fabric_sites_zones_workflow_manager:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
     dnac_password: "{{dnac_password}}"
@@ -622,16 +622,14 @@ class FabricSitesZones(DnacBase):
             fabric_site_payload = []
             site_name = site.get("site_name")
             auth_profile = site.get("authentication_profile")
+
             if not auth_profile:
-                self.status = "failed"
                 self.msg = (
                     "Required parameter 'authentication_profile'is missing needed for creation of fabric sites in Cisco Catalyst Center. "
                     "Please provide one of the following authentication_profile ['Closed Authentication', 'Low Impact'"
                     ", 'No Authentication', 'Open Authentication'] in the playbook."
                 )
-                self.log(self.msg, "ERROR")
-                self.result["response"] = self.msg
-                return self
+                self.set_operation_result("failed", False, self.msg, "ERROR").check_return_status()
 
             site_payload = {
                 "siteId": self.get_site_id(site_name),
@@ -639,50 +637,59 @@ class FabricSitesZones(DnacBase):
                 "isPubSubEnabled": site.get("is_pub_sub_enabled", False)
             }
             fabric_site_payload.append(site_payload)
-            self.log("Requested payload for creating fabric site '{0}' is:  {1}".format(site_name, str(site_payload)), "INFO")
+            task_name = "add_fabric_site"
+            payload = {"payload": fabric_site_payload}
+            task_id = self.get_taskid_post_api_call("sda", task_name, payload)
 
-            response = self.dnac._exec(
-                family="sda",
-                function='add_fabric_site',
-                op_modifies=True,
-                params={'payload': fabric_site_payload}
-            )
-            self.log("Received API response from 'add_fabric_site' for the site {0}: {1}".format(site_name, str(response)), "DEBUG")
-            response = response.get("response")
-
-            if not response:
-                self.status = "failed"
-                self.msg = "No response received from 'add_fabric_site' API, task ID not retrieved."
-                self.log(self.msg, "ERROR")
+            if not task_id:
+                self.msg = "Unable to retrive the task_id for the task '{0}'.".format(task_name)
+                self.set_operation_result("failed", False, self.msg, "ERROR")
                 return self
 
-            task_id = response.get("taskId")
+            success_msg = "Fabric site '{0}' created successfully in the Cisco Catalyst Center".format(site_name)
+            self.get_task_status_from_tasks_by_id(task_id, task_name, success_msg)
+            self.create_site.append(site_name)
+            # response = self.dnac._exec(
+            #     family="sda",
+            #     function='add_fabric_site',
+            #     op_modifies=True,
+            #     params={'payload': fabric_site_payload}
+            # )
+            # self.log("Received API response from 'add_fabric_site' for the site {0}: {1}".format(site_name, str(response)), "DEBUG")
+            # response = response.get("response")
 
-            while True:
-                task_details = self.get_task_details(task_id)
+            # if not response:
+            #     self.status = "failed"
+            #     self.msg = "No response received from 'add_fabric_site' API, task ID not retrieved."
+            #     self.log(self.msg, "ERROR")
+            #     return self
 
-                if task_details.get("isError"):
-                    self.status = "failed"
-                    failure_reason = task_details.get("failureReason")
-                    if failure_reason:
-                        self.msg = "Failed to create the Fabric site '{0}' due to {1}.".format(site_name, failure_reason)
-                    else:
-                        self.msg = "Failed to create the Fabric site '{0}'.".format(site_name)
-                    self.log(self.msg, "ERROR")
-                    self.result['response'] = self.msg
-                    break
-                elif task_details.get("endTime") and "workflow_id" in task_details.get("data"):
-                    self.status = "success"
-                    self.create_site.append(site_name)
-                    self.log("Fabric site '{0}' created successfully in the Cisco Catalyst Center".format(site_name), "INFO")
-                    break
+            # task_id = response.get("taskId")
 
-                time.sleep(1)
+            # while True:
+            #     task_details = self.get_task_details(task_id)
+
+            #     if task_details.get("isError"):
+            #         self.status = "failed"
+            #         failure_reason = task_details.get("failureReason")
+            #         if failure_reason:
+            #             self.msg = "Failed to create the Fabric site '{0}' due to {1}.".format(site_name, failure_reason)
+            #         else:
+            #             self.msg = "Failed to create the Fabric site '{0}'.".format(site_name)
+            #         self.log(self.msg, "ERROR")
+            #         self.result['response'] = self.msg
+            #         break
+            #     elif task_details.get("endTime") and "workflow_id" in task_details.get("data"):
+            #         self.status = "success"
+            #         self.create_site.append(site_name)
+            #         self.log("Fabric site '{0}' created successfully in the Cisco Catalyst Center".format(site_name), "INFO")
+            #         break
+
+            #     time.sleep(1)
 
         except Exception as e:
-            self.status = "failed"
             self.msg = "An exception occured while creating the fabric site '{0}' in Cisco Catalyst Center: {1}".format(site_name, str(e))
-            self.log(self.msg, "ERROR")
+            self.set_operation_result("failed", False, self.msg, "ERROR")
 
         return self
 
@@ -754,43 +761,54 @@ class FabricSitesZones(DnacBase):
                 "isPubSubEnabled": pub_sub_enable
             }
             update_site_params.append(site_payload)
-            self.log("Requested payload for updating fabric site '{0}' is:  {1}".format(site_name, str(site_payload)), "INFO")
+            payload = {"payload": update_site_params}
+            task_name = "update_fabric_site"
+            task_id = self.get_taskid_post_api_call("sda", task_name, payload)
 
-            response = self.dnac._exec(
-                family="sda",
-                function='update_fabric_site',
-                op_modifies=True,
-                params={'payload': update_site_params}
-            )
-            self.log("Received API response from 'update_fabric_site' for the site {0}: {1}".format(site_name, str(response)), "DEBUG")
-            response = response.get("response")
-
-            if not response:
-                self.status = "failed"
-                self.msg = "Unable to fetch the task Id for the updation of fabric site as the 'update_fabric_site' response is empty."
-                self.log(self.msg, "ERROR")
+            if not task_id:
+                self.msg = "Unable to retrive the task_id for the task '{0}'.".format(task_name)
+                self.set_operation_result("failed", False, self.msg, "ERROR")
                 return self
 
-            task_id = response.get("taskId")
+            success_msg = "Fabric site '{0}' updated successfully in the Cisco Catalyst Center".format(site_name)
+            self.get_task_status_from_tasks_by_id(task_id, task_name, success_msg)
+            self.update_site.append(site_name)
 
-            while True:
-                task_details = self.get_task_details(task_id)
-                if task_details.get("isError"):
-                    self.status = "failed"
-                    failure_reason = task_details.get("failureReason")
-                    if failure_reason:
-                        self.msg = "Unable to update the Fabric site '{0}' because of {1}.".format(site_name, failure_reason)
-                    else:
-                        self.msg = "Unable to update the Fabric site '{0}'.".format(site_name)
-                    self.log(self.msg, "ERROR")
-                    self.result['response'] = self.msg
-                    break
-                elif task_details.get("endTime") and "workflow_id" in task_details.get("data"):
-                    self.status = "success"
-                    self.update_site.append(site_name)
-                    self.log("Fabric site '{0}' updated successfully in the Cisco Catalyst Center".format(site_name), "INFO")
-                    break
-                time.sleep(1)
+            # response = self.dnac._exec(
+            #     family="sda",
+            #     function='update_fabric_site',
+            #     op_modifies=True,
+            #     params={'payload': update_site_params}
+            # )
+            # self.log("Received API response from 'update_fabric_site' for the site {0}: {1}".format(site_name, str(response)), "DEBUG")
+            # response = response.get("response")
+
+            # if not response:
+            #     self.status = "failed"
+            #     self.msg = "Unable to fetch the task Id for the updation of fabric site as the 'update_fabric_site' response is empty."
+            #     self.log(self.msg, "ERROR")
+            #     return self
+
+            # task_id = response.get("taskId")
+
+            # while True:
+            #     task_details = self.get_task_details(task_id)
+            #     if task_details.get("isError"):
+            #         self.status = "failed"
+            #         failure_reason = task_details.get("failureReason")
+            #         if failure_reason:
+            #             self.msg = "Unable to update the Fabric site '{0}' because of {1}.".format(site_name, failure_reason)
+            #         else:
+            #             self.msg = "Unable to update the Fabric site '{0}'.".format(site_name)
+            #         self.log(self.msg, "ERROR")
+            #         self.result['response'] = self.msg
+            #         break
+            #     elif task_details.get("endTime") and "workflow_id" in task_details.get("data"):
+            #         self.status = "success"
+            #         self.update_site.append(site_name)
+            #         self.log("Fabric site '{0}' updated successfully in the Cisco Catalyst Center".format(site_name), "INFO")
+            #         break
+            #     time.sleep(1)
         except Exception as e:
             self.status = "failed"
             self.msg = "An exception occured while updating the fabric site '{0}' in Cisco Catalyst Center: {1}".format(site_name, str(e))
@@ -820,54 +838,64 @@ class FabricSitesZones(DnacBase):
         try:
             fabric_zone_payload = []
             site_name = zone.get("site_name")
-
             zone_payload = {
                 "siteId": self.get_site_id(site_name),
                 "authenticationProfileName": zone.get("authentication_profile"),
             }
             fabric_zone_payload.append(zone_payload)
             self.log("Requested payload for creating fabric zone '{0}' is:  {1}".format(site_name, zone_payload), "INFO")
+            task_name = "add_fabric_site"
+            payload = {"payload": fabric_zone_payload}
+            task_id = self.get_taskid_post_api_call("sda", task_name, payload)
 
-            response = self.dnac._exec(
-                family="sda",
-                function='add_fabric_zone',
-                op_modifies=True,
-                params={'payload': fabric_zone_payload}
-            )
-            self.log("Received API response from 'add_fabric_zone' for the site {0}: {1}".format(site_name, str(response)), "DEBUG")
-            response = response.get("response")
-
-            if not response:
-                self.status = "failed"
-                self.msg = "Unable to fetch the task Id for the creation of fabric zone as the 'add_fabric_zone' response is empty."
-                self.log(self.msg, "ERROR")
+            if not task_id:
+                self.msg = "Unable to retrive the task_id for the task '{0}'.".format(task_name)
+                self.set_operation_result("failed", False, self.msg, "ERROR")
                 return self
 
-            task_id = response.get("taskId")
+            success_msg = "Fabric zone '{0}' created successfully in the Cisco Catalyst Center.".format(site_name)
+            self.get_task_status_from_tasks_by_id(task_id, task_name, success_msg)
+            self.create_zone.append(site_name)
 
-            while True:
-                task_details = self.get_task_details(task_id)
+            # response = self.dnac._exec(
+            #     family="sda",
+            #     function='add_fabric_zone',
+            #     op_modifies=True,
+            #     params={'payload': fabric_zone_payload}
+            # )
+            # self.log("Received API response from 'add_fabric_zone' for the site {0}: {1}".format(site_name, str(response)), "DEBUG")
+            # response = response.get("response")
 
-                if task_details.get("isError"):
-                    self.status = "failed"
-                    failure_reason = task_details.get("failureReason")
-                    if failure_reason:
-                        self.msg = "Unable to create the Fabric zone '{0}' because of {1}.".format(site_name, failure_reason)
-                    else:
-                        self.msg = "Unable to create the Fabric zone '{0}'.".format(site_name)
-                    self.log(self.msg, "ERROR")
-                    self.result['response'] = self.msg
-                    break
-                elif task_details.get("endTime") and "workflow_id" in task_details.get("data"):
-                    self.status = "success"
-                    self.create_zone.append(site_name)
-                    self.log("Fabric zone '{0}' created successfully in the Cisco Catalyst Center.".format(site_name), "INFO")
-                    break
-                time.sleep(1)
+            # if not response:
+            #     self.status = "failed"
+            #     self.msg = "Unable to fetch the task Id for the creation of fabric zone as the 'add_fabric_zone' response is empty."
+            #     self.log(self.msg, "ERROR")
+            #     return self
+
+            # task_id = response.get("taskId")
+
+            # while True:
+            #     task_details = self.get_task_details(task_id)
+
+            #     if task_details.get("isError"):
+            #         self.status = "failed"
+            #         failure_reason = task_details.get("failureReason")
+            #         if failure_reason:
+            #             self.msg = "Unable to create the Fabric zone '{0}' because of {1}.".format(site_name, failure_reason)
+            #         else:
+            #             self.msg = "Unable to create the Fabric zone '{0}'.".format(site_name)
+            #         self.log(self.msg, "ERROR")
+            #         self.result['response'] = self.msg
+            #         break
+            #     elif task_details.get("endTime") and "workflow_id" in task_details.get("data"):
+            #         self.status = "success"
+            #         self.create_zone.append(site_name)
+            #         self.log("Fabric zone '{0}' created successfully in the Cisco Catalyst Center.".format(site_name), "INFO")
+            #         break
+            #     time.sleep(1)
         except Exception as e:
-            self.status = "failed"
             self.msg = "An exception occured while creating the fabric zone '{0}' in Cisco Catalyst Center: {1}".format(site_name, str(e))
-            self.log(self.msg, "ERROR")
+            self.set_operation_result("failed", False, self.msg, "ERROR")
 
         return self
 

--- a/plugins/modules/sda_fabric_transits_workflow_manager.py
+++ b/plugins/modules/sda_fabric_transits_workflow_manager.py
@@ -11,7 +11,7 @@ __author__ = ['Muthu Rakesh, Madhan Sankaranarayanan']
 
 DOCUMENTATION = r"""
 ---
-module: fabric_transits_workflow_manager
+module: sda_fabric_transits_workflow_manager
 short_description: Resource module for SDA fabric transits
 description:
 - Manage operations on SDA fabric transits.
@@ -132,7 +132,7 @@ notes:
 
 EXAMPLES = r"""
 - name: Create SDA fabric transit of transit_type IP_BASED_TRANSIT
-  cisco.dnac.fabric_transits_workflow_manager:
+  cisco.dnac.sda_fabric_transits_workflow_manager:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
     dnac_password: "{{dnac_password}}"
@@ -153,7 +153,7 @@ EXAMPLES = r"""
         autonomous_system_number: 1234
 
 - name: Create SDA fabric transit of transit_type SDA_LISP_BGP_TRANSIT
-  cisco.dnac.fabric_transits_workflow_manager:
+  cisco.dnac.sda_fabric_transits_workflow_manager:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
     dnac_password: "{{dnac_password}}"
@@ -175,7 +175,7 @@ EXAMPLES = r"""
         - string
 
 - name: Create SDA fabric transit of transit_type SDA_LISP_PUB_SUB_TRANSIT
-  cisco.dnac.fabric_transits_workflow_manager:
+  cisco.dnac.sda_fabric_transits_workflow_manager:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
     dnac_password: "{{dnac_password}}"
@@ -200,7 +200,7 @@ EXAMPLES = r"""
         - string
 
 - name: Update SDA fabric transit of transit_type SDA_LISP_BGP_TRANSIT
-  cisco.dnac.fabric_transits_workflow_manager:
+  cisco.dnac.sda_fabric_transits_workflow_manager:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
     dnac_password: "{{dnac_password}}"
@@ -222,7 +222,7 @@ EXAMPLES = r"""
         - string
 
 - name: Update the multicast over transit
-  cisco.dnac.fabric_transits_workflow_manager:
+  cisco.dnac.sda_fabric_transits_workflow_manager:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
     dnac_password: "{{dnac_password}}"
@@ -242,7 +242,7 @@ EXAMPLES = r"""
         is_multicast_over_transit_enabled: true
 
 - name: Update the control plane network devices
-  cisco.dnac.fabric_transits_workflow_manager:
+  cisco.dnac.sda_fabric_transits_workflow_manager:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
     dnac_password: "{{dnac_password}}"
@@ -265,7 +265,7 @@ EXAMPLES = r"""
         - string
 
 - name: Delete SDA fabric transit
-  cisco.dnac.fabric_transits_workflow_manager:
+  cisco.dnac.sda_fabric_transits_workflow_manager:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
     dnac_password: "{{dnac_password}}"
@@ -338,7 +338,7 @@ from ansible_collections.cisco.dnac.plugins.module_utils.dnac import (
 
 
 class FabricTransit(DnacBase):
-    """Class containing member attributes for fabric_transits_workflow_manager module"""
+    """Class containing member attributes for sda_fabric_transits_workflow_manager module"""
 
     def __init__(self, module):
         super().__init__(module)


### PR DESCRIPTION
## Description
Rename the following module and their corresponding playbooks - 
renamed:    fabric_devices_workflow_manager.yml -> sda_fabric_devices_workflow_manager.yml
	renamed:    fabric_sites_zones_workflow_manager.yml -> sda_fabric_sites_zones_workflow_manager.yml
	renamed:    fabric_transits_workflow_manager.yml -> sda_fabric_transits_workflow_manager.yml
	renamed:    ../plugins/modules/fabric_devices_workflow_manager.py -> ../plugins/modules/sda_fabric_devices_workflow_manager.py
	renamed:    ../plugins/modules/fabric_sites_zones_workflow_manager.py -> ../plugins/modules/sda_fabric_sites_zones_workflow_manager.py
	renamed:    ../plugins/modules/fabric_transits_workflow_manager.py -> ../plugins/modules/sda_fabric_transits_workflow_manager.py

## Type of Change
- [ yes ] Bug fix
- [ no ] New feature
- [ no ] Breaking change
- [ yes ] Documentation update

## Checklist
- [ yes ] My code follows the style guidelines of this project
- [ yes ] I have performed a self-review of my own code
- [ yes ] I have commented my code, particularly in hard-to-understand areas
- [ yes ] I have made corresponding changes to the documentation
- [ no ] My changes generate no new warnings
- [ no ] I have added tests that prove my fix is effective or that my feature works
- [ no ] New and existing unit tests pass locally with my changes
- [ no ] Any dependent changes have been merged and published in downstream modules
- [ yes ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ yes ] Tasks are idempotent (can be run multiple times without changing state)
- [ no ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ yes ] Playbooks are modular and reusable
- [ no ] Handlers are used for actions that need to run on change

## Documentation
- [ yes ] All options and parameters are documented clearly.
- [ yes ] Examples are provided and tested.
- [ yes ] Notes and limitations are clearly stated.

