### PR TITLE
Removed the check for the provisioning status of the WLC

### DIFF
--- a/plugins/modules/sda_fabric_devices_workflow_manager.py
+++ b/plugins/modules/sda_fabric_devices_workflow_manager.py
@@ -88,6 +88,7 @@ options:
                                   managing traffic entering or exiting the SDA environment.
                   - WIRELESS_CONTROLLER_NODE - Manages and controls wireless access points and
                                                devices within the network.
+                - For 'WIRELESS_CONTROLLER_NODE', the check for the provisioning status will be added in 2.3.7.6 SDK.
                 choices: [CONTROL_PLANE_NODE, EDGE_NODE, BORDER_NODE, WIRELESS_CONTROLLER_NODE]
                 type: list
                 elements: str
@@ -2094,9 +2095,9 @@ class FabricDevices(DnacBase):
             # The device should be provisioned to the site
             if not is_the_device_wlc:
                 self.check_device_is_provisioned(fabric_device_ip,
-                                                    network_device_id,
-                                                    site_id,
-                                                    fabric_name).check_return_status()
+                                                 network_device_id,
+                                                 site_id,
+                                                 fabric_name).check_return_status()
 
             delete_fabric_device = item.get("delete_fabric_device")
             if delete_fabric_device is None:

--- a/plugins/modules/sda_fabric_devices_workflow_manager.py
+++ b/plugins/modules/sda_fabric_devices_workflow_manager.py
@@ -1043,22 +1043,22 @@ class FabricDevices(DnacBase):
         )
         return transit_id
 
-    def get_device_id_from_ip(self, device_ip):
+    def get_device_details_from_ip(self, device_ip):
         """
-        Get the network device ID from the network device IP.
+        Get the network device details from the network device IP.
 
         Parameters:
             device_ip (str): The IP address of the network device.
         Returns:
-            device_id (str or None): The ID of the network device. None, if the device doesnot exist.
+            device_details (dict or None): The details of the network device. None, if the device doesnot exist.
         Description:
             Call the API 'get_device_list' by setting the 'management_ip_address' field with the
             given IP address.
-            If the response is not empty, fetch the Id and return. Else, return None.
+            If the response is not empty, return the device details. Else, return None.
         """
 
-        self.log("Starting to get device ID for device IP: '{ip}'.".format(ip=device_ip), "DEBUG")
-        device_id = None
+        self.log("Starting to get device details for device IP: '{ip}'.".format(ip=device_ip), "DEBUG")
+        device_details = None
         try:
             device_details = self.dnac._exec(
                 family="devices",
@@ -1077,17 +1077,8 @@ class FabricDevices(DnacBase):
                     "There is no device with the IP address '{ip_address}'."
                     .format(ip_address=device_ip), "DEBUG"
                 )
-                return device_id
+                return device_details
 
-            self.log(
-                "The device with the IP {ip} is a valid network device IP."
-                .format(ip=device_ip), "DEBUG"
-            )
-            device_id = device_details[0].get("id")
-            self.log(
-                "Device ID found: '{id}' for device IP: '{ip}'."
-                .format(id=device_id, ip=device_ip), "DEBUG"
-            )
         except Exception as msg:
             self.msg = (
                 "Exception occured while running the API 'get_device_list': {msg}"
@@ -1098,9 +1089,9 @@ class FabricDevices(DnacBase):
             return self.check_return_status()
 
         self.log(
-            "Returning device ID: '{id}'.".format(id=device_id), "DEBUG"
+            "Returning device details: '{details}'.".format(details=device_details), "DEBUG"
         )
-        return device_id
+        return device_details
 
     def check_valid_virtual_network_name(self, virtual_network_name):
         """
@@ -2076,8 +2067,8 @@ class FabricDevices(DnacBase):
                 "Fetching network device ID for IP '{device_ip}'."
                 .format(device_ip=fabric_device_ip), "INFO"
             )
-            network_device_id = self.get_device_id_from_ip(fabric_device_ip)
-            if not network_device_id:
+            network_device_details = self.get_device_details_from_ip(fabric_device_ip)
+            if not network_device_details:
                 self.msg = (
                     "The 'device_ip' '{ip}' in 'device_config' is not a valid IP under the fabric '{fabric_name}'."
                     .format(ip=fabric_device_ip, fabric_name=fabric_name)
@@ -2087,12 +2078,26 @@ class FabricDevices(DnacBase):
                 return self
 
             self.log(
+                "The device with the IP {ip} is a valid network device IP."
+                .format(ip=fabric_device_ip), "DEBUG"
+            )
+            network_device_id = network_device_details[0].get("id")
+            self.log(
                 "Obtained network device ID: {network_device_id}."
                 .format(network_device_id=network_device_id), "DEBUG"
             )
+            is_the_device_wlc = False
+            family_name = network_device_details[0].get("family")
+            if family_name == "Wireless Controller":
+                is_the_device_wlc = True
 
             # The device should be provisioned to the site
-            self.check_device_is_provisioned(fabric_device_ip, network_device_id, site_id, fabric_name).check_return_status()
+            if not is_the_device_wlc:
+                self.check_device_is_provisioned(fabric_device_ip,
+                                                    network_device_id,
+                                                    site_id,
+                                                    fabric_name).check_return_status()
+
             delete_fabric_device = item.get("delete_fabric_device")
             if delete_fabric_device is None:
                 delete_fabric_device = False

--- a/plugins/modules/sda_fabric_devices_workflow_manager.py
+++ b/plugins/modules/sda_fabric_devices_workflow_manager.py
@@ -2087,17 +2087,21 @@ class FabricDevices(DnacBase):
                 "Obtained network device ID: {network_device_id}."
                 .format(network_device_id=network_device_id), "DEBUG"
             )
-            is_the_device_wlc = False
             family_name = network_device_details[0].get("family")
-            if family_name == "Wireless Controller":
-                is_the_device_wlc = True
-
-            # The device should be provisioned to the site
-            if not is_the_device_wlc:
+            if family_name != "Wireless Controller":
+                self.log(
+                    "The device with the IP '{ip}' is not a Wireless Controller, "
+                    "proceeding with provisioning checks."
+                )
                 self.check_device_is_provisioned(fabric_device_ip,
                                                  network_device_id,
                                                  site_id,
                                                  fabric_name).check_return_status()
+            else:
+                self.log(
+                    "The device with the IP '{ip}' is a Wireless Controller, "
+                    "skipping provisioning checks."
+                )
 
             delete_fabric_device = item.get("delete_fabric_device")
             if delete_fabric_device is None:


### PR DESCRIPTION
## Description
Removed the check for the provisioning status of the WLC.
Since we dont have the API for the finding whether the WLC is provisioned or not.
We will just ignore the provisioning check for the WLC alone.
It will added again in the 2.3.7.9 SDK release.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

