### PR TITLE
 IPv4 prefix length is required even after setting IPv4 prefix to False

### DIFF
--- a/plugins/modules/network_settings_workflow_manager.py
+++ b/plugins/modules/network_settings_workflow_manager.py
@@ -2321,7 +2321,7 @@ class NetworkSettings(DnacBase):
                     self.status = "failed"
                     return self
 
-                if not pool_values.get("ipv4PrefixLength") and pool_values.get("ipv4Prefix") is True:
+                if pool_values.get("ipv4Prefix") and not pool_values.get("ipv4PrefixLength"):
                     self.msg = "missing parameter 'ipv4_prefix_length' in reserve_pool_details '{0}' element" \
                                .format(reserve_pool_index + 1)
                     self.status = "failed"

--- a/plugins/modules/network_settings_workflow_manager.py
+++ b/plugins/modules/network_settings_workflow_manager.py
@@ -2321,7 +2321,7 @@ class NetworkSettings(DnacBase):
                     self.status = "failed"
                     return self
 
-                if not pool_values.get("ipv4PrefixLength"):
+                if not pool_values.get("ipv4PrefixLength") and pool_values.get("ipv4Prefix") is True:
                     self.msg = "missing parameter 'ipv4_prefix_length' in reserve_pool_details '{0}' element" \
                                .format(reserve_pool_index + 1)
                     self.status = "failed"

--- a/plugins/modules/network_settings_workflow_manager.py
+++ b/plugins/modules/network_settings_workflow_manager.py
@@ -2340,7 +2340,7 @@ class NetworkSettings(DnacBase):
                 if pool_values.get("ipv4TotalHost") is None:
                     del pool_values['ipv4TotalHost']
                 if pool_values.get("ipv6AddressSpace") is True:
-                    pool_values.update({"ipv6Prefix": True})
+                    pool_values.update({"ipv6AddressSpace": True})
                 else:
                     del pool_values['ipv6Prefix']
 


### PR DESCRIPTION
## Description
Fix for below issues:
       - IPv4 prefix length is required even after setting IPv4 prefix to False
       - Unable to create subpool using Total host (Number of IP Addresses)

## Type of Change
- [ Yes] Bug fix
- [ No] New feature
- [No ] Breaking change
- [ No] Documentation update

## Checklist
- [ Yes] My code follows the style guidelines of this project
- [ Yes] I have performed a self-review of my own code
- [ Yes] I have commented my code, particularly in hard-to-understand areas
- [ Yes] I have made corresponding changes to the documentation
- [Yes ] My changes generate no new warnings
- [ No] I have added tests that prove my fix is effective or that my feature works
- [ Yes] New and existing unit tests pass locally with my changes
- [ Yes] Any dependent changes have been merged and published in downstream modules
- [ Yes] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ Yes] Tasks are idempotent (can be run multiple times without changing state)
- [ No] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [Yes ] Playbooks are modular and reusable
- [No ] Handlers are used for actions that need to run on change

## Documentation
- [ Yes] All options and parameters are documented clearly.
- [ Yes] Examples are provided and tested.
- [ Yes] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

