### PR TITLE
Ordered the device_config details before removing the devices from the fabric

### DIFF
--- a/plugins/modules/sda_fabric_devices_workflow_manager.py
+++ b/plugins/modules/sda_fabric_devices_workflow_manager.py
@@ -4022,6 +4022,55 @@ class FabricDevices(DnacBase):
 
         return self
 
+    def arrange_config_for_deletion(self, device_config):
+        """
+        Arrange the device config in such a way that the device with the role 'CONTROL_PLANE_NODE'
+        will be deleted at last.
+
+        Parameters:
+            device_config (list): Devices config details provided by the user in the playbook.
+        Returns:
+            updated_device_config (list): Updated device config details.
+        Description:
+            Loop in the device config information. If the device doesnot exists, prepend the
+            config details and the information collected from the Cisco Catalyst Center to the
+            new list or if the device has a role of 'CONTROL_PLANE_NODE', append the config details
+            and the information collected from the Cisco Catalyst Center to the new list.
+            Update the self.have.get("fabric_details") and return the new device_config list.
+        """
+
+        fabric_device_index = -1
+        updated_device_config = []
+        update_have = []
+        for item in device_config:
+            fabric_device_index += 1
+            device_ip = item.get("device_ip")
+            have_device_details = self.have.get("fabric_devices")[fabric_device_index]
+            exists = have_device_details.get("exists")
+            if not exists:
+                self.log(
+                    "The device with IP address '{ip}' is not available in the Cisco Catalyst Center."
+                    .format(ip=device_ip)
+                )
+                updated_device_config = [item] + updated_device_config
+                update_have = [have_device_details] + update_have
+                continue
+
+            device_roles = have_device_details.get("device_details").get("deviceRoles")
+            if "CONTROL_PLANE_NODE" in device_roles:
+                updated_device_config.append(item)
+                update_have.append(have_device_details)
+                continue
+
+            updated_device_config = [item] + updated_device_config
+            update_have = [have_device_details] + update_have
+
+        self.have.update({
+            "fabric_devices": update_have
+        })
+
+        return updated_device_config
+
     def delete_l2_handoff(self, have_l2_handoff, device_ip,
                           result_fabric_device_response,
                           result_fabric_device_msg):
@@ -4316,7 +4365,8 @@ class FabricDevices(DnacBase):
             "Starting deletion of fabric devices under fabric '{fabric_name}'"
             .format(fabric_name=fabric_name), "DEBUG"
         )
-        for item in device_config:
+        updated_device_config = self.arrange_config_for_deletion(device_config)
+        for item in updated_device_config:
             fabric_device_index += 1
             device_ip = item.get("device_ip")
             self.response[0].get("response").get(fabric_name).update({


### PR DESCRIPTION
## Description
Ordered the device_config details before removing the devices from the fabric
Because the first node that should be added to the fabric is a CONTROL_PLANE_NODE and the last should be deleted from the fabric is also the CONTROL_PLANE_NODE.
If user passes series of devices that to be removed from the fabric, we will order it in such a way that the CONTROL_PLANE_NODE should be removed at last from the fabric.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

